### PR TITLE
feat: update card.dfu API schemas to v0.2.1

### DIFF
--- a/card.dfu.req.notecard.api.json
+++ b/card.dfu.req.notecard.api.json
@@ -4,15 +4,42 @@
     "title": "card.dfu Request Application Programming Interface (API) Schema",
     "description": "Used to configure a Notecard for Notecard Outboard Firmware Update.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "name": {
-            "description": "One of the supported classes of host MCU. Supported MCU classes are 'esp32', 'stm32', 'stm32-bi', '-'",
+            "description": "One of the supported classes of host MCU. Supported MCU classes are 'esp32', 'stm32', 'stm32-bi', 'mcuboot', '-'",
             "type": "string",
             "enum": [
                 "esp32",
                 "stm32",
                 "stm32-bi",
+                "mcuboot",
                 "-"
+            ],
+            "skus": ["CELL", "CELL+WIFI", "WIFI"],
+            "sub-descriptions": [
+                {
+                    "const": "esp32",
+                    "description": "ESP32 microcontroller family."
+                },
+                {
+                    "const": "stm32",
+                    "description": "STM32 microcontroller family."
+                },
+                {
+                    "const": "stm32-bi",
+                    "description": "STM32 microcontroller family with boot inverted (boot pin active low)."
+                },
+                {
+                    "const": "mcuboot",
+                    "description": "MCUboot compatible microcontroller (added in v5.3.1)."
+                },
+                {
+                    "const": "-",
+                    "description": "Resets the configuration."
+                }
             ]
         },
         "on": {
@@ -30,6 +57,28 @@
         "stop": {
             "description": "Set to true to disable the host RESET that is normally performed on the host MCU when the Notecard starts up",
             "type": "boolean"
+        },
+        "start": {
+            "description": "Set to true to re-enable host MCU reset during startup",
+            "type": "boolean"
+        },
+        "mode": {
+            "description": "Control whether a Notecard's AUX pins (default) or ALT_DFU pins are used for Notecard Outboard Firmware Update. Supported on Notecards that have ALT_DFU pins: all versions of Notecard Cell+WiFi, non-legacy versions of Notecard Cellular, and Notecard WiFi v2.",
+            "type": "string",
+            "enum": ["altdfu", "off"],
+            "skus": ["CELL", "CELL+WIFI", "WIFI"],
+            "sub-descriptions": [
+                {
+                    "const": "altdfu",
+                    "description": "Enable the Notecard's ALT_DFU pins (instead of the AUX pins) for use with Notecard Outboard Firmware Update.",
+                    "skus": ["CELL", "CELL+WIFI", "WIFI"]
+                },
+                {
+                    "const": "off",
+                    "description": "Return the Notecard's ALT_DFU pins to their default state.",
+                    "skus": ["CELL", "CELL+WIFI", "WIFI"]
+                }
+            ]
         },
         "cmd": {
             "description": "Command for the Notecard (no response)",
@@ -63,6 +112,26 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Configure STM32 DFU",
+            "description": "Enable DFU for STM32 microcontroller.",
+            "json": "{\"req\": \"card.dfu\", \"name\": \"stm32\", \"on\": true}"
+        },
+        {
+            "title": "Configure ESP32 DFU",
+            "description": "Enable DFU for ESP32 microcontroller.",
+            "json": "{\"cmd\": \"card.dfu\", \"name\": \"esp32\", \"on\": true}"
+        },
+        {
+            "title": "Enable Alternative DFU Pins",
+            "description": "Use ALT_DFU pins instead of AUX pins on Cell+WiFi.",
+            "json": "{\"req\": \"card.dfu\", \"mode\": \"altdfu\"}"
+        },
+        {
+            "title": "Disable DFU Temporarily",
+            "description": "Disable DFU for 3600 seconds.",
+            "json": "{\"req\": \"card.dfu\", \"off\": true, \"seconds\": 3600}"
+        }
+    ]
 }

--- a/card.dfu.rsp.notecard.api.json
+++ b/card.dfu.rsp.notecard.api.json
@@ -3,7 +3,20 @@
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.dfu.rsp.notecard.api.json",
     "title": "card.dfu Response Application Programming Interface (API) Schema",
     "type": "object",
-    "properties": {},
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
+    "properties": {
+        "name": {
+            "description": "The class of MCU that the Notecard is currently configured to support for Outboard DFU.",
+            "type": "string"
+        }
+    },
+    "samples": [
+        {
+            "title": "DFU Status Response",
+            "description": "Example response showing current DFU configuration.",
+            "json": "{\"name\": \"stm32\"}"
+        }
+    ]
 }

--- a/tests/test_card_dfu_rsp.py
+++ b/tests/test_card_dfu_rsp.py
@@ -1,5 +1,6 @@
 import pytest
 import jsonschema
+import json
 
 SCHEMA_FILE = "card.dfu.rsp.notecard.api.json"
 
@@ -8,7 +9,36 @@ def test_minimal_valid_rsp(schema):
     instance = {}
     jsonschema.validate(instance=instance, schema=schema)
 
+def test_valid_name_field(schema):
+    """Tests valid response with name field."""
+    instance = {"name": "stm32"}
+    jsonschema.validate(instance=instance, schema=schema)
+    instance = {"name": "esp32"}
+    jsonschema.validate(instance=instance, schema=schema)
+    instance = {"name": "mcuboot"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_name_invalid_type(schema):
+    """Tests invalid type for name field."""
+    instance = {"name": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
 def test_valid_additional_property(schema):
     """Tests valid response with an additional property."""
     instance = {"some_field": "some_value"}
     jsonschema.validate(instance=instance, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Add mcuboot MCU class (v5.3.1 feature)
- Add start parameter for re-enabling host MCU reset
- Add mode parameter with altdfu/off enum values
- Consolidate SKU declarations at property level
- Add comprehensive samples and documentation
- Update to apiVersion 9.1.1

Closes #19