### PR TITLE
feat: update hub.log schemas to v0.2.1 with comprehensive test coverage

### DIFF
--- a/hub.log.req.notecard.api.json
+++ b/hub.log.req.notecard.api.json
@@ -4,17 +4,12 @@
     "title": "hub.log Request Application Programming Interface (API) Schema",
     "description": "Add a \"device health\" log message to send to Notehub on the next sync via the _health_host.qo Notefile.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
-        "text": {
-            "description": "Text to log",
-            "type": "string"
-        },
         "alert": {
-            "description": "Whether this is an alert message",
-            "type": "boolean"
-        },
-        "sync": {
-            "description": "Whether to sync this log message immediately",
+            "description": "`true` if the message is urgent. This doesn't change any functionality, but rather `alert` is provided as a convenient flag to use in your program logic.",
             "type": "boolean"
         },
         "cmd": {
@@ -24,6 +19,14 @@
         "req": {
             "description": "Request for the Notecard (expects response)",
             "const": "hub.log"
+        },
+        "sync": {
+            "description": "`true` if a sync should be initiated immediately. Setting `true` will also remove the Notecard from certain types of penalty boxes.",
+            "type": "boolean"
+        },
+        "text": {
+            "description": "Text to log.",
+            "type": "string"
         }
     },
     "oneOf": [
@@ -49,6 +52,16 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Log Health Alert with Immediate Sync",
+            "description": "Log an urgent health alert and sync immediately.",
+            "json": "{\"req\": \"hub.log\", \"text\": \"something is wrong!\", \"alert\": true, \"sync\": true}"
+        },
+        {
+            "title": "Log Simple Message",
+            "description": "Log a simple text message.",
+            "json": "{\"req\": \"hub.log\", \"text\": \"System status: normal\"}"
+        }
+    ]
 }

--- a/hub.log.rsp.notecard.api.json
+++ b/hub.log.rsp.notecard.api.json
@@ -2,8 +2,18 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/hub.log.rsp.notecard.api.json",
     "title": "hub.log Response Application Programming Interface (API) Schema",
+    "description": "Response from logging a device health message to Notehub.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {},
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Empty Response",
+            "description": "Successful response with no content.",
+            "json": "{}"
+        }
+    ]
 }

--- a/tests/test_hub_log_req.py
+++ b/tests/test_hub_log_req.py
@@ -1,0 +1,222 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "hub.log.req.notecard.api.json"
+
+def test_valid_req_with_text(schema):
+    """Tests a minimal valid request with text."""
+    instance = {"req": "hub.log", "text": "System status"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_with_text(schema):
+    """Tests a minimal valid command with text."""
+    instance = {"cmd": "hub.log", "text": "System status"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_only(schema):
+    """Tests valid request with only req field."""
+    instance = {"req": "hub.log"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_only(schema):
+    """Tests valid command with only cmd field."""
+    instance = {"cmd": "hub.log"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_all_fields(schema):
+    """Tests valid request with all fields."""
+    instance = {
+        "req": "hub.log",
+        "text": "something is wrong!",
+        "alert": True,
+        "sync": True
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_alert_false(schema):
+    """Tests valid request with alert false."""
+    instance = {"req": "hub.log", "text": "System normal", "alert": False}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_sync_false(schema):
+    """Tests valid request with sync false."""
+    instance = {"req": "hub.log", "text": "System normal", "sync": False}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_text_only(schema):
+    """Tests valid request with only text parameter."""
+    instance = {"req": "hub.log", "text": "Just logging something"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_alert_only(schema):
+    """Tests valid request with only alert parameter."""
+    instance = {"req": "hub.log", "alert": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_sync_only(schema):
+    """Tests valid request with only sync parameter."""
+    instance = {"req": "hub.log", "sync": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_empty_text(schema):
+    """Tests valid request with empty text."""
+    instance = {"req": "hub.log", "text": ""}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_long_text(schema):
+    """Tests valid request with long text."""
+    long_text = "A" * 1000
+    instance = {"req": "hub.log", "text": long_text}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"text": "some text"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {"req": "hub.log", "cmd": "hub.log", "text": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is valid under each of" in str(excinfo.value)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {"req": "wrong.api", "text": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.log' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {"cmd": "wrong.api", "text": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.log' was expected" in str(excinfo.value)
+
+def test_text_invalid_type(schema):
+    """Tests invalid type for text."""
+    instance = {"req": "hub.log", "text": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_text_invalid_boolean(schema):
+    """Tests invalid boolean type for text."""
+    instance = {"req": "hub.log", "text": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'string'" in str(excinfo.value)
+
+def test_text_invalid_array(schema):
+    """Tests invalid array type for text."""
+    instance = {"req": "hub.log", "text": ["message"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_alert_invalid_type(schema):
+    """Tests invalid type for alert."""
+    instance = {"req": "hub.log", "alert": "true"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_alert_invalid_integer(schema):
+    """Tests invalid integer type for alert."""
+    instance = {"req": "hub.log", "alert": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_sync_invalid_type(schema):
+    """Tests invalid type for sync."""
+    instance = {"req": "hub.log", "sync": "false"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'false' is not of type 'boolean'" in str(excinfo.value)
+
+def test_sync_invalid_integer(schema):
+    """Tests invalid integer type for sync."""
+    instance = {"req": "hub.log", "sync": 0}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "0 is not of type 'boolean'" in str(excinfo.value)
+
+def test_req_invalid_type(schema):
+    """Tests invalid type for req."""
+    instance = {"req": 123, "text": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.log' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_type(schema):
+    """Tests invalid type for cmd."""
+    instance = {"cmd": ["hub.log"], "text": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.log' was expected" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with an additional property."""
+    instance = {"req": "hub.log", "text": "test", "extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_with_cmd(schema):
+    """Tests invalid command with an additional property."""
+    instance = {"cmd": "hub.log", "text": "test", "invalid": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {"req": "hub.log", "text": "test", "extra1": 123, "extra2": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_valid_field_combinations(schema):
+    """Tests valid requests with various field combinations."""
+    combinations = [
+        {"req": "hub.log", "text": "message", "alert": True},
+        {"req": "hub.log", "text": "message", "sync": True},
+        {"req": "hub.log", "alert": False, "sync": False},
+        {"cmd": "hub.log", "text": "message", "alert": True, "sync": True},
+        {"cmd": "hub.log", "alert": True},
+        {"cmd": "hub.log", "sync": False}
+    ]
+    
+    for combo in combinations:
+        jsonschema.validate(instance=combo, schema=schema)
+
+def test_all_parameters_optional(schema):
+    """Tests that all parameters except req/cmd are optional."""
+    # Test individual optional parameters
+    optional_params = [
+        {"req": "hub.log", "text": "message"},
+        {"req": "hub.log", "alert": True},
+        {"req": "hub.log", "sync": False}
+    ]
+    
+    for param_dict in optional_params:
+        jsonschema.validate(instance=param_dict, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_hub_log_rsp.py
+++ b/tests/test_hub_log_rsp.py
@@ -1,0 +1,120 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "hub.log.rsp.notecard.api.json"
+
+def test_minimal_valid_rsp(schema):
+    """Tests a minimal valid response (empty object)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_empty_response_object(schema):
+    """Tests that empty response object is valid."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with an additional property."""
+    instance = {"extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"status": "ok"},
+        {"message": "success"},
+        {"time": 1234567890},
+        {"version": "1.0"},
+        {"result": {}},
+        {"error": "none"},
+        {"data": "logged"},
+        {"success": True}
+    ]
+    
+    for field_dict in invalid_fields:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests that multiple additional properties are not allowed."""
+    instance = {"status": "ok", "message": "logged"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = [
+        "string",
+        123,
+        True,
+        False,
+        ["array"],
+        None
+    ]
+    
+    for invalid_instance in invalid_types:
+        if invalid_instance is None:
+            continue  # Skip None as it's handled differently
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+        # The error message will vary based on type, just ensure validation fails
+
+def test_response_is_object_type(schema):
+    """Tests that response schema requires object type."""
+    # String should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance="not an object", schema=schema)
+    
+    # Number should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=42, schema=schema)
+    
+    # Array should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=[], schema=schema)
+    
+    # Boolean should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=True, schema=schema)
+
+def test_no_properties_defined(schema):
+    """Tests that the schema defines no properties."""
+    # Verify schema has empty properties
+    assert schema.get("properties") == {}
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    # Verify schema has additionalProperties: false
+    assert schema.get("additionalProperties") is False
+
+def test_strict_validation(schema):
+    """Tests that schema enforces strict validation."""
+    # Any property should be rejected
+    properties_to_test = [
+        "device", "product", "status", "error", "message", "time",
+        "result", "data", "success", "code", "info", "warning"
+    ]
+    
+    for prop in properties_to_test:
+        instance = {prop: "test"}
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Enhanced `hub.log.req.notecard.api.json` to v0.2.1 standards with proper field hierarchy and exact API reference descriptions
- Enhanced `hub.log.rsp.notecard.api.json` to v0.2.1 standards with strict validation for empty response
- Added comprehensive test coverage with 42 test cases covering all validation scenarios
- Updated all field descriptions to match the official API reference documentation exactly

## Changes
- **Request Schema**: Updated to v0.2.1 with oneOf validation for req/cmd patterns, proper field ordering, and three optional parameters (text, alert, sync)
- **Response Schema**: Updated to v0.2.1 with strict validation for empty response object
- **Test Coverage**: 31 request tests + 11 response tests covering all field types, validation rules, and edge cases
- **SKU Compatibility**: Support for CELL, CELL+WIFI, WIFI as specified in API reference
- **API Compliance**: Field descriptions match API reference exactly with proper markdown formatting

## Key Features
- **Health Logging**: Supports device health messages sent to Notehub via _health_host.qo Notefile
- **Alert Flag**: Boolean flag for urgent messages (program logic convenience)
- **Sync Control**: Immediate sync capability that also removes Notecard from penalty boxes
- **Flexible Usage**: All parameters are optional except req/cmd

## Test Results
All 42 tests pass successfully:
- Request schema validation with req/cmd patterns and optional parameters
- Response schema validation for empty object with strict additionalProperties enforcement
- Type validation and constraint enforcement for all fields
- Sample JSON validation from schema definitions

🤖 Generated with [Claude Code](https://claude.ai/code)