### PR TITLE
feat: update hub.signal schemas to v0.2.1 with comprehensive test coverage

### DIFF
--- a/hub.signal.req.notecard.api.json
+++ b/hub.signal.req.notecard.api.json
@@ -46,7 +46,7 @@
     "additionalProperties": false,
     "annotations": [
         {
-            "title": "note",
+            "title": "warning",
             "description": "A Notecard must be in continuous mode and have its `sync` argument set to `true` to receive signals."
         }
     ],

--- a/hub.signal.req.notecard.api.json
+++ b/hub.signal.req.notecard.api.json
@@ -48,6 +48,10 @@
         {
             "title": "warning",
             "description": "A Notecard must be in continuous mode and have its `sync` argument set to `true` to receive signals."
+        },
+        {
+            "title": "note",
+            "description": "See our guide to [Using Inbound Signals](/guides-and-tutorials/notecard-guides/minimizing-latency#using-inbound-signals) for more information on how to set up a host microcontroller or single-board computer to receive inbound signals."
         }
     ],
     "samples": [

--- a/hub.signal.req.notecard.api.json
+++ b/hub.signal.req.notecard.api.json
@@ -4,11 +4,10 @@
     "title": "hub.signal Request Application Programming Interface (API) Schema",
     "description": "Receive a signal (a near-real-time note) from Notehub.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
-        "seconds": {
-            "description": "Number of seconds to wait for a signal",
-            "type": "integer"
-        },
         "cmd": {
             "description": "Command for the Notecard (no response)",
             "const": "hub.signal"
@@ -16,6 +15,10 @@
         "req": {
             "description": "Request for the Notecard (expects response)",
             "const": "hub.signal"
+        },
+        "seconds": {
+            "description": "The number of seconds to wait before timing out the request.",
+            "type": "integer"
         }
     },
     "oneOf": [
@@ -41,6 +44,22 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "annotations": [
+        {
+            "title": "note",
+            "description": "A Notecard must be in continuous mode and have its `sync` argument set to `true` to receive signals."
+        }
+    ],
+    "samples": [
+        {
+            "title": "Receive a Signal",
+            "description": "Check for an inbound signal from Notehub.",
+            "json": "{\"req\": \"hub.signal\"}"
+        },
+        {
+            "title": "Receive Signal with Timeout",
+            "description": "Check for an inbound signal with custom timeout.",
+            "json": "{\"req\": \"hub.signal\", \"seconds\": 30}"
+        }
+    ]
 }

--- a/hub.signal.rsp.notecard.api.json
+++ b/hub.signal.rsp.notecard.api.json
@@ -2,24 +2,41 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/hub.signal.rsp.notecard.api.json",
     "title": "hub.signal Response Application Programming Interface (API) Schema",
+    "description": "Response containing a received signal from Notehub.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "body": {
-            "description": "Signal information",
+            "description": "The JSON body of a received signal.",
             "type": "object"
         },
         "connected": {
-            "description": "Whether the Notecard is connected to the network",
+            "description": "`true` if the Notecard is connected to Notehub.",
             "type": "boolean"
         },
         "signals": {
-            "description": "Array of signal information",
-            "type": "array",
-            "items": {
-                "type": "object"
-            }
+            "description": "The number of queued signals remaining.",
+            "type": "integer"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Signal Received",
+            "description": "Response when a signal is received from Notehub.",
+            "json": "{\"body\": {\"example-key\": \"example-value\"}, \"connected\": true}"
+        },
+        {
+            "title": "No Signals Available",
+            "description": "Response when no signals are available.",
+            "json": "{\"connected\": true, \"signals\": 0}"
+        },
+        {
+            "title": "Multiple Signals Queued",
+            "description": "Response with remaining queued signals.",
+            "json": "{\"body\": {\"data\": \"signal-data\"}, \"connected\": true, \"signals\": 3}"
+        }
+    ]
 }

--- a/tests/test_hub_signal_req.py
+++ b/tests/test_hub_signal_req.py
@@ -1,0 +1,215 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "hub.signal.req.notecard.api.json"
+
+def test_valid_req_only(schema):
+    """Tests a minimal valid request with only req."""
+    instance = {"req": "hub.signal"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_only(schema):
+    """Tests a minimal valid command with only cmd."""
+    instance = {"cmd": "hub.signal"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_seconds(schema):
+    """Tests valid request with seconds parameter."""
+    instance = {"req": "hub.signal", "seconds": 30}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_with_seconds(schema):
+    """Tests valid command with seconds parameter."""
+    instance = {"cmd": "hub.signal", "seconds": 60}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_seconds_zero(schema):
+    """Tests valid request with seconds set to zero."""
+    instance = {"req": "hub.signal", "seconds": 0}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_seconds_large_value(schema):
+    """Tests valid request with large seconds value."""
+    instance = {"req": "hub.signal", "seconds": 300}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_seconds_small_value(schema):
+    """Tests valid request with small seconds value."""
+    instance = {"req": "hub.signal", "seconds": 1}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"seconds": 30}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {"req": "hub.signal", "cmd": "hub.signal"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is valid under each of" in str(excinfo.value)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {"req": "wrong.api"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.signal' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {"cmd": "wrong.api"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.signal' was expected" in str(excinfo.value)
+
+def test_seconds_invalid_type_string(schema):
+    """Tests invalid string type for seconds."""
+    instance = {"req": "hub.signal", "seconds": "30"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'30' is not of type 'integer'" in str(excinfo.value)
+
+def test_seconds_invalid_type_float(schema):
+    """Tests invalid float type for seconds."""
+    instance = {"req": "hub.signal", "seconds": 30.5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "30.5 is not of type 'integer'" in str(excinfo.value)
+
+def test_seconds_invalid_type_boolean(schema):
+    """Tests invalid boolean type for seconds."""
+    instance = {"req": "hub.signal", "seconds": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'integer'" in str(excinfo.value)
+
+def test_seconds_invalid_type_array(schema):
+    """Tests invalid array type for seconds."""
+    instance = {"req": "hub.signal", "seconds": [30]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_seconds_invalid_type_object(schema):
+    """Tests invalid object type for seconds."""
+    instance = {"req": "hub.signal", "seconds": {"value": 30}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_req_invalid_type_integer(schema):
+    """Tests invalid integer type for req."""
+    instance = {"req": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.signal' was expected" in str(excinfo.value)
+
+def test_req_invalid_type_boolean(schema):
+    """Tests invalid boolean type for req."""
+    instance = {"req": False}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.signal' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_type_array(schema):
+    """Tests invalid array type for cmd."""
+    instance = {"cmd": ["hub.signal"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.signal' was expected" in str(excinfo.value)
+
+def test_cmd_invalid_type_object(schema):
+    """Tests invalid object type for cmd."""
+    instance = {"cmd": {"api": "hub.signal"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'hub.signal' was expected" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with additional property."""
+    instance = {"req": "hub.signal", "extra": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_with_cmd(schema):
+    """Tests invalid command with additional property."""
+    instance = {"cmd": "hub.signal", "timeout": 30}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {"req": "hub.signal", "extra1": 123, "extra2": "value"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"body": {}},
+        {"signal": "data"},
+        {"timeout": 30},
+        {"wait": True},
+        {"mode": "sync"},
+        {"continuous": True}
+    ]
+    
+    for field_dict in invalid_fields:
+        field_dict["req"] = "hub.signal"
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_seconds_optional_parameter(schema):
+    """Tests that seconds parameter is optional."""
+    # Test with and without seconds parameter
+    instances = [
+        {"req": "hub.signal"},
+        {"req": "hub.signal", "seconds": 30},
+        {"cmd": "hub.signal"},
+        {"cmd": "hub.signal", "seconds": 60}
+    ]
+    
+    for instance in instances:
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_seconds_negative_value(schema):
+    """Tests that negative seconds values are allowed."""
+    # JSON Schema doesn't restrict negative values by default
+    instance = {"req": "hub.signal", "seconds": -1}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_seconds_extreme_values(schema):
+    """Tests seconds with extreme integer values."""
+    extreme_values = [0, 1, 86400, 999999]  # 0 seconds to very large values
+    for value in extreme_values:
+        instance = {"req": "hub.signal", "seconds": value}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_empty_request_invalid(schema):
+    """Tests that completely empty request is invalid."""
+    instance = {}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_hub_signal_rsp.py
+++ b/tests/test_hub_signal_rsp.py
@@ -1,0 +1,282 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "hub.signal.rsp.notecard.api.json"
+
+def test_minimal_valid_rsp(schema):
+    """Tests a minimal valid response (empty object)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_body_only(schema):
+    """Tests valid response with only body field."""
+    instance = {"body": {"example-key": "example-value"}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_connected_only(schema):
+    """Tests valid response with only connected field."""
+    instance = {"connected": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_signals_only(schema):
+    """Tests valid response with only signals field."""
+    instance = {"signals": 3}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_all_fields(schema):
+    """Tests valid response with all fields."""
+    instance = {
+        "body": {"data": "signal-content", "timestamp": 1234567890},
+        "connected": True,
+        "signals": 2
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_body_empty_object(schema):
+    """Tests valid response with empty body object."""
+    instance = {"body": {}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_body_complex_object(schema):
+    """Tests valid response with complex body object."""
+    complex_body = {
+        "sensor_data": {
+            "temperature": 23.5,
+            "humidity": 65.2
+        },
+        "metadata": {
+            "device_id": "sensor-001",
+            "timestamp": "2024-01-15T10:30:00Z"
+        },
+        "alerts": ["high_temp", "low_battery"]
+    }
+    instance = {"body": complex_body, "connected": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_connected_true(schema):
+    """Tests valid response with connected true."""
+    instance = {"connected": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_connected_false(schema):
+    """Tests valid response with connected false."""
+    instance = {"connected": False}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_signals_zero(schema):
+    """Tests valid response with signals zero."""
+    instance = {"signals": 0}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_signals_positive(schema):
+    """Tests valid response with positive signals count."""
+    valid_counts = [1, 5, 10, 100]
+    for count in valid_counts:
+        instance = {"signals": count}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_partial_combinations(schema):
+    """Tests valid responses with various field combinations."""
+    combinations = [
+        {"body": {"key": "value"}, "connected": True},
+        {"body": {"data": 123}, "signals": 2},
+        {"connected": False, "signals": 0},
+        {"body": {"alert": "message"}},
+        {"connected": True, "signals": 1}
+    ]
+    
+    for combo in combinations:
+        jsonschema.validate(instance=combo, schema=schema)
+
+def test_all_fields_optional(schema):
+    """Tests that all fields are optional."""
+    # Test each field individually and empty object
+    individual_fields = [
+        {},
+        {"body": {"test": "value"}},
+        {"connected": True},
+        {"signals": 5}
+    ]
+    
+    for field_dict in individual_fields:
+        jsonschema.validate(instance=field_dict, schema=schema)
+
+def test_body_invalid_type_string(schema):
+    """Tests invalid string type for body."""
+    instance = {"body": "not an object"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not an object' is not of type 'object'" in str(excinfo.value)
+
+def test_body_invalid_type_array(schema):
+    """Tests invalid array type for body."""
+    instance = {"body": ["array", "not", "object"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'object'" in str(excinfo.value)
+
+def test_body_invalid_type_integer(schema):
+    """Tests invalid integer type for body."""
+    instance = {"body": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'object'" in str(excinfo.value)
+
+def test_body_invalid_type_boolean(schema):
+    """Tests invalid boolean type for body."""
+    instance = {"body": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'object'" in str(excinfo.value)
+
+def test_connected_invalid_type_string(schema):
+    """Tests invalid string type for connected."""
+    instance = {"connected": "true"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_connected_invalid_type_integer(schema):
+    """Tests invalid integer type for connected."""
+    instance = {"connected": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_connected_invalid_type_object(schema):
+    """Tests invalid object type for connected."""
+    instance = {"connected": {"status": True}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'boolean'" in str(excinfo.value)
+
+def test_signals_invalid_type_string(schema):
+    """Tests invalid string type for signals."""
+    instance = {"signals": "5"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'5' is not of type 'integer'" in str(excinfo.value)
+
+def test_signals_invalid_type_float(schema):
+    """Tests invalid float type for signals."""
+    instance = {"signals": 3.5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "3.5 is not of type 'integer'" in str(excinfo.value)
+
+def test_signals_invalid_type_boolean(schema):
+    """Tests invalid boolean type for signals."""
+    instance = {"signals": False}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "False is not of type 'integer'" in str(excinfo.value)
+
+def test_signals_invalid_type_array(schema):
+    """Tests invalid array type for signals."""
+    instance = {"signals": [1, 2, 3]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_signals_negative_value(schema):
+    """Tests that negative signals values are allowed."""
+    # JSON Schema doesn't restrict negative values by default
+    instance = {"signals": -1}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with additional property."""
+    instance = {"body": {"key": "value"}, "extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"status": "ok"},
+        {"message": "received"},
+        {"time": 1234567890},
+        {"version": "1.0"},
+        {"result": {}},
+        {"error": "none"},
+        {"data": "signal"},
+        {"success": True},
+        {"signal_id": "abc123"}
+    ]
+    
+    for field_dict in invalid_fields:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests that multiple additional properties are not allowed."""
+    instance = {"body": {}, "status": "ok", "message": "received"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = [
+        "string",
+        123,
+        True,
+        False,
+        ["array"],
+        None
+    ]
+    
+    for invalid_instance in invalid_types:
+        if invalid_instance is None:
+            continue  # Skip None as it's handled differently
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+        # The error message will vary based on type, just ensure validation fails
+
+def test_response_is_object_type(schema):
+    """Tests that response schema requires object type."""
+    # String should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance="not an object", schema=schema)
+    
+    # Number should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=42, schema=schema)
+    
+    # Array should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=[], schema=schema)
+    
+    # Boolean should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=True, schema=schema)
+
+def test_strict_validation(schema):
+    """Tests that schema enforces strict validation."""
+    # Any property not in the defined schema should be rejected
+    properties_to_test = [
+        "device", "product", "status", "error", "message", "time",
+        "result", "data", "success", "code", "info", "warning", "signal_id"
+    ]
+    
+    for prop in properties_to_test:
+        instance = {prop: "test"}
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Enhanced `hub.signal.req.notecard.api.json` to v0.2.1 standards with proper field hierarchy and timeout support
- Enhanced `hub.signal.rsp.notecard.api.json` to v0.2.1 standards with correct field types matching API specification
- Added comprehensive test coverage with 61 test cases covering all validation scenarios and edge cases
- Updated all field descriptions to match the official API reference documentation exactly with proper markdown formatting

## Changes
- **Request Schema**: Updated to v0.2.1 with oneOf validation for req/cmd patterns and optional `seconds` timeout parameter
- **Response Schema**: Updated to v0.2.1 with correct field types - `signals` is now integer (count) instead of array, matching API specification
- **Test Coverage**: 29 request tests + 32 response tests covering all field types, validation rules, and edge cases
- **SKU Compatibility**: Support for CELL, CELL+WIFI, WIFI (signals not supported on LoRa devices)
- **API Compliance**: All field descriptions match API reference exactly with proper markdown formatting

## Key Features Supported
- **Signal Reception**: Near-real-time signal reception from Notehub in FIFO order
- **Timeout Control**: Optional `seconds` parameter for request timeout configuration
- **Connection Status**: `connected` boolean indicating Notecard's Notehub connection status
- **Queue Information**: `signals` integer count of remaining queued signals
- **Signal Content**: `body` JSON object containing the actual signal payload
- **Prerequisites**: Requires continuous mode with sync=true for signal reception

## API Specification Corrections
- **Fixed `signals` field type**: Changed from array to integer to match API documentation (represents count of remaining signals)
- **All response fields are optional**: Reflects actual API behavior where fields may not be present
- **Proper field descriptions**: Exact matches with API reference documentation including backticks and formatting

## Test Results
All 61 tests pass successfully:
- Request schema validation with req/cmd patterns and optional seconds parameter
- Response schema validation for all 3 optional fields with correct types
- Type validation and constraint enforcement for all fields and edge cases
- Sample JSON validation from schema definitions
- Comprehensive coverage of valid/invalid scenarios and boundary conditions

🤖 Generated with [Claude Code](https://claude.ai/code)