### PR TITLE
feat: update hub.get schemas to v0.2.1 with comprehensive test coverage

### DIFF
--- a/hub.get.req.notecard.api.json
+++ b/hub.get.req.notecard.api.json
@@ -4,6 +4,9 @@
     "title": "hub.get Request Application Programming Interface (API) Schema",
     "description": "Retrieves the current Notehub configuration for the Notecard.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
         "cmd": {
             "description": "Command for the Notecard (no response)",
@@ -37,6 +40,11 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Get Notehub Configuration",
+            "description": "Retrieve the current Notehub configuration for the Notecard.",
+            "json": "{\"req\": \"hub.get\"}"
+        }
+    ]
 }

--- a/hub.get.rsp.notecard.api.json
+++ b/hub.get.rsp.notecard.api.json
@@ -2,49 +2,59 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/hub.get.rsp.notecard.api.json",
     "title": "hub.get Response Application Programming Interface (API) Schema",
+    "description": "Response containing the current Notehub configuration for the Notecard.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
         "device": {
-            "description": "The DeviceUID for the Notecard",
-            "type": "string"
-        },
-        "product": {
-            "description": "Product identifier",
-            "type": "string"
-        },
-        "mode": {
-            "description": "Hub mode (periodic, continuous, minimum)",
-            "type": "string"
-        },
-        "outbound": {
-            "description": "Outbound data period in seconds",
-            "type": "integer"
-        },
-        "voutbound": {
-            "description": "Voltage-variable outbound period",
-            "type": "string"
-        },
-        "inbound": {
-            "description": "Inbound data period in seconds",
-            "type": "integer"
-        },
-        "vinbound": {
-            "description": "Voltage-variable inbound period",
+            "description": "The [DeviceUID](/api-reference/glossary#deviceuid) for the Notecard.",
             "type": "string"
         },
         "host": {
-            "description": "Host address",
+            "description": "The URL of the Notehub host.",
+            "type": "string"
+        },
+        "inbound": {
+            "description": "The max wait time, in minutes, to sync inbound data from Notehub.",
+            "type": "integer"
+        },
+        "mode": {
+            "description": "The current operating `mode` of the Notecard, as defined in `hub.set`.",
+            "type": "string"
+        },
+        "outbound": {
+            "description": "The max wait time, in minutes, to sync outbound data from the Notecard.",
+            "type": "integer"
+        },
+        "product": {
+            "description": "The ProductUID to which the Notecard is registered.",
             "type": "string"
         },
         "sn": {
-            "description": "Serial number",
+            "description": "The serial number of the device, if set.",
             "type": "string"
         },
         "sync": {
-            "description": "Whether sync is enabled",
+            "description": "`true` if the device is in `continuous` mode and set to sync every time a change is detected.",
             "type": "boolean"
+        },
+        "vinbound": {
+            "description": "If `inbound` has been overridden with a voltage-variable value.",
+            "type": "string"
+        },
+        "voutbound": {
+            "description": "If `outbound` is overridden with a voltage-variable value.",
+            "type": "string"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Notehub Configuration Response",
+            "description": "Response with current Notehub configuration settings.",
+            "json": "{\"device\": \"dev:000000000000000\", \"product\": \"com.your-company.your-name:your_product\", \"mode\": \"periodic\", \"outbound\": 60, \"inbound\": 240, \"host\": \"a.notefile.net\", \"sn\": \"your-serial-number\"}"
+        }
+    ]
 }

--- a/tests/test_hub_get_req.py
+++ b/tests/test_hub_get_req.py
@@ -1,0 +1,124 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "hub.get.req.notecard.api.json"
+
+def test_valid_req(schema):
+    """Tests a minimal valid request."""
+    instance = {"req": "hub.get"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd(schema):
+    """Tests a minimal valid command."""
+    instance = {"cmd": "hub.get"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {"req": "hub.get", "cmd": "hub.get"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is valid under each of" in str(excinfo.value)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {"req": "wrong.api"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.get' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {"cmd": "wrong.api"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.get' was expected" in str(excinfo.value)
+
+def test_req_invalid_type(schema):
+    """Tests invalid type for req."""
+    instance = {"req": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.get' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_type(schema):
+    """Tests invalid type for cmd."""
+    instance = {"cmd": ["hub.get"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.get' was expected" in str(excinfo.value)
+
+def test_req_invalid_boolean(schema):
+    """Tests invalid boolean type for req."""
+    instance = {"req": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.get' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_boolean(schema):
+    """Tests invalid boolean type for cmd."""
+    instance = {"cmd": False}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.get' was expected" in str(excinfo.value)
+
+def test_req_invalid_object(schema):
+    """Tests invalid object type for req."""
+    instance = {"req": {"api": "hub.get"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.get' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_object(schema):
+    """Tests invalid object type for cmd."""
+    instance = {"cmd": {"api": "hub.get"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.get' was expected" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with an additional property."""
+    instance = {"req": "hub.get", "extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_with_cmd(schema):
+    """Tests invalid command with an additional property."""
+    instance = {"cmd": "hub.get", "invalid": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {"req": "hub.get", "extra1": 123, "extra2": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_no_parameters_required(schema):
+    """Tests that hub.get requires no parameters besides req/cmd."""
+    instance = {"req": "hub.get"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_hub_get_rsp.py
+++ b/tests/test_hub_get_rsp.py
@@ -1,0 +1,245 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "hub.get.rsp.notecard.api.json"
+
+def test_minimal_valid_rsp(schema):
+    """Tests a minimal valid response (empty object)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_device_only(schema):
+    """Tests valid response with only device field."""
+    instance = {"device": "dev:000000000000000"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_product_only(schema):
+    """Tests valid response with only product field."""
+    instance = {"product": "com.company.user:product"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_mode_only(schema):
+    """Tests valid response with only mode field."""
+    instance = {"mode": "periodic"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_all_fields(schema):
+    """Tests valid response with all fields."""
+    instance = {
+        "device": "dev:000000000000000",
+        "product": "com.your-company.your-name:your_product",
+        "mode": "periodic",
+        "outbound": 60,
+        "inbound": 240,
+        "host": "a.notefile.net",
+        "sn": "your-serial-number",
+        "sync": False,
+        "voutbound": "5:10",
+        "vinbound": "10:15"
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_mode_values(schema):
+    """Tests valid mode values."""
+    mode_values = ["periodic", "continuous", "minimum"]
+    for mode in mode_values:
+        instance = {"mode": mode}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_sync_true(schema):
+    """Tests valid response with sync true."""
+    instance = {"sync": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_sync_false(schema):
+    """Tests valid response with sync false."""
+    instance = {"sync": False}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_zero_timing_values(schema):
+    """Tests valid response with zero timing values."""
+    instance = {"outbound": 0, "inbound": 0}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_large_timing_values(schema):
+    """Tests valid response with large timing values."""
+    instance = {"outbound": 86400, "inbound": 43200}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_device_invalid_type(schema):
+    """Tests invalid type for device."""
+    instance = {"device": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_product_invalid_type(schema):
+    """Tests invalid type for product."""
+    instance = {"product": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'string'" in str(excinfo.value)
+
+def test_mode_invalid_type(schema):
+    """Tests invalid type for mode."""
+    instance = {"mode": ["periodic"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_outbound_invalid_type(schema):
+    """Tests invalid type for outbound."""
+    instance = {"outbound": "not-integer"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not-integer' is not of type 'integer'" in str(excinfo.value)
+
+def test_outbound_invalid_float(schema):
+    """Tests invalid float type for outbound."""
+    instance = {"outbound": 60.5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "60.5 is not of type 'integer'" in str(excinfo.value)
+
+def test_inbound_invalid_type(schema):
+    """Tests invalid type for inbound."""
+    instance = {"inbound": "not-integer"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not-integer' is not of type 'integer'" in str(excinfo.value)
+
+def test_inbound_invalid_float(schema):
+    """Tests invalid float type for inbound."""
+    instance = {"inbound": 240.5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "240.5 is not of type 'integer'" in str(excinfo.value)
+
+def test_voutbound_invalid_type(schema):
+    """Tests invalid type for voutbound."""
+    instance = {"voutbound": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_vinbound_invalid_type(schema):
+    """Tests invalid type for vinbound."""
+    instance = {"vinbound": 456}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "456 is not of type 'string'" in str(excinfo.value)
+
+def test_host_invalid_type(schema):
+    """Tests invalid type for host."""
+    instance = {"host": {"url": "a.notefile.net"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_sn_invalid_type(schema):
+    """Tests invalid type for sn."""
+    instance = {"sn": 789}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "789 is not of type 'string'" in str(excinfo.value)
+
+def test_sync_invalid_type(schema):
+    """Tests invalid type for sync."""
+    instance = {"sync": "not-boolean"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not-boolean' is not of type 'boolean'" in str(excinfo.value)
+
+def test_sync_invalid_integer(schema):
+    """Tests invalid integer type for sync."""
+    instance = {"sync": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_valid_partial_combinations(schema):
+    """Tests valid responses with various field combinations."""
+    combinations = [
+        {"device": "dev:123", "product": "com.test:app"},
+        {"mode": "continuous", "sync": True},
+        {"outbound": 30, "inbound": 120},
+        {"host": "custom.notefile.net"},
+        {"sn": "SN123456789"},
+        {"voutbound": "5:10", "vinbound": "8:12"}
+    ]
+    
+    for combo in combinations:
+        jsonschema.validate(instance=combo, schema=schema)
+
+def test_all_fields_optional(schema):
+    """Tests that all fields are optional."""
+    # Test each field individually
+    fields = [
+        {"device": "dev:000000000000000"},
+        {"product": "com.company.user:product"},
+        {"mode": "periodic"},
+        {"outbound": 60},
+        {"inbound": 240},
+        {"host": "a.notefile.net"},
+        {"sn": "serial123"},
+        {"sync": True},
+        {"voutbound": "5:10"},
+        {"vinbound": "10:15"}
+    ]
+    
+    for field_dict in fields:
+        jsonschema.validate(instance=field_dict, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with an additional property."""
+    instance = {"device": "dev:123", "extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"status": "ok"},
+        {"message": "success"},
+        {"time": 1234567890},
+        {"version": "1.0"},
+        {"result": {}}
+    ]
+    
+    for field_dict in invalid_fields:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = [
+        "string",
+        123,
+        True,
+        False,
+        ["array"],
+        None
+    ]
+    
+    for invalid_instance in invalid_types:
+        if invalid_instance is None:
+            continue  # Skip None as it's handled differently
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+        # The error message will vary based on type, just ensure validation fails
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Enhanced `hub.get.req.notecard.api.json` to v0.2.1 standards with proper field hierarchy
- Enhanced `hub.get.rsp.notecard.api.json` with complete field documentation matching API reference
- Added comprehensive test coverage with 46 test cases covering all validation scenarios
- Ensured all field descriptions match the official API reference documentation exactly

## Changes
- **Request Schema**: Updated to v0.2.1 with oneOf validation for req/cmd patterns
- **Response Schema**: Complete 10-field response structure with exact API reference descriptions
- **Test Coverage**: 17 request tests + 29 response tests covering all field types and validation rules
- **SKU Compatibility**: Full support for CELL, CELL+WIFI, LORA, WIFI across all schemas

## Test Results
All 46 tests pass successfully:
- Request schema validation with req/cmd patterns
- Response schema validation for all 10 optional fields
- Type validation and constraint enforcement
- Sample JSON validation from schema definitions

🤖 Generated with [Claude Code](https://claude.ai/code)