### PR TITLE
feat: enhance env.set schemas to v0.2.1 with complete API alignment

### DIFF
--- a/env.set.req.notecard.api.json
+++ b/env.set.req.notecard.api.json
@@ -2,15 +2,19 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/env.set.req.notecard.api.json",
     "title": "env.set Request Application Programming Interface (API) Schema",
-    "description": "deprecatedThe env.set API is deprecated as of v7.2.2. We recommend setting environment variables in Notehub using either the Notehub user interface or Notehub API. You may also use the env.default API to provide a default value for an environment variable, until that variable is overridden by a value from Notehub.",
+    "description": "Sets a local environment variable on the Notecard. Local environment variables cannot be overridden by a Notehub variable of any scope.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
+    "deprecated": true,
     "properties": {
         "name": {
-            "description": "Name of the environment variable to set",
+            "description": "The name of the environment variable (case-insensitive).",
             "type": "string"
         },
         "text": {
-            "description": "Value to set for the environment variable",
+            "description": "The value of the variable. Pass `\"\"` or omit from the request to delete it.",
             "type": "string"
         },
         "cmd": {
@@ -45,6 +49,27 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "annotations": [
+        {
+            "title": "deprecated",
+            "description": "The `env.set` API is deprecated as of v7.2.2. We recommend setting environment variables in Notehub using either the Notehub user interface or [Notehub API](/api-reference/notehub-api). You may also use the `env.default` API to provide a default value for an environment variable, until that variable is overridden by a value from Notehub."
+        }
+    ],
+    "samples": [
+        {
+            "title": "Set Environment Variable",
+            "description": "Set a local environment variable on the Notecard.",
+            "json": "{\"req\": \"env.set\", \"name\": \"monitor-pump\", \"text\": \"on\"}"
+        },
+        {
+            "title": "Clear Environment Variable",
+            "description": "Clear a local environment variable by omitting text.",
+            "json": "{\"req\": \"env.set\", \"name\": \"monitor-pump\"}"
+        },
+        {
+            "title": "Set Empty String",
+            "description": "Set an environment variable to an empty string.",
+            "json": "{\"req\": \"env.set\", \"name\": \"debug-mode\", \"text\": \"\"}"
+        }
+    ]
 }

--- a/env.set.rsp.notecard.api.json
+++ b/env.set.rsp.notecard.api.json
@@ -2,21 +2,24 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/env.set.rsp.notecard.api.json",
     "title": "env.set Response Application Programming Interface (API) Schema",
+    "description": "Response containing the timestamp of the environment variable change.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
+    "deprecated": true,
     "properties": {
-        "name": {
-            "description": "Name of the environment variable",
-            "type": "string"
-        },
-        "text": {
-            "description": "Value of the environment variable",
-            "type": "string"
-        },
         "time": {
-            "description": "The logged time of the variable change",
+            "description": "The logged time of the variable change.",
             "type": "integer"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Environment Variable Set Response",
+            "description": "Response containing the timestamp of when the variable was set.",
+            "json": "{\"time\": 1605814493}"
+        }
+    ]
 }

--- a/tests/test_env_set_req.py
+++ b/tests/test_env_set_req.py
@@ -1,0 +1,98 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "env.set.req.notecard.api.json"
+
+def test_valid_req(schema):
+    """Tests a minimal valid request with required name."""
+    instance = {"req": "env.set", "name": "test-var"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd(schema):
+    """Tests a minimal valid command with required name."""
+    instance = {"cmd": "env.set", "name": "test-var"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"name": "test-var"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {"req": "env.set", "cmd": "env.set", "name": "test-var"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is valid under each of" in str(excinfo.value)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {"req": "wrong.api", "name": "test-var"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'env.set' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {"cmd": "wrong.api", "name": "test-var"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'env.set' was expected" in str(excinfo.value)
+
+def test_valid_name(schema):
+    """Tests valid name field."""
+    instance = {"req": "env.set", "name": "monitor-pump"}
+    jsonschema.validate(instance=instance, schema=schema)
+    instance = {"req": "env.set", "name": "SAMPLE_RATE"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_name_invalid_type(schema):
+    """Tests invalid type for name."""
+    instance = {"req": "env.set", "name": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_valid_text(schema):
+    """Tests valid text field."""
+    instance = {"req": "env.set", "name": "test-var", "text": "on"}
+    jsonschema.validate(instance=instance, schema=schema)
+    instance = {"req": "env.set", "name": "test-var", "text": ""}
+    jsonschema.validate(instance=instance, schema=schema)
+    instance = {"req": "env.set", "name": "test-var", "text": "60"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_text_invalid_type(schema):
+    """Tests invalid type for text."""
+    instance = {"req": "env.set", "name": "test-var", "text": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_text_optional(schema):
+    """Tests that text field is optional."""
+    instance = {"req": "env.set", "name": "test-var"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with an additional property."""
+    instance = {"req": "env.set", "name": "test-var", "extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_env_set_rsp.py
+++ b/tests/test_env_set_rsp.py
@@ -1,0 +1,87 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "env.set.rsp.notecard.api.json"
+
+def test_minimal_valid_rsp(schema):
+    """Tests a minimal valid response (empty object)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_time_response(schema):
+    """Tests valid response with time field."""
+    instance = {"time": 1605814493}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_zero_time(schema):
+    """Tests valid response with zero time."""
+    instance = {"time": 0}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_large_time(schema):
+    """Tests valid response with large timestamp."""
+    instance = {"time": 2147483647}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_time_invalid_type(schema):
+    """Tests invalid type for time."""
+    instance = {"time": "not-integer"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not-integer' is not of type 'integer'" in str(excinfo.value)
+
+def test_time_invalid_float(schema):
+    """Tests invalid float type for time."""
+    instance = {"time": 1605814493.5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1605814493.5 is not of type 'integer'" in str(excinfo.value)
+
+def test_time_invalid_boolean(schema):
+    """Tests invalid boolean type for time."""
+    instance = {"time": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'integer'" in str(excinfo.value)
+
+def test_time_invalid_array(schema):
+    """Tests invalid array type for time."""
+    instance = {"time": [1605814493]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with an additional property."""
+    instance = {"time": 1605814493, "extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_name_property(schema):
+    """Tests that name property is not allowed in response."""
+    instance = {"name": "test-var"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_text_property(schema):
+    """Tests that text property is not allowed in response."""
+    instance = {"text": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Enhanced env.set.req.notecard.api.json with comprehensive parameter descriptions and deprecation handling
- Added SKU compatibility for CELL, CELL+WIFI, and WIFI variants (excluding LORA as not supported by env.set)
- Properly marked as deprecated with detailed annotation explaining alternatives including Notehub API and env.default
- Updated samples with practical examples for setting, clearing, and empty string values
- Enhanced env.set.rsp.notecard.api.json with simplified response containing only time field
- Removed name and text fields from response as they're not returned by the actual API
- Added strict validation with additionalProperties: false to response schema
- Created comprehensive test suites for both request and response schemas with full parameter coverage

## Test plan
- [x] All tests pass (25/25) including comprehensive parameter validation
- [x] Schema samples validate successfully against their schemas
- [x] Request schema supports both req/cmd patterns with oneOf validation
- [x] Request schema properly handles deprecated status with appropriate annotation
- [x] Response schema enforces strict validation with additionalProperties: false
- [x] SKU compatibility properly defined for supported Notecard variants
- [x] Response contains only time field as per actual API behavior
- [x] Deprecation annotation provides clear guidance on recommended alternatives

🤖 Generated with [Claude Code](https://claude.ai/code)