### PR TITLE
feat: update card.binary.get schemas to version 0.2.1

### DIFF
--- a/card.binary.get.req.notecard.api.json
+++ b/card.binary.get.req.notecard.api.json
@@ -2,20 +2,23 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.binary.get.req.notecard.api.json",
     "title": "card.binary.get Request Application Programming Interface (API) Schema",
-    "description": "Returns binary data stored in the binary storage area of the Notecard. The response to this API command first returns the JSON-formatted response object, then the binary data.",
+    "description": "Returns binary data stored in the binary storage area of the Notecard. The response to this API command first returns the JSON-formatted response object, then the binary data.\n\nSee the guide on [Sending and Receiving Large Binary Objects](/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects) for best practices when using `card.binary`.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "cobs": {
-            "description": "The size of the COBS-encoded data you are expecting to be returned (in bytes)",
+            "description": "The size of the COBS-encoded data you are expecting to be returned (in bytes).",
             "type": "integer"
         },
         "offset": {
-            "description": "Used along with length, the number of bytes to offset the binary payload from 0 when retrieving binary data from the Notecard",
+            "description": "Used along with `length`, the number of bytes to offset the binary payload from 0 when retrieving binary data from the binary storage area of the Notecard. Primarily used when retrieving multiple fragments of a binary payload from the Notecard.",
             "type": "integer",
             "minimum": 0
         },
         "length": {
-            "description": "Used along with offset, the number of bytes to retrieve from the binary storage area of the Notecard",
+            "description": "Used along with `offset`, the number of bytes to retrieve from the binary storage area of the Notecard.",
             "type": "integer",
             "minimum": 0
         },
@@ -51,6 +54,11 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Get All Binary Data",
+            "description": "Retrieve all binary data from storage area.",
+            "json": "{\"req\": \"card.binary.get\"}"
+        }
+    ]
 }

--- a/card.binary.get.rsp.notecard.api.json
+++ b/card.binary.get.rsp.notecard.api.json
@@ -3,6 +3,9 @@
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.binary.get.rsp.notecard.api.json",
     "title": "card.binary.get Response Application Programming Interface (API) Schema",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "status": {
             "description": "The MD5 checksum of the data returned, after it has been decoded",
@@ -13,6 +16,11 @@
             "type": "string"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Binary Data Response",
+            "description": "Example response with MD5 checksum.",
+            "json": "{\"status\":\"ce6fdef565eeecf14ab38d83643b922d\"}"
+        }
+    ]
 }

--- a/tests/test_card_binary_get_req.py
+++ b/tests/test_card_binary_get_req.py
@@ -111,3 +111,17 @@ def test_invalid_additional_property(schema):
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
     assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    import json
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_card_binary_get_req.py
+++ b/tests/test_card_binary_get_req.py
@@ -1,5 +1,6 @@
 import pytest
 import jsonschema
+import json
 
 SCHEMA_FILE = "card.binary.get.req.notecard.api.json"
 
@@ -114,7 +115,6 @@ def test_invalid_additional_property(schema):
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""
-    import json
     for sample in schema_samples:
         sample_json_str = sample.get("json")
         if not sample_json_str:

--- a/tests/test_card_binary_get_rsp.py
+++ b/tests/test_card_binary_get_rsp.py
@@ -1,5 +1,6 @@
 import pytest
 import jsonschema
+import json
 
 SCHEMA_FILE = "card.binary.get.rsp.notecard.api.json"
 
@@ -47,7 +48,6 @@ def test_valid_additional_property(schema):
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""
-    import json
     for sample in schema_samples:
         sample_json_str = sample.get("json")
         if not sample_json_str:

--- a/tests/test_card_binary_get_rsp.py
+++ b/tests/test_card_binary_get_rsp.py
@@ -44,3 +44,17 @@ def test_valid_additional_property(schema):
     """Tests valid response with an additional property (allowed by default)."""
     instance = {"status": "md5:ok", "extra": "data"}
     jsonschema.validate(instance=instance, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    import json
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Updated card.binary.get schemas from version 0.1.1 to 0.2.1
- Enhanced descriptions to match API reference documentation exactly
- Added SKU compatibility arrays and samples for both schemas

## Changes Made
- **Request schema**: Enhanced description with link to binary objects guide, updated parameter descriptions to match reference formatting, added sample request
- **Response schema**: Added SKU compatibility and sample response with MD5 checksum
- **Both schemas**: Moved version/apiVersion/skus fields to top of schema structure for consistency

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/code)