### PR TITLE
feat: enhance card.restart schemas to v0.2.1 with complete API alignment

### DIFF
--- a/card.restart.req.notecard.api.json
+++ b/card.restart.req.notecard.api.json
@@ -4,6 +4,14 @@
     "title": "card.restart Request Application Programming Interface (API) Schema",
     "description": "Performs a firmware restart of the Notecard.",
     "type": "object",
+    "skus": [
+        "CELL",
+        "CELL+WIFI",
+        "LORA",
+        "WIFI"
+    ],
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
     "properties": {
         "cmd": {
             "description": "Command for the Notecard (no response)",
@@ -37,6 +45,17 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "annotations": [
+        {
+            "title": "note",
+            "description": "Calls to `card.restart` are not supported for use in production applications as they can cause increased cellular data and consumption credit usage."
+        }
+    ],
+    "samples": [
+        {
+            "title": "Restart Notecard",
+            "description": "Perform a firmware restart of the Notecard.",
+            "json": "{\"req\": \"card.restart\"}"
+        }
+    ]
 }

--- a/card.restart.req.notecard.api.json
+++ b/card.restart.req.notecard.api.json
@@ -47,7 +47,7 @@
     "additionalProperties": false,
     "annotations": [
         {
-            "title": "note",
+            "title": "warning",
             "description": "Calls to `card.restart` are not supported for use in production applications as they can cause increased cellular data and consumption credit usage."
         }
     ],

--- a/card.restart.rsp.notecard.api.json
+++ b/card.restart.rsp.notecard.api.json
@@ -2,8 +2,18 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.restart.rsp.notecard.api.json",
     "title": "card.restart Response Application Programming Interface (API) Schema",
+    "description": "Response from the Notecard restart command. The response is typically empty as the restart occurs immediately.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {},
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Empty Restart Response",
+            "description": "Typical empty response before Notecard restarts.",
+            "json": "{}"
+        }
+    ]
 }

--- a/tests/test_card_restart_rsp.py
+++ b/tests/test_card_restart_rsp.py
@@ -1,5 +1,6 @@
 import pytest
 import jsonschema
+import json
 
 SCHEMA_FILE = "card.restart.rsp.notecard.api.json"
 
@@ -8,7 +9,32 @@ def test_minimal_valid_rsp(schema):
     instance = {}
     jsonschema.validate(instance=instance, schema=schema)
 
-def test_valid_additional_property(schema):
-    """Tests valid response with an additional property."""
+def test_invalid_additional_property(schema):
+    """Tests invalid response with additional property."""
     instance = {"restarting": True}
-    jsonschema.validate(instance=instance, schema=schema)
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed ('restarting' was unexpected)" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests response with multiple additional properties (should fail)."""
+    instance = {
+        "status": "restarting",
+        "timestamp": "2024-01-01T00:00:00Z"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Enhanced card.restart request and response schemas to v0.2.1 standards with complete API alignment
- Added comprehensive SKU support for all Notecard types (CELL, CELL+WIFI, LORA, WIFI)
- Added warning annotation about production usage restrictions per API documentation
- Implemented strict validation with additionalProperties: false
- Added comprehensive samples with proper title and description fields

## Test plan
- [x] All existing and new tests pass (13/13)
- [x] Updated test files to validate schema samples and strict additionalProperties behavior
- [x] Request schema properly validates both req and cmd patterns
- [x] Response schema enforces strict validation rejecting any additional properties
- [x] Warning annotation properly captures production usage restrictions from API docs

🤖 Generated with [Claude Code](https://claude.ai/code)