### PR TITLE
feat: add card.trace API schemas with v0.2.1 standards

### DIFF
--- a/card.trace.req.notecard.api.json
+++ b/card.trace.req.notecard.api.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.trace.req.notecard.api.json",
+    "title": "card.trace Request Application Programming Interface (API) Schema",
+    "description": "Enable and disable [trace mode](/guides-and-tutorials/notecard-guides/using-notecard-trace-mode) on a Notecard for debugging.",
+    "type": "object",
+    "skus": [
+        "CELL",
+        "CELL+WIFI",
+        "LORA",
+        "WIFI"
+    ],
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "properties": {
+        "mode": {
+            "description": "Set to `\"on\"` to enable trace mode on a Notecard, or `\"off\"` to disable it.",
+            "type": "string",
+            "enum": ["on", "off"]
+        },
+        "cmd": {
+            "description": "Command for the Notecard (no response)",
+            "const": "card.trace"
+        },
+        "req": {
+            "description": "Request for the Notecard (expects response)",
+            "const": "card.trace"
+        }
+    },
+    "oneOf": [
+        {
+            "required": [
+                "req"
+            ],
+            "properties": {
+                "req": {
+                    "const": "card.trace"
+                }
+            }
+        },
+        {
+            "required": [
+                "cmd"
+            ],
+            "properties": {
+                "cmd": {
+                    "const": "card.trace"
+                }
+            }
+        }
+    ],
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Enable Trace Mode",
+            "description": "Enable trace mode for debugging the Notecard.",
+            "json": "{\"req\": \"card.trace\", \"mode\": \"on\"}"
+        },
+        {
+            "title": "Disable Trace Mode",
+            "description": "Disable trace mode on the Notecard.",
+            "json": "{\"cmd\": \"card.trace\", \"mode\": \"off\"}"
+        }
+    ]
+}

--- a/card.trace.rsp.notecard.api.json
+++ b/card.trace.rsp.notecard.api.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.trace.rsp.notecard.api.json",
+    "title": "card.trace Response Application Programming Interface (API) Schema",
+    "description": "Response from trace mode configuration request. Returns an empty object upon successful completion.",
+    "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
+    "properties": {},
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Trace Mode Configuration Response",
+            "description": "Standard response after successfully enabling or disabling trace mode.",
+            "json": "{}"
+        }
+    ]
+}

--- a/notecard.api.json
+++ b/notecard.api.json
@@ -94,6 +94,9 @@
             "$ref": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.time.req.notecard.api.json"
         },
         {
+            "$ref": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.trace.req.notecard.api.json"
+        },
+        {
             "$ref": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.transport.req.notecard.api.json"
         },
         {

--- a/tests/test_card_trace_req.py
+++ b/tests/test_card_trace_req.py
@@ -1,0 +1,97 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "card.trace.req.notecard.api.json"
+
+def test_valid_req(schema):
+    """Tests a minimal valid request using 'req'."""
+    instance = {"req": "card.trace"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd(schema):
+    """Tests a minimal valid request using 'cmd'."""
+    instance = {"cmd": "card.trace"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request missing req/cmd."""
+    instance = {"mode": "on"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request having both req and cmd."""
+    instance = {"req": "card.trace", "cmd": "card.trace"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is valid under each of" in str(excinfo.value)
+
+def test_valid_mode_on(schema):
+    """Tests valid mode field set to 'on'."""
+    instance = {"req": "card.trace", "mode": "on"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_mode_off(schema):
+    """Tests valid mode field set to 'off'."""
+    instance = {"cmd": "card.trace", "mode": "off"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_mode_invalid_value(schema):
+    """Tests invalid value for mode."""
+    instance = {"req": "card.trace", "mode": "invalid"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'invalid' is not one of ['on', 'off']" in str(excinfo.value)
+
+def test_mode_invalid_type(schema):
+    """Tests invalid type for mode."""
+    instance = {"req": "card.trace", "mode": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'string'" in str(excinfo.value)
+
+def test_req_invalid_value(schema):
+    """Tests invalid req value."""
+    instance = {"req": "invalid.command"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'card.trace' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_value(schema):
+    """Tests invalid cmd value."""
+    instance = {"cmd": "invalid.command"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'card.trace' was expected" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with an additional property."""
+    instance = {"req": "card.trace", "mode": "on", "extra": "field"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+
+def test_valid_trace_enable_request(schema):
+    """Tests valid complete request to enable trace mode."""
+    instance = {"req": "card.trace", "mode": "on"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_trace_disable_request(schema):
+    """Tests valid complete request to disable trace mode."""
+    instance = {"cmd": "card.trace", "mode": "off"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_card_trace_rsp.py
+++ b/tests/test_card_trace_rsp.py
@@ -1,0 +1,67 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "card.trace.rsp.notecard.api.json"
+
+def test_minimal_valid_rsp(schema):
+    """Tests a minimal valid response (empty object)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_empty_response(schema):
+    """Tests valid empty response from trace configuration."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with additional property."""
+    instance = {"status": "enabled"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed ('status' was unexpected)" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests response with multiple additional properties (should fail)."""
+    instance = {
+        "status": "enabled",
+        "mode": "on",
+        "extra": "field"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_string_property(schema):
+    """Tests invalid response with string property."""
+    instance = {"message": "trace enabled"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed ('message' was unexpected)" in str(excinfo.value)
+
+def test_invalid_boolean_property(schema):
+    """Tests invalid response with boolean property."""
+    instance = {"success": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed ('success' was unexpected)" in str(excinfo.value)
+
+def test_invalid_number_property(schema):
+    """Tests invalid response with number property."""
+    instance = {"code": 200}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed ('code' was unexpected)" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Added complete `card.trace` API schemas following v0.2.1 standards for trace mode debugging functionality
- Created both request and response schemas with comprehensive validation and test coverage
- Added schema reference to main notecard.api.json index file

## Changes Made

### New Schema Files Created

#### Request Schema (`card.trace.req.notecard.api.json`)
- Full v0.2.1 compliant schema with SKU support for all Notecard types
- `mode` parameter with enum validation for `"on"` and `"off"` values only
- Standard req/cmd pattern support with oneOf validation
- Strict validation with `additionalProperties: false`
- Enhanced description with link to trace mode documentation
- Comprehensive samples for both enable and disable operations

#### Response Schema (`card.trace.rsp.notecard.api.json`)
- Empty object response schema matching API specification
- SKU support and strict validation
- Sample showing standard empty response `{}`

### Test Coverage (`tests/test_card_trace_*.py`)
- Created comprehensive test suite with 22 tests total
- Request tests: 14 tests covering req/cmd patterns, mode validation, enum restrictions, and error cases
- Response tests: 8 tests covering empty response validation and additional property restrictions
- Full sample validation for both schemas

### Index Update (`notecard.api.json`)
- Added card.trace.req.notecard.api.json reference to oneOf array in alphabetical order

## API Specification Alignment
The schemas align exactly with the provided API reference:
- `mode` parameter accepts only `"on"` or `"off"` string values
- Response is an empty object `{}`
- Supports all Notecard SKUs (CELL, CELL+WIFI, LORA, WIFI)
- Links to trace mode documentation for debugging guidance

## Test Results
```
22 passed in 0.05s
```

All schemas created from scratch following established v0.2.1 patterns with full validation coverage.

🤖 Generated with [Claude Code](https://claude.ai/code)