### PR TITLE
feat: update card.aux.serial schemas to version 0.2.1

### DIFF
--- a/card.aux.serial.req.notecard.api.json
+++ b/card.aux.serial.req.notecard.api.json
@@ -4,6 +4,9 @@
     "title": "card.aux.serial Request Application Programming Interface (API) Schema",
     "description": "Configure various uses of the AUXTX and AUXRX pins on the Notecard's edge connector.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
         "mode": {
             "description": "The AUX mode. Must be one of the following",
@@ -16,7 +19,50 @@
                 "notify,signals",
                 "notify,env",
                 "notify,dfu"
+            ],
+            "sub-descriptions": [
+                {
+                    "const": "req",
+                    "description": "Request mode for sending commands and receiving responses.",
+                    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"]
+                },
+                {
+                    "const": "gps",
+                    "description": "GPS mode for external GPS module communication.",
+                    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"]
+                },
+                {
+                    "const": "notify",
+                    "description": "General notification mode.",
+                    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"]
+                },
+                {
+                    "const": "notify,accel",
+                    "description": "Notification mode for accelerometer events.",
+                    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"]
+                },
+                {
+                    "const": "notify,signals",
+                    "description": "Notification mode for signal events.",
+                    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"]
+                },
+                {
+                    "const": "notify,env",
+                    "description": "Notification mode for environment variable changes.",
+                    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"]
+                },
+                {
+                    "const": "notify,dfu",
+                    "description": "Notification mode for Device Firmware Update events.",
+                    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"]
+                }
             ]
+        },
+        "minutes": {
+            "description": "When in notify,dfu mode, the number of minutes for DFU notification timeout.",
+            "type": "integer",
+            "minimum": 1,
+            "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"]
         },
         "cmd": {
             "description": "Command for the Notecard (no response)",
@@ -50,6 +96,32 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "annotations": [
+        {
+            "title": "note",
+            "description": "Utilizing these pins requires a physical connection to each pin, separate from a connection to the Notecard's serial data interfaces. See the debugging with FTDI cable guide for an example of connecting to the Notecard AUX pins using an FTDI cable."
+        }
+    ],
+    "samples": [
+        {
+            "title": "Enable GPS Mode",
+            "description": "Configure AUX serial for external GPS communication.",
+            "json": "{\"req\": \"card.aux.serial\", \"mode\": \"gps\"}"
+        },
+        {
+            "title": "Enable DFU Notifications",
+            "description": "Configure AUX serial for DFU notifications with timeout.",
+            "json": "{\"cmd\": \"card.aux.serial\", \"mode\": \"notify,dfu\", \"minutes\": 30}"
+        },
+        {
+            "title": "Enable Environment Notifications",
+            "description": "Configure AUX serial for environment variable change notifications.",
+            "json": "{\"req\": \"card.aux.serial\", \"mode\": \"notify,env\"}"
+        },
+        {
+            "title": "Request Mode",
+            "description": "Set AUX serial to request mode for command/response communication.",
+            "json": "{\"cmd\": \"card.aux.serial\", \"mode\": \"req\"}"
+        }
+    ]
 }

--- a/card.aux.serial.rsp.notecard.api.json
+++ b/card.aux.serial.rsp.notecard.api.json
@@ -3,7 +3,20 @@
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.aux.serial.rsp.notecard.api.json",
     "title": "card.aux.serial Response Application Programming Interface (API) Schema",
     "type": "object",
-    "properties": {},
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
+    "properties": {
+        "mode": {
+            "description": "The current AUX serial mode configuration.",
+            "type": "string"
+        }
+    },
+    "samples": [
+        {
+            "title": "AUX Serial Status",
+            "description": "Example response showing current AUX serial configuration.",
+            "json": "{\"mode\": \"notify,env\"}"
+        }
+    ]
 }

--- a/tests/test_card_aux_serial_req.py
+++ b/tests/test_card_aux_serial_req.py
@@ -1,5 +1,6 @@
 import pytest
 import jsonschema
+import json
 
 SCHEMA_FILE = "card.aux.serial.req.notecard.api.json"
 
@@ -53,3 +54,51 @@ def test_valid_with_mode(schema):
     """Tests a valid request including the mode field."""
     instance = {"req": "card.aux.serial", "mode": "notify,signals"}
     jsonschema.validate(instance=instance, schema=schema)
+
+def test_minutes_valid(schema):
+    """Tests valid minutes values (integer >= 1)."""
+    instance = {"req": "card.aux.serial", "minutes": 1}
+    jsonschema.validate(instance=instance, schema=schema)
+    instance = {"req": "card.aux.serial", "minutes": 30}
+    jsonschema.validate(instance=instance, schema=schema)
+    instance = {"req": "card.aux.serial", "minutes": 1440}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_minutes_invalid_type(schema):
+    """Tests invalid type for minutes."""
+    instance = {"req": "card.aux.serial", "minutes": "30"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'30' is not of type 'integer'" in str(excinfo.value)
+
+def test_minutes_invalid_minimum(schema):
+    """Tests invalid minutes value (< 1)."""
+    instance = {"req": "card.aux.serial", "minutes": 0}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "0 is less than the minimum of 1" in str(excinfo.value)
+
+def test_minutes_invalid_float(schema):
+    """Tests invalid float type for minutes."""
+    instance = {"req": "card.aux.serial", "minutes": 30.5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "30.5 is not of type 'integer'" in str(excinfo.value)
+
+def test_valid_with_mode_and_minutes(schema):
+    """Tests a valid request with both mode and minutes."""
+    instance = {"cmd": "card.aux.serial", "mode": "notify,dfu", "minutes": 60}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_card_aux_serial_rsp.py
+++ b/tests/test_card_aux_serial_rsp.py
@@ -1,5 +1,6 @@
 import pytest
 import jsonschema
+import json
 
 SCHEMA_FILE = "card.aux.serial.rsp.notecard.api.json"
 
@@ -27,3 +28,39 @@ def test_invalid_type(schema):
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
         assert "is not of type 'object'" in str(excinfo.value)
+
+def test_mode_valid(schema):
+    """Tests valid mode field."""
+    instance = {"mode": "notify,env"}
+    jsonschema.validate(instance=instance, schema=schema)
+    instance = {"mode": "gps"}
+    jsonschema.validate(instance=instance, schema=schema)
+    instance = {"mode": ""}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_mode_invalid_type(schema):
+    """Tests invalid type for mode."""
+    instance = {"mode": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_mode_invalid_array(schema):
+    """Tests invalid array type for mode."""
+    instance = {"mode": ["notify", "env"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Update card.aux.serial request and response schemas to version 0.2.1
- Add `minutes` parameter for DFU notification timeout with proper validation
- Add comprehensive samples with JSON examples for different notification modes
- Add detailed sub-descriptions for all mode enum values with SKU compatibility
- Add SKU compatibility information at both API and property level
- Add annotation about physical pin connection requirements from documentation
- Update tests to include new parameter validation and schema sample testing

The schemas now fully support the latest notification modes including `notify,dfu` with timeout configuration and comprehensive documentation for all modes.