### PR TITLE
feat: update card.binary API schemas to v0.2.1

### DIFF
--- a/card.binary.req.notecard.api.json
+++ b/card.binary.req.notecard.api.json
@@ -2,11 +2,14 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.binary.req.notecard.api.json",
     "title": "card.binary Request Application Programming Interface (API) Schema",
-    "description": "View the status of the binary storage area of the Notecard and optionally clear any data and related card.binary variables.",
+    "description": "View the status of the binary storage area of the Notecard and optionally clear any data and related `card.binary` variables. See the guide on [Sending and Receiving Large Binary Objects](/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects) for best practices when using `card.binary`.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "delete": {
-            "description": "Clear the COBS area on the Notecard and reset all related arguments previously set by a card.binary request",
+            "description": "Clear the COBS area on the Notecard and reset all related arguments previously set by a card.binary request.",
             "type": "boolean"
         },
         "cmd": {
@@ -41,6 +44,16 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "View Binary Status",
+            "description": "Check the status of binary storage area.",
+            "json": "{\"req\": \"card.binary\"}"
+        },
+        {
+            "title": "Reset Binary Data",
+            "description": "Clear the COBS area and reset binary variables.",
+            "json": "{\"req\": \"card.binary\", \"delete\": true}"
+        }
+    ]
 }

--- a/card.binary.rsp.notecard.api.json
+++ b/card.binary.rsp.notecard.api.json
@@ -3,24 +3,40 @@
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.binary.rsp.notecard.api.json",
     "title": "card.binary Response Application Programming Interface (API) Schema",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "cobs": {
-            "description": "The size of COBS-encoded data stored in the reserved area",
+            "description": "The size of COBS-encoded data stored in the reserved area (without the trailing \n).",
             "type": "integer"
         },
         "connected": {
-            "description": "Returns true if the Notecard is connected to the network",
+            "description": "Returns true if the Notecard is connected to the network.",
             "type": "boolean"
         },
         "err": {
-            "description": "If present, a string describing the error that occurred during transmission",
+            "description": "If present, a string describing the error that occurred during transmission.",
             "type": "string"
         },
         "length": {
-            "description": "The length of the binary data",
+            "description": "The amount of unencoded data currently stored (in bytes).",
             "type": "integer"
+        },
+        "max": {
+            "description": "The space available (in bytes) for storing unencoded data on the Notecard.",
+            "type": "integer"
+        },
+        "status": {
+            "description": "The MD5 checksum calculated for the entire unencoded buffer.",
+            "type": "string"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Binary Status Response",
+            "description": "Example response showing binary storage status.",
+            "json": "{\"connected\": true, \"max\": 130554, \"status\": \"ce6fdef565eeecf14ab38d83643b922d\", \"length\": 4, \"cobs\": 5}"
+        }
+    ]
 }

--- a/tests/test_card_binary_req.py
+++ b/tests/test_card_binary_req.py
@@ -1,5 +1,6 @@
 import pytest
 import jsonschema
+import json
 
 SCHEMA_FILE = "card.binary.req.notecard.api.json"
 
@@ -74,3 +75,16 @@ def test_invalid_additional_property(schema):
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
     assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Add missing response fields: max, status
- Update descriptions to match documentation exactly  
- Add comprehensive samples for both schemas
- Update to apiVersion 9.1.1 and add SKU support
- Add tests for new response fields

Closes #21