### PR TITLE
feat: update file.stats schemas to v0.2.1 with comprehensive test coverage

### DIFF
--- a/file.stats.req.notecard.api.json
+++ b/file.stats.req.notecard.api.json
@@ -4,14 +4,17 @@
     "title": "file.stats Request Application Programming Interface (API) Schema",
     "description": "Gets resource statistics about local Notefiles.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
-        "file": {
-            "description": "Optional file to get stats for",
-            "type": "string"
-        },
         "cmd": {
             "description": "Command for the Notecard (no response)",
             "const": "file.stats"
+        },
+        "file": {
+            "description": "Returns the stats for the specified Notefile only.",
+            "type": "string"
         },
         "req": {
             "description": "Request for the Notecard (expects response)",
@@ -41,6 +44,16 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Get All File Stats",
+            "description": "Get resource statistics for all Notefiles.",
+            "json": "{\"req\": \"file.stats\"}"
+        },
+        {
+            "title": "Get Specific File Stats",
+            "description": "Get resource statistics for a specific Notefile.",
+            "json": "{\"req\": \"file.stats\", \"file\": \"sensors.qo\"}"
+        }
+    ]
 }

--- a/file.stats.rsp.notecard.api.json
+++ b/file.stats.rsp.notecard.api.json
@@ -2,21 +2,36 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/file.stats.rsp.notecard.api.json",
     "title": "file.stats Response Application Programming Interface (API) Schema",
+    "description": "Response containing resource statistics about local Notefiles.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
-        "total": {
-            "description": "Total number of notes in the file",
-            "type": "integer"
-        },
         "changes": {
-            "description": "Number of changes to the file",
+            "description": "The number of Notes across all Notefiles pending sync.",
             "type": "integer"
         },
         "sync": {
-            "description": "Whether the file is synced with Notehub",
+            "description": "`true` if a sync is recommended based on the number of pending notes.",
             "type": "boolean"
+        },
+        "total": {
+            "description": "The total number of Notes across all Notefiles.",
+            "type": "integer"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "File Statistics Response",
+            "description": "Response with resource statistics showing pending sync recommendation.",
+            "json": "{\"total\": 83, \"changes\": 78, \"sync\": true}"
+        },
+        {
+            "title": "No Pending Changes",
+            "description": "Response when no changes are pending sync.",
+            "json": "{\"total\": 25, \"changes\": 0, \"sync\": false}"
+        }
+    ]
 }

--- a/tests/test_file_stats_req.py
+++ b/tests/test_file_stats_req.py
@@ -1,0 +1,175 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "file.stats.req.notecard.api.json"
+
+def test_valid_req_without_file(schema):
+    """Tests a valid request without file parameter."""
+    instance = {"req": "file.stats"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_without_file(schema):
+    """Tests a valid command without file parameter."""
+    instance = {"cmd": "file.stats"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_file(schema):
+    """Tests a valid request with file parameter."""
+    instance = {"req": "file.stats", "file": "sensors.qo"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_with_file(schema):
+    """Tests a valid command with file parameter."""
+    instance = {"cmd": "file.stats", "file": "data.qo"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"file": "data.qo"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {"req": "file.stats", "cmd": "file.stats"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is valid under each of" in str(excinfo.value)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {"req": "wrong.api"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.stats' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {"cmd": "wrong.api"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.stats' was expected" in str(excinfo.value)
+
+def test_valid_file_various_extensions(schema):
+    """Tests valid file with various extensions."""
+    extensions = ["sensors.qo", "data.qos", "config.db", "settings.dbs"]
+    for ext in extensions:
+        instance = {"req": "file.stats", "file": ext}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_file_no_extension(schema):
+    """Tests valid file without extension."""
+    instance = {"req": "file.stats", "file": "data"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_file_empty_string(schema):
+    """Tests valid file with empty string."""
+    instance = {"req": "file.stats", "file": ""}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_file_with_special_chars(schema):
+    """Tests valid file with special characters."""
+    instance = {"req": "file.stats", "file": "my-sensor_data.qo"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_file_invalid_type(schema):
+    """Tests invalid type for file."""
+    instance = {"req": "file.stats", "file": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_file_invalid_boolean(schema):
+    """Tests invalid boolean type for file."""
+    instance = {"req": "file.stats", "file": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'string'" in str(excinfo.value)
+
+def test_file_invalid_array(schema):
+    """Tests invalid array type for file."""
+    instance = {"req": "file.stats", "file": ["data.qo"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_file_invalid_object(schema):
+    """Tests invalid object type for file."""
+    instance = {"req": "file.stats", "file": {"name": "data.qo"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_req_invalid_type(schema):
+    """Tests invalid type for req."""
+    instance = {"req": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.stats' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_type(schema):
+    """Tests invalid type for cmd."""
+    instance = {"cmd": ["file.stats"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.stats' was expected" in str(excinfo.value)
+
+def test_req_invalid_boolean(schema):
+    """Tests invalid boolean type for req."""
+    instance = {"req": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.stats' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_boolean(schema):
+    """Tests invalid boolean type for cmd."""
+    instance = {"cmd": False}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file.stats' was expected" in str(excinfo.value)
+
+def test_file_parameter_optional(schema):
+    """Tests that file parameter is optional."""
+    instance = {"req": "file.stats"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_file_parameter_optional_with_cmd(schema):
+    """Tests that file parameter is optional with cmd."""
+    instance = {"cmd": "file.stats"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with an additional property."""
+    instance = {"req": "file.stats", "extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_with_cmd(schema):
+    """Tests invalid command with an additional property."""
+    instance = {"cmd": "file.stats", "invalid": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {"req": "file.stats", "extra1": 123, "extra2": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_file_stats_rsp.py
+++ b/tests/test_file_stats_rsp.py
@@ -1,0 +1,218 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "file.stats.rsp.notecard.api.json"
+
+def test_minimal_valid_rsp(schema):
+    """Tests a minimal valid response (empty object)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_total_only(schema):
+    """Tests valid response with only total field."""
+    instance = {"total": 83}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_changes_only(schema):
+    """Tests valid response with only changes field."""
+    instance = {"changes": 78}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_sync_only(schema):
+    """Tests valid response with only sync field."""
+    instance = {"sync": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_sync_false(schema):
+    """Tests valid response with sync false."""
+    instance = {"sync": False}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_all_fields(schema):
+    """Tests valid response with all fields."""
+    instance = {"total": 83, "changes": 78, "sync": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_zero_values(schema):
+    """Tests valid response with zero values."""
+    instance = {"total": 0, "changes": 0, "sync": False}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_large_values(schema):
+    """Tests valid response with large values."""
+    instance = {"total": 1000000, "changes": 999999, "sync": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_no_pending_changes(schema):
+    """Tests valid response with no pending changes."""
+    instance = {"total": 25, "changes": 0, "sync": False}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_total_invalid_type(schema):
+    """Tests invalid type for total."""
+    instance = {"total": "not-integer"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not-integer' is not of type 'integer'" in str(excinfo.value)
+
+def test_total_invalid_float(schema):
+    """Tests invalid float type for total."""
+    instance = {"total": 83.5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "83.5 is not of type 'integer'" in str(excinfo.value)
+
+def test_total_invalid_boolean(schema):
+    """Tests invalid boolean type for total."""
+    instance = {"total": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'integer'" in str(excinfo.value)
+
+def test_total_invalid_array(schema):
+    """Tests invalid array type for total."""
+    instance = {"total": [83]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_changes_invalid_type(schema):
+    """Tests invalid type for changes."""
+    instance = {"changes": "not-integer"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not-integer' is not of type 'integer'" in str(excinfo.value)
+
+def test_changes_invalid_float(schema):
+    """Tests invalid float type for changes."""
+    instance = {"changes": 78.5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "78.5 is not of type 'integer'" in str(excinfo.value)
+
+def test_changes_invalid_boolean(schema):
+    """Tests invalid boolean type for changes."""
+    instance = {"changes": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'integer'" in str(excinfo.value)
+
+def test_changes_invalid_array(schema):
+    """Tests invalid array type for changes."""
+    instance = {"changes": [78]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_sync_invalid_type(schema):
+    """Tests invalid type for sync."""
+    instance = {"sync": "not-boolean"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not-boolean' is not of type 'boolean'" in str(excinfo.value)
+
+def test_sync_invalid_integer(schema):
+    """Tests invalid integer type for sync."""
+    instance = {"sync": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_sync_invalid_array(schema):
+    """Tests invalid array type for sync."""
+    instance = {"sync": [True]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'boolean'" in str(excinfo.value)
+
+def test_sync_invalid_object(schema):
+    """Tests invalid object type for sync."""
+    instance = {"sync": {"value": True}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'boolean'" in str(excinfo.value)
+
+def test_valid_partial_combinations(schema):
+    """Tests valid responses with various field combinations."""
+    combinations = [
+        {"total": 100},
+        {"changes": 50},
+        {"sync": True},
+        {"total": 100, "changes": 50},
+        {"total": 100, "sync": True},
+        {"changes": 50, "sync": False},
+        {"total": 100, "changes": 50, "sync": True}
+    ]
+    
+    for combo in combinations:
+        jsonschema.validate(instance=combo, schema=schema)
+
+def test_total_optional(schema):
+    """Tests that total field is optional."""
+    instance = {"changes": 78, "sync": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_changes_optional(schema):
+    """Tests that changes field is optional."""
+    instance = {"total": 83, "sync": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_sync_optional(schema):
+    """Tests that sync field is optional."""
+    instance = {"total": 83, "changes": 78}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with an additional property."""
+    instance = {"total": 83, "changes": 78, "sync": True, "extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"status": "ok"},
+        {"message": "success"},
+        {"count": 5},
+        {"files": []},
+        {"result": {}},
+        {"data": {"total": 83}}
+    ]
+    
+    for field_dict in invalid_fields:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = [
+        "string",
+        123,
+        True,
+        False,
+        ["array"],
+        None
+    ]
+    
+    for invalid_instance in invalid_types:
+        if invalid_instance is None:
+            continue  # Skip None as it's handled differently
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+        # The error message will vary based on type, just ensure validation fails
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
• Enhanced file.stats API schemas to v0.2.1 standards with improved field hierarchy and proper ordering
• Added comprehensive SKU compatibility for all Notecard types (CELL, CELL+WIFI, LORA, WIFI)
• Enhanced parameter descriptions matching API reference documentation exactly
• Made file parameter optional as specified in API reference (string, optional)
• Updated response field descriptions to match API reference exactly with proper backtick formatting
• Added comprehensive samples demonstrating both general and specific file statistics scenarios
• Implemented strict validation with additionalProperties: false for both request and response schemas
• Created extensive test suites with 55 passing tests covering all validation scenarios

## Test plan
- [x] Enhanced file.stats.req.notecard.api.json with v0.2.1 standards, proper field ordering, optional file parameter, and comprehensive samples matching API reference
- [x] Enhanced file.stats.rsp.notecard.api.json with exact field descriptions from API reference including proper backtick formatting
- [x] Created test_file_stats_req.py with 26 comprehensive test cases covering valid/invalid requests, optional file parameter validation, and oneOf constraints
- [x] Created test_file_stats_rsp.py with 29 comprehensive test cases covering all response field types and validation scenarios
- [x] All 55 tests pass validation successfully
- [x] Schema samples validate against their respective schemas matching example response from API reference
- [x] file.stats.req.notecard.api.json already exists in notecard.api.json index

🤖 Generated with [Claude Code](https://claude.ai/code)