### PR TITLE
feat: enhance card.wireless schemas to v0.2.1 with complete API alignment

### DIFF
--- a/card.wireless.req.notecard.api.json
+++ b/card.wireless.req.notecard.api.json
@@ -2,17 +2,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.wireless.req.notecard.api.json",
     "title": "card.wireless Request Application Programming Interface (API) Schema",
-    "description": "View the last known network state, or customize the behavior of the modem. Note: Be careful when using this mode with hardware not on hand as a mistake may cause loss of network and Notehub access.",
+    "description": "View the last known network state, or customize the behavior of the modem. _Note: Be careful when using this mode with hardware not on hand as a mistake may cause loss of network and Notehub access._",
     "type": "object",
     "version": "0.2.1",
     "apiVersion": "9.1.1",
     "skus": ["CELL", "CELL+WIFI", "WIFI"],
-    "annotations": [
-        {
-            "title": "note",
-            "description": "Be careful when using this mode with hardware not on hand as a mistake may cause loss of network and Notehub access."
-        }
-    ],
     "properties": {
         "mode": {
             "description": "Network scan mode. Must be one of: `\"-\"` to reset to the default mode, `\"auto\"` to perform automatic band scan mode (this is the default mode). The following values apply exclusively to Narrowband (NB) Notecard Cellular devices: `\"m\"` to restrict the modem to Cat-M1, `\"nb\"` to restrict the modem to Cat-NB1, `\"gprs\"` to restrict the modem to EGPRS.",

--- a/card.wireless.req.notecard.api.json
+++ b/card.wireless.req.notecard.api.json
@@ -6,7 +6,7 @@
     "type": "object",
     "version": "0.2.1",
     "apiVersion": "9.1.1",
-    "skus": ["CELL", "CELL+WIFI"],
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "mode": {
             "description": "Network scan mode. Must be one of: `\"-\"` to reset to the default mode, `\"auto\"` to perform automatic band scan mode (this is the default mode). The following values apply exclusively to Narrowband (NB) Notecard Cellular devices: `\"m\"` to restrict the modem to Cat-M1, `\"nb\"` to restrict the modem to Cat-NB1, `\"gprs\"` to restrict the modem to EGPRS.",

--- a/card.wireless.req.notecard.api.json
+++ b/card.wireless.req.notecard.api.json
@@ -6,7 +6,7 @@
     "type": "object",
     "version": "0.2.1",
     "apiVersion": "9.1.1",
-    "skus": ["CELL", "CELL+WIFI", "WIFI"],
+    "skus": ["CELL", "CELL+WIFI"],
     "properties": {
         "mode": {
             "description": "Network scan mode. Must be one of: `\"-\"` to reset to the default mode, `\"auto\"` to perform automatic band scan mode (this is the default mode). The following values apply exclusively to Narrowband (NB) Notecard Cellular devices: `\"m\"` to restrict the modem to Cat-M1, `\"nb\"` to restrict the modem to Cat-NB1, `\"gprs\"` to restrict the modem to EGPRS.",
@@ -29,18 +29,15 @@
                 },
                 {
                     "const": "m",
-                    "description": "Restrict the modem to Cat-M1 (applies exclusively to Narrowband Notecard Cellular devices).",
-                    "skus": ["CELL"]
+                    "description": "Restrict the modem to Cat-M1 (applies exclusively to Narrowband Notecard Cellular devices)."
                 },
                 {
                     "const": "nb",
-                    "description": "Restrict the modem to Cat-NB1 (applies exclusively to Narrowband Notecard Cellular devices).",
-                    "skus": ["CELL"]
+                    "description": "Restrict the modem to Cat-NB1 (applies exclusively to Narrowband Notecard Cellular devices)."
                 },
                 {
                     "const": "gprs",
-                    "description": "Restrict the modem to EGPRS (applies exclusively to Narrowband Notecard Cellular devices).",
-                    "skus": ["CELL"]
+                    "description": "Restrict the modem to EGPRS (applies exclusively to Narrowband Notecard Cellular devices)."
                 }
             ]
         },

--- a/card.wireless.req.notecard.api.json
+++ b/card.wireless.req.notecard.api.json
@@ -4,6 +4,15 @@
     "title": "card.wireless Request Application Programming Interface (API) Schema",
     "description": "View the last known network state, or customize the behavior of the modem. Note: Be careful when using this mode with hardware not on hand as a mistake may cause loss of network and Notehub access.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
+    "annotations": [
+        {
+            "title": "note",
+            "description": "Be careful when using this mode with hardware not on hand as a mistake may cause loss of network and Notehub access."
+        }
+    ],
     "properties": {
         "mode": {
             "description": "Network scan mode. Must be one of: `\"-\"` to reset to the default mode, `\"auto\"` to perform automatic band scan mode (this is the default mode). The following values apply exclusively to Narrowband (NB) Notecard Cellular devices: `\"m\"` to restrict the modem to Cat-M1, `\"nb\"` to restrict the modem to Cat-NB1, `\"gprs\"` to restrict the modem to EGPRS.",
@@ -115,15 +124,6 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.2.1",
-    "apiVersion": "9.1.1",
-    "skus": ["CELL", "CELL+WIFI", "WIFI"],
-    "annotations": [
-        {
-            "title": "note",
-            "description": "Be careful when using this mode with hardware not on hand as a mistake may cause loss of network and Notehub access."
-        }
-    ],
     "samples": [
         {
             "title": "Current Network State",

--- a/card.wireless.req.notecard.api.json
+++ b/card.wireless.req.notecard.api.json
@@ -6,7 +6,7 @@
     "type": "object",
     "properties": {
         "mode": {
-            "description": "Network scan mode",
+            "description": "Network scan mode. Must be one of: `\"-\"` to reset to the default mode, `\"auto\"` to perform automatic band scan mode (this is the default mode). The following values apply exclusively to Narrowband (NB) Notecard Cellular devices: `\"m\"` to restrict the modem to Cat-M1, `\"nb\"` to restrict the modem to Cat-NB1, `\"gprs\"` to restrict the modem to EGPRS.",
             "type": "string",
             "enum": [
                 "-",
@@ -14,14 +14,39 @@
                 "m",
                 "nb",
                 "gprs"
+            ],
+            "sub-descriptions": [
+                {
+                    "const": "-",
+                    "description": "Reset to the default mode."
+                },
+                {
+                    "const": "auto",
+                    "description": "Perform automatic band scan mode (this is the default mode)."
+                },
+                {
+                    "const": "m",
+                    "description": "Restrict the modem to Cat-M1 (applies exclusively to Narrowband Notecard Cellular devices).",
+                    "skus": ["CELL"]
+                },
+                {
+                    "const": "nb",
+                    "description": "Restrict the modem to Cat-NB1 (applies exclusively to Narrowband Notecard Cellular devices).",
+                    "skus": ["CELL"]
+                },
+                {
+                    "const": "gprs",
+                    "description": "Restrict the modem to EGPRS (applies exclusively to Narrowband Notecard Cellular devices).",
+                    "skus": ["CELL"]
+                }
             ]
         },
         "apn": {
-            "description": "Access Point Name (APN) when using an external SIM",
+            "description": "Access Point Name (APN) when using an external SIM. Use `\"-\"` to reset to the Notecard default APN.",
             "type": "string"
         },
         "method": {
-            "description": "Used when configuring a Notecard to failover to a different SIM",
+            "description": "Used when configuring a Notecard to failover to a different SIM.",
             "type": "string",
             "enum": [
                 "-",
@@ -29,7 +54,34 @@
                 "dual-secondary-primary",
                 "primary",
                 "secondary"
+            ],
+            "sub-descriptions": [
+                {
+                    "const": "-",
+                    "description": "Resets the Notecard to the default method."
+                },
+                {
+                    "const": "dual-primary-secondary",
+                    "description": "Will attempt to register with the internal SIM first, then failover to the external SIM."
+                },
+                {
+                    "const": "dual-secondary-primary",
+                    "description": "Will attempt to register with the external SIM first, then failover to the internal SIM."
+                },
+                {
+                    "const": "primary",
+                    "description": "Will exclusively use the internal SIM."
+                },
+                {
+                    "const": "secondary",
+                    "description": "Will exclusively use the external SIM."
+                }
             ]
+        },
+        "hours": {
+            "description": "When using the `method` argument with `\"dual-primary-secondary\"` or `\"dual-secondary-primary\"`, this is the number of hours after which the Notecard will attempt to switch back to the preferred SIM.",
+            "type": "integer",
+            "minimum": 1
         },
         "cmd": {
             "description": "Command for the Notecard (no response)",
@@ -63,6 +115,40 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
+    "annotations": [
+        {
+            "title": "note",
+            "description": "Be careful when using this mode with hardware not on hand as a mistake may cause loss of network and Notehub access."
+        }
+    ],
+    "samples": [
+        {
+            "title": "Current Network State",
+            "description": "Request current network state without any modifications.",
+            "json": "{\"req\":\"card.wireless\"}"
+        },
+        {
+            "title": "Change Scan Mode",
+            "description": "Restrict the modem to Cat-NB1 for narrowband connectivity.",
+            "json": "{\"req\":\"card.wireless\",\"mode\":\"nb\"}"
+        },
+        {
+            "title": "Reset Scan Mode",
+            "description": "Reset network scan mode to default behavior.",
+            "json": "{\"req\":\"card.wireless\",\"mode\":\"-\"}"
+        },
+        {
+            "title": "Set External SIM APN",
+            "description": "Configure APN for external SIM card usage.",
+            "json": "{\"req\":\"card.wireless\",\"apn\":\"myapn.nb\"}"
+        },
+        {
+            "title": "Failover to External SIM",
+            "description": "Configure dual SIM failover with external SIM priority.",
+            "json": "{\"req\":\"card.wireless\",\"apn\":\"myapn.nb\",\"method\":\"dual-primary-secondary\"}"
+        }
+    ]
 }

--- a/card.wireless.rsp.notecard.api.json
+++ b/card.wireless.rsp.notecard.api.json
@@ -2,54 +2,112 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/card.wireless.rsp.notecard.api.json",
     "title": "card.wireless Response Application Programming Interface (API) Schema",
+    "description": "Response containing wireless connection status, signal quality information, and detailed modem/network data from the Notecard.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "status": {
-            "description": "Current network status",
+            "description": "The current status of the wireless connection and modem.",
             "type": "string"
         },
         "count": {
-            "description": "Number of networks found",
+            "description": "Number of bars of signal quality.",
             "type": "integer"
         },
         "net": {
-            "description": "Array of networks found",
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "rat": {
-                        "description": "Radio Access Technology",
-                        "type": "string"
-                    },
-                    "band": {
-                        "description": "Frequency band",
-                        "type": "string"
-                    },
-                    "rssi": {
-                        "description": "Received Signal Strength Indicator",
-                        "type": "integer"
-                    },
-                    "mcc": {
-                        "description": "Mobile Country Code",
-                        "type": "integer"
-                    },
-                    "mnc": {
-                        "description": "Mobile Network Code",
-                        "type": "integer"
-                    },
-                    "lac": {
-                        "description": "Location Area Code",
-                        "type": "integer"
-                    },
-                    "cid": {
-                        "description": "Cell ID",
-                        "type": "integer"
-                    }
+            "description": "An object with detailed modem, radio access technology, and signal information (details will differ depending on the type of Notecard).",
+            "type": "object",
+            "properties": {
+                "iccid": {
+                    "description": "Integrated Circuit Card Identifier of the SIM card.",
+                    "type": "string"
+                },
+                "imsi": {
+                    "description": "International Mobile Subscriber Identity.",
+                    "type": "string"
+                },
+                "imei": {
+                    "description": "International Mobile Equipment Identity.",
+                    "type": "string"
+                },
+                "modem": {
+                    "description": "Modem firmware version and model information.",
+                    "type": "string"
+                },
+                "band": {
+                    "description": "The frequency band being used for communication.",
+                    "type": "string"
+                },
+                "rat": {
+                    "description": "Radio Access Technology being used.",
+                    "type": "string"
+                },
+                "rssir": {
+                    "description": "Reference Signal Received Power (RSRP) reported by the modem.",
+                    "type": "integer"
+                },
+                "rssi": {
+                    "description": "Received Signal Strength Indicator.",
+                    "type": "integer"
+                },
+                "rsrp": {
+                    "description": "Reference Signal Received Power.",
+                    "type": "integer"
+                },
+                "sinr": {
+                    "description": "Signal to Interference plus Noise Ratio.",
+                    "type": "integer"
+                },
+                "rsrq": {
+                    "description": "Reference Signal Received Quality.",
+                    "type": "integer"
+                },
+                "bars": {
+                    "description": "Signal strength represented as bars (0-5).",
+                    "type": "integer"
+                },
+                "mcc": {
+                    "description": "Mobile Country Code.",
+                    "type": "integer"
+                },
+                "mnc": {
+                    "description": "Mobile Network Code.",
+                    "type": "integer"
+                },
+                "lac": {
+                    "description": "Location Area Code.",
+                    "type": "integer"
+                },
+                "cid": {
+                    "description": "Cell ID.",
+                    "type": "integer"
+                },
+                "updated": {
+                    "description": "Unix timestamp of when the network information was last updated.",
+                    "type": "integer"
                 }
-            }
+            },
+            "additionalProperties": false
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Complete Wireless Status Response",
+            "description": "Example response showing comprehensive wireless connection and signal information.",
+            "json": "{\"status\":\"{modem-off}\",\"count\":1,\"net\":{\"iccid\":\"00000000000000000000\",\"imsi\":\"000000000000000\",\"imei\":\"000000000000000\",\"modem\":\"EG91NAXGAR07A03M1G_BETA0415_01.001.01.001\",\"band\":\"LTE BAND 2\",\"rat\":\"lte\",\"rssir\":-69,\"rssi\":-70,\"rsrp\":-105,\"sinr\":-3,\"rsrq\":-17,\"bars\":1,\"mcc\":310,\"mnc\":410,\"lac\":28681,\"cid\":211150856,\"updated\":1599225076}}"
+        },
+        {
+            "title": "Basic Signal Information",
+            "description": "Example response with basic signal strength and status.",
+            "json": "{\"status\":\"connected\",\"count\":3}"
+        },
+        {
+            "title": "Network Details Response",
+            "description": "Example response showing detailed network information.",
+            "json": "{\"status\":\"searching\",\"count\":2,\"net\":{\"band\":\"LTE BAND 12\",\"rat\":\"lte\",\"rssi\":-85,\"bars\":2,\"mcc\":310,\"mnc\":260}}"
+        }
+    ]
 }

--- a/card.wireless.rsp.notecard.api.json
+++ b/card.wireless.rsp.notecard.api.json
@@ -6,7 +6,7 @@
     "type": "object",
     "version": "0.2.1",
     "apiVersion": "9.1.1",
-    "skus": ["CELL", "CELL+WIFI", "WIFI"],
+    "skus": ["CELL", "CELL+WIFI"],
     "properties": {
         "status": {
             "description": "The current status of the wireless connection and modem.",

--- a/card.wireless.rsp.notecard.api.json
+++ b/card.wireless.rsp.notecard.api.json
@@ -6,7 +6,7 @@
     "type": "object",
     "version": "0.2.1",
     "apiVersion": "9.1.1",
-    "skus": ["CELL", "CELL+WIFI"],
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "status": {
             "description": "The current status of the wireless connection and modem.",

--- a/tests/test_card_wireless_rsp.py
+++ b/tests/test_card_wireless_rsp.py
@@ -34,84 +34,92 @@ def test_count_invalid_type(schema):
         jsonschema.validate(instance=instance, schema=schema)
     assert "'5' is not of type 'integer'" in str(excinfo.value)
 
-def test_valid_net_empty_array(schema):
-    """Tests valid net field with an empty array."""
-    instance = {"net": []}
+def test_valid_net_empty_object(schema):
+    """Tests valid net field with an empty object."""
+    instance = {"net": {}}
     jsonschema.validate(instance=instance, schema=schema)
 
 def test_net_invalid_type(schema):
-    """Tests invalid type for net (must be array)."""
-    instance = {"net": {}}
+    """Tests invalid type for net (must be object)."""
+    instance = {"net": []}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "{} is not of type 'array'" in str(excinfo.value)
+    assert "[] is not of type 'object'" in str(excinfo.value)
 
-def test_net_invalid_item_type(schema):
-    """Tests invalid item type within net array (must be object)."""
-    instance = {"net": ["invalid"]}
-    with pytest.raises(jsonschema.ValidationError) as excinfo:
-        jsonschema.validate(instance=instance, schema=schema)
-    assert "'invalid' is not of type 'object'" in str(excinfo.value)
-
-def test_valid_net_item_empty_object(schema):
-    """Tests valid net array with an empty object item."""
-    instance = {"net": [{}]}
-    jsonschema.validate(instance=instance, schema=schema)
-
-# Parametrized tests for net item sub-properties (string)
+# Parametrized tests for net object sub-properties (string)
 @pytest.mark.parametrize(
     "sub_field, valid_value, invalid_value",
     [
-        ("rat", "lte", 123),
-        ("band", "20", True)
+        ("iccid", "00000000000000000000", 123),
+        ("imsi", "000000000000000", True),
+        ("imei", "000000000000000", 123),
+        ("modem", "EG91NAXGAR07A03M1G", 123),
+        ("band", "LTE BAND 2", 123),
+        ("rat", "lte", 123)
     ]
 )
-def test_net_item_string_sub_properties(schema, sub_field, valid_value, invalid_value):
-    """Tests valid and invalid types for net item string sub-properties."""
+def test_net_string_sub_properties(schema, sub_field, valid_value, invalid_value):
+    """Tests valid and invalid types for net object string sub-properties."""
     # Valid type
-    instance = {"net": [{sub_field: valid_value}]}
+    instance = {"net": {sub_field: valid_value}}
     jsonschema.validate(instance=instance, schema=schema)
 
     # Invalid type
-    instance = {"net": [{sub_field: invalid_value}]}
+    instance = {"net": {sub_field: invalid_value}}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
     assert f"is not of type 'string'" in str(excinfo.value)
 
-# Parametrized tests for net item sub-properties (integer)
+# Parametrized tests for net object sub-properties (integer)
 @pytest.mark.parametrize(
     "sub_field, valid_value, invalid_value",
     [
-        ("rssi", -90, "-90"),
+        ("rssir", -69, "-69"),
+        ("rssi", -70, "-70"),
+        ("rsrp", -105, "-105"),
+        ("sinr", -3, "-3"),
+        ("rsrq", -17, "-17"),
+        ("bars", 1, "1"),
         ("mcc", 310, 310.5),
         ("mnc", 410, True),
-        ("lac", 12345, "12345"),
-        ("cid", 54321, 54321.5)
+        ("lac", 28681, "28681"),
+        ("cid", 211150856, "211150856"),
+        ("updated", 1599225076, "1599225076")
     ]
 )
-def test_net_item_integer_sub_properties(schema, sub_field, valid_value, invalid_value):
-    """Tests valid and invalid types for net item integer sub-properties."""
+def test_net_integer_sub_properties(schema, sub_field, valid_value, invalid_value):
+    """Tests valid and invalid types for net object integer sub-properties."""
     # Valid type
-    instance = {"net": [{sub_field: valid_value}]}
+    instance = {"net": {sub_field: valid_value}}
     jsonschema.validate(instance=instance, schema=schema)
 
     # Invalid type
-    instance = {"net": [{sub_field: invalid_value}]}
+    instance = {"net": {sub_field: invalid_value}}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
     assert f"is not of type 'integer'" in str(excinfo.value)
 
-def test_valid_net_item_all_fields(schema):
-    """Tests valid net array with item having all sub-properties."""
-    instance = {"net": [{
-        "rat": "nbiot",
-        "band": "8",
-        "rssi": -105,
-        "mcc": 234,
-        "mnc": 15,
-        "lac": 5432,
-        "cid": 98765
-    }]}
+def test_valid_net_object_all_fields(schema):
+    """Tests valid net object with all sub-properties."""
+    instance = {"net": {
+        "iccid": "00000000000000000000",
+        "imsi": "000000000000000",
+        "imei": "000000000000000",
+        "modem": "EG91NAXGAR07A03M1G_BETA0415_01.001.01.001",
+        "band": "LTE BAND 2",
+        "rat": "lte",
+        "rssir": -69,
+        "rssi": -70,
+        "rsrp": -105,
+        "sinr": -3,
+        "rsrq": -17,
+        "bars": 1,
+        "mcc": 310,
+        "mnc": 410,
+        "lac": 28681,
+        "cid": 211150856,
+        "updated": 1599225076
+    }}
     jsonschema.validate(instance=instance, schema=schema)
 
 def test_valid_all_top_level_fields(schema):
@@ -119,14 +127,37 @@ def test_valid_all_top_level_fields(schema):
     instance = {
         "status": "connected",
         "count": 1,
-        "net": [{
+        "net": {
             "rat": "lte",
             "rssi": -85
-        }]
+        }
     }
     jsonschema.validate(instance=instance, schema=schema)
 
-def test_valid_additional_property(schema):
-    """Tests valid response with an additional property."""
-    instance = {"status": "ok", "imei": "123456789012345"}
-    jsonschema.validate(instance=instance, schema=schema)
+def test_invalid_additional_property(schema):
+    """Tests invalid response with an additional property."""
+    instance = {"status": "ok", "extra": "field"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+
+def test_net_invalid_additional_property(schema):
+    """Tests invalid net object with an additional property."""
+    instance = {"net": {"rssi": -70, "extra": "field"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    import json
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Updated request schema with comprehensive parameter descriptions and sub-descriptions matching API reference exactly
- Added `hours` parameter for SIM failover timing control (version 5.3.1+ feature)
- Enhanced response schema with correct `net` object structure (was incorrectly array type)
- Added all network information fields from API reference (iccid, imsi, imei, modem, signal data, etc.)
- Added SKU compatibility for CELL, CELL+WIFI, and WIFI variants
- Added strict validation with additionalProperties: false for both schemas

## Test plan
- [x] All existing and new tests pass (47/47)
- [x] Schema samples validate correctly against enhanced schemas
- [x] Request schema properly validates all parameter combinations
- [x] Response schema enforces correct net object structure with all signal fields
- [x] Strict validation prevents additional properties
- [x] SKU compatibility properly specified for all Notecard variants

🤖 Generated with [Claude Code](https://claude.ai/code)