### PR TITLE
feat: update file.delete schemas to v0.2.1 with comprehensive test coverage

### DIFF
--- a/file.delete.req.notecard.api.json
+++ b/file.delete.req.notecard.api.json
@@ -4,17 +4,20 @@
     "title": "file.delete Request Application Programming Interface (API) Schema",
     "description": "Deletes Notefiles and the Notes they contain.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
+        "cmd": {
+            "description": "Command for the Notecard (no response)",
+            "const": "file.delete"
+        },
         "files": {
-            "description": "Array of files to delete",
+            "description": "One or more files to delete.",
             "type": "array",
             "items": {
                 "type": "string"
             }
-        },
-        "cmd": {
-            "description": "Command for the Notecard (no response)",
-            "const": "file.delete"
         },
         "req": {
             "description": "Request for the Notecard (expects response)",
@@ -24,7 +27,8 @@
     "oneOf": [
         {
             "required": [
-                "req"
+                "req",
+                "files"
             ],
             "properties": {
                 "req": {
@@ -34,7 +38,8 @@
         },
         {
             "required": [
-                "cmd"
+                "cmd",
+                "files"
             ],
             "properties": {
                 "cmd": {
@@ -44,6 +49,16 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Delete Multiple Files",
+            "description": "Delete multiple Notefiles and their contents.",
+            "json": "{\"req\": \"file.delete\", \"files\": [\"my-settings.db\", \"other-settings.db\"]}"
+        },
+        {
+            "title": "Delete Single File",
+            "description": "Delete a single Notefile and its contents.",
+            "json": "{\"req\": \"file.delete\", \"files\": [\"data.qo\"]}"
+        }
+    ]
 }

--- a/file.delete.rsp.notecard.api.json
+++ b/file.delete.rsp.notecard.api.json
@@ -2,13 +2,18 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/file.delete.rsp.notecard.api.json",
     "title": "file.delete Response Application Programming Interface (API) Schema",
+    "description": "Response confirming the deletion of the specified Notefiles.",
     "type": "object",
-    "properties": {
-        "result": {
-            "description": "Empty object returned on success",
-            "type": "object"
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
+    "properties": {},
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Delete Success Response",
+            "description": "Successful response after deleting Notefiles.",
+            "json": "{}"
         }
-    },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    ]
 }

--- a/tests/test_file_delete_req.py
+++ b/tests/test_file_delete_req.py
@@ -1,0 +1,198 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "file.delete.req.notecard.api.json"
+
+def test_valid_req_with_files(schema):
+    """Tests a valid request with files parameter."""
+    instance = {"req": "file.delete", "files": ["my-settings.db", "other-settings.db"]}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_with_files(schema):
+    """Tests a valid command with files parameter."""
+    instance = {"cmd": "file.delete", "files": ["data.qo"]}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_req_missing_files(schema):
+    """Tests invalid request missing files parameter."""
+    instance = {"req": "file.delete"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_cmd_missing_files(schema):
+    """Tests invalid command missing files parameter."""
+    instance = {"cmd": "file.delete"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"files": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {"req": "file.delete", "cmd": "file.delete", "files": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is valid under each of" in str(excinfo.value)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {"req": "wrong.api", "files": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.delete' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {"cmd": "wrong.api", "files": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.delete' was expected" in str(excinfo.value)
+
+def test_valid_files_single_item(schema):
+    """Tests valid files array with single item."""
+    instance = {"req": "file.delete", "files": ["data.qo"]}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_files_multiple_items(schema):
+    """Tests valid files array with multiple items."""
+    instance = {"req": "file.delete", "files": ["sensors.db", "data.qo", "config.qos"]}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_files_empty_array(schema):
+    """Tests valid files array that is empty."""
+    instance = {"req": "file.delete", "files": []}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_files_various_extensions(schema):
+    """Tests valid files with various extensions."""
+    instance = {"req": "file.delete", "files": ["data.qo", "secure.qos", "settings.db", "temp.dbs"]}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_files_no_extensions(schema):
+    """Tests valid files without extensions."""
+    instance = {"req": "file.delete", "files": ["data", "settings", "temp"]}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_files_empty_strings(schema):
+    """Tests valid files with empty strings."""
+    instance = {"req": "file.delete", "files": ["", "data.qo", ""]}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_files_invalid_type(schema):
+    """Tests invalid type for files."""
+    instance = {"req": "file.delete", "files": "not-array"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not-array' is not of type 'array'" in str(excinfo.value)
+
+def test_files_invalid_integer(schema):
+    """Tests invalid integer type for files."""
+    instance = {"req": "file.delete", "files": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'array'" in str(excinfo.value)
+
+def test_files_invalid_boolean(schema):
+    """Tests invalid boolean type for files."""
+    instance = {"req": "file.delete", "files": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'array'" in str(excinfo.value)
+
+def test_files_invalid_object(schema):
+    """Tests invalid object type for files."""
+    instance = {"req": "file.delete", "files": {"name": "data.qo"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'array'" in str(excinfo.value)
+
+def test_files_item_invalid_type(schema):
+    """Tests invalid item type in files array."""
+    instance = {"req": "file.delete", "files": [123, "data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_files_item_invalid_boolean(schema):
+    """Tests invalid boolean item in files array."""
+    instance = {"req": "file.delete", "files": ["data.qo", True, "config.db"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'string'" in str(excinfo.value)
+
+def test_files_item_invalid_object(schema):
+    """Tests invalid object item in files array."""
+    instance = {"req": "file.delete", "files": [{"name": "data.qo"}]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_files_item_invalid_array(schema):
+    """Tests invalid array item in files array."""
+    instance = {"req": "file.delete", "files": [["data.qo"]]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_req_invalid_type(schema):
+    """Tests invalid type for req."""
+    instance = {"req": 123, "files": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.delete' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_type(schema):
+    """Tests invalid type for cmd."""
+    instance = {"cmd": ["file.delete"], "files": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.delete' was expected" in str(excinfo.value)
+
+def test_req_invalid_boolean(schema):
+    """Tests invalid boolean type for req."""
+    instance = {"req": True, "files": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.delete' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_boolean(schema):
+    """Tests invalid boolean type for cmd."""
+    instance = {"cmd": False, "files": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.delete' was expected" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with an additional property."""
+    instance = {"req": "file.delete", "files": ["data.qo"], "extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_with_cmd(schema):
+    """Tests invalid command with an additional property."""
+    instance = {"cmd": "file.delete", "files": ["data.qo"], "invalid": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_file_delete_rsp.py
+++ b/tests/test_file_delete_rsp.py
@@ -1,0 +1,113 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "file.delete.rsp.notecard.api.json"
+
+def test_minimal_valid_rsp(schema):
+    """Tests a minimal valid response (empty object)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_empty_object_response(schema):
+    """Tests that empty object is the expected response format."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property_single(schema):
+    """Tests invalid response with a single additional property."""
+    instance = {"extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_string(schema):
+    """Tests invalid response with string additional property."""
+    instance = {"message": "deleted"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_boolean(schema):
+    """Tests invalid response with boolean additional property."""
+    instance = {"success": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_object(schema):
+    """Tests invalid response with object additional property."""
+    instance = {"result": {"status": "ok"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_array(schema):
+    """Tests invalid response with array additional property."""
+    instance = {"files": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_result_property(schema):
+    """Tests that the old result property is no longer allowed."""
+    instance = {"result": {}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid response with multiple additional properties."""
+    instance = {"extra1": 123, "extra2": "value", "extra3": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_response_fields(schema):
+    """Tests that common response fields are not allowed."""
+    # Test typical fields that might be returned but shouldn't be
+    invalid_fields = [
+        {"status": "success"},
+        {"code": 200},
+        {"message": "Files deleted successfully"},
+        {"deleted": ["data.qo"]},
+        {"count": 2},
+        {"response": "ok"}
+    ]
+    
+    for field_dict in invalid_fields:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    # Test that non-objects are rejected
+    invalid_types = [
+        "string",
+        123,
+        True,
+        False,
+        ["array"],
+        None
+    ]
+    
+    for invalid_instance in invalid_types:
+        if invalid_instance is None:
+            continue  # Skip None as it's handled differently
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+        # The error message will vary based on type, just ensure validation fails
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
• Enhanced file.delete API schemas to v0.2.1 standards with improved field hierarchy and proper ordering
• Added comprehensive SKU compatibility for all Notecard types (CELL, CELL+WIFI, LORA, WIFI)
• Enhanced parameter descriptions matching API reference documentation exactly
• Made files parameter required for both req and cmd patterns using oneOf validation
• Corrected response schema to empty object (removed incorrect result property per API reference)
• Added comprehensive samples demonstrating multiple and single file deletion scenarios
• Implemented strict validation with additionalProperties: false for both request and response schemas
• Created extensive test suites with 41 passing tests covering all validation scenarios

## Test plan
- [x] Enhanced file.delete.req.notecard.api.json with v0.2.1 standards, proper field ordering, required files parameter, and comprehensive samples matching API reference
- [x] Enhanced file.delete.rsp.notecard.api.json with empty object response (removed incorrect result property)
- [x] Created test_file_delete_req.py with 29 comprehensive test cases covering valid/invalid requests, files parameter validation, and oneOf constraints  
- [x] Created test_file_delete_rsp.py with 12 comprehensive test cases ensuring only empty object responses are valid
- [x] All 41 tests pass validation successfully
- [x] Schema samples validate against their respective schemas
- [x] file.delete.req.notecard.api.json already exists in notecard.api.json index

🤖 Generated with [Claude Code](https://claude.ai/code)