### PR TITLE
feat: enhance note.changes schemas to v0.2.1 with complete API alignment

### DIFF
--- a/note.changes.req.notecard.api.json
+++ b/note.changes.req.notecard.api.json
@@ -4,15 +4,10 @@
     "title": "note.changes Request Application Programming Interface (API) Schema",
     "description": "Used to incrementally retrieve changes within a specific Notefile.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
-        "file": {
-            "description": "Name of the notefile to check for changes",
-            "type": "string"
-        },
-        "tracker": {
-            "description": "Tracker ID for monitoring changes",
-            "type": "string"
-        },
         "cmd": {
             "description": "Command for the Notecard (no response)",
             "const": "note.changes"
@@ -20,8 +15,42 @@
         "req": {
             "description": "Request for the Notecard (expects response)",
             "const": "note.changes"
+        },
+        "file": {
+            "description": "The Notefile ID.",
+            "type": "string"
+        },
+        "tracker": {
+            "description": "The change tracker ID. This value is developer-defined and can be used across both the `note.changes` and `file.changes` requests.",
+            "type": "string"
+        },
+        "max": {
+            "description": "The maximum number of Notes to return in the request.",
+            "type": "integer",
+            "minimum": 1
+        },
+        "start": {
+            "description": "`true` to reset the tracker to the beginning.",
+            "type": "boolean"
+        },
+        "stop": {
+            "description": "`true` to delete the tracker.",
+            "type": "boolean"
+        },
+        "deleted": {
+            "description": "`true` to return deleted Notes with this request. Deleted notes are only persisted in a database notefile (`.db/.dbs`) between the time of note deletion on the Notecard and the time that a sync with notehub takes place. As such, this boolean will have no effect after a sync or on queue notefiles (`.q*`).",
+            "type": "boolean"
+        },
+        "delete": {
+            "description": "`true` to delete the Notes returned by the request.",
+            "type": "boolean"
+        },
+        "reset": {
+            "description": "`true` to reset a change tracker.",
+            "type": "boolean"
         }
     },
+    "required": ["file"],
     "oneOf": [
         {
             "required": [
@@ -45,6 +74,36 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Peek at Changes",
+            "description": "Check changes in a Notefile with tracker starting from beginning.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"my-settings.db\", \"tracker\": \"inbound-tracker\", \"start\": true}"
+        },
+        {
+            "title": "Pop Changes with Limit",
+            "description": "Retrieve and delete up to 2 changes from a Notefile.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"my-settings.db\", \"tracker\": \"inbound-tracker\", \"start\": true, \"delete\": true, \"max\": 2}"
+        },
+        {
+            "title": "Basic File Changes",
+            "description": "Get changes from a Notefile without tracker.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"data.db\"}"
+        },
+        {
+            "title": "Reset Tracker",
+            "description": "Reset a change tracker to start from beginning.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"events.db\", \"tracker\": \"event-tracker\", \"reset\": true}"
+        },
+        {
+            "title": "Include Deleted Notes",
+            "description": "Retrieve changes including deleted notes from database.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"config.db\", \"tracker\": \"config-tracker\", \"deleted\": true}"
+        },
+        {
+            "title": "Stop Tracker",
+            "description": "Delete a change tracker when finished.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"logs.db\", \"tracker\": \"log-tracker\", \"stop\": true}"
+        }
+    ]
 }

--- a/note.changes.rsp.notecard.api.json
+++ b/note.changes.rsp.notecard.api.json
@@ -2,24 +2,56 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/note.changes.rsp.notecard.api.json",
     "title": "note.changes Response Application Programming Interface (API) Schema",
+    "description": "Response containing incremental changes from a specific Notefile.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
+        "total": {
+            "description": "The total number of Notes in the Notefile.",
+            "type": "integer"
+        },
         "changes": {
-            "description": "Whether there are changes",
-            "type": "boolean"
+            "description": "The number of pending changes in the Notefile.",
+            "type": "integer"
         },
         "notes": {
-            "description": "Array of note IDs that have changed",
-            "type": "array",
-            "items": {
-                "type": "string"
+            "description": "An object with a key for each Note (the Note ID in a DB Notefile or an internally-generated ID for `.qo` and `.qi` Notes) and value object with the `body` of each Note and the `time` the Note was added.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "body": {
+                        "description": "The body content of the Note.",
+                        "type": "object"
+                    },
+                    "time": {
+                        "description": "The time the Note was added (Unix timestamp).",
+                        "type": "integer"
+                    }
+                },
+                "required": ["body", "time"],
+                "additionalProperties": false
             }
-        },
-        "tracker": {
-            "description": "Tracker ID for monitoring changes",
-            "type": "string"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Changes Response with Notes",
+            "description": "Response showing changes with note details and timestamps.",
+            "json": "{\"changes\": 4, \"total\": 4, \"notes\": {\"setting-one\": {\"body\": {\"foo\": \"bar\"}, \"time\": 1598918235}, \"setting-two\": {\"body\": {\"foo\": \"bat\"}, \"time\": 1598918245}, \"setting-three\": {\"body\": {\"foo\": \"baz\"}, \"time\": 1598918225}, \"setting-four\": {\"body\": {\"foo\": \"foo\"}, \"time\": 1598910532}}}"
+        },
+        {
+            "title": "No Changes Response",
+            "description": "Response when no changes are available.",
+            "json": "{\"changes\": 0, \"total\": 10, \"notes\": {}}"
+        },
+        {
+            "title": "Single Change Response", 
+            "description": "Response with a single note change.",
+            "json": "{\"changes\": 1, \"total\": 5, \"notes\": {\"config-update\": {\"body\": {\"brightness\": 75, \"volume\": 50}, \"time\": 1609459200}}}"
+        }
+    ]
 }

--- a/tests/test_note_changes_req.py
+++ b/tests/test_note_changes_req.py
@@ -1,0 +1,404 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "note.changes.req.notecard.api.json"
+
+def test_valid_req_only_with_file(schema):
+    """Tests a minimal valid request with only req and file."""
+    instance = {"req": "note.changes", "file": "data.db"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_only_with_file(schema):
+    """Tests a minimal valid command with only cmd and file."""
+    instance = {"cmd": "note.changes", "file": "settings.db"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_tracker(schema):
+    """Tests valid request with tracker parameter."""
+    instance = {"req": "note.changes", "file": "my-settings.db", "tracker": "inbound-tracker"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_max(schema):
+    """Tests valid request with max parameter."""
+    instance = {"req": "note.changes", "file": "data.db", "max": 5}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_start(schema):
+    """Tests valid request with start parameter."""
+    instance = {"req": "note.changes", "file": "events.db", "tracker": "event-tracker", "start": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_stop(schema):
+    """Tests valid request with stop parameter."""
+    instance = {"req": "note.changes", "file": "logs.db", "tracker": "log-tracker", "stop": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_deleted(schema):
+    """Tests valid request with deleted parameter."""
+    instance = {"req": "note.changes", "file": "config.db", "tracker": "config-tracker", "deleted": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_delete(schema):
+    """Tests valid request with delete parameter."""
+    instance = {"req": "note.changes", "file": "temp.db", "delete": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_reset(schema):
+    """Tests valid request with reset parameter."""
+    instance = {"req": "note.changes", "file": "status.db", "tracker": "status-tracker", "reset": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_peek_example(schema):
+    """Tests the peek example from API reference."""
+    instance = {
+        "req": "note.changes",
+        "file": "my-settings.db",
+        "tracker": "inbound-tracker", 
+        "start": True
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_pop_example(schema):
+    """Tests the pop example from API reference."""
+    instance = {
+        "req": "note.changes",
+        "file": "my-settings.db",
+        "tracker": "inbound-tracker",
+        "start": True,
+        "delete": True,
+        "max": 2
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_all_parameters(schema):
+    """Tests valid request with most parameters."""
+    instance = {
+        "req": "note.changes",
+        "file": "comprehensive.db",
+        "tracker": "comprehensive-tracker",
+        "max": 10,
+        "start": False,
+        "deleted": True,
+        "delete": False
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_variations(schema):
+    """Tests valid command variations."""
+    instance = {"cmd": "note.changes", "file": "cmd-test.db", "tracker": "cmd-tracker"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_boolean_combinations(schema):
+    """Tests various boolean parameter combinations."""
+    combinations = [
+        {"req": "note.changes", "file": "test1.db", "start": True, "deleted": True},
+        {"req": "note.changes", "file": "test2.db", "stop": True, "delete": False},
+        {"req": "note.changes", "file": "test3.db", "reset": True, "start": False},
+        {"req": "note.changes", "file": "test4.db", "deleted": False, "delete": True}
+    ]
+    
+    for combo in combinations:
+        jsonschema.validate(instance=combo, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"file": "data.db"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {"req": "note.changes", "cmd": "note.changes", "file": "data.db"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is valid under each of" in str(excinfo.value)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {"req": "wrong.api", "file": "data.db"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'note.changes' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {"cmd": "wrong.api", "file": "data.db"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'note.changes' was expected" in str(excinfo.value)
+
+def test_invalid_missing_file(schema):
+    """Tests invalid request without required file parameter."""
+    instance = {"req": "note.changes", "tracker": "test-tracker"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file' is a required property" in str(excinfo.value)
+
+def test_file_invalid_type_integer(schema):
+    """Tests invalid integer type for file."""
+    instance = {"req": "note.changes", "file": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_file_invalid_type_boolean(schema):
+    """Tests invalid boolean type for file."""
+    instance = {"req": "note.changes", "file": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'string'" in str(excinfo.value)
+
+def test_file_invalid_type_array(schema):
+    """Tests invalid array type for file."""
+    instance = {"req": "note.changes", "file": ["data.db"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_tracker_invalid_type_integer(schema):
+    """Tests invalid integer type for tracker."""
+    instance = {"req": "note.changes", "file": "data.db", "tracker": 456}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "456 is not of type 'string'" in str(excinfo.value)
+
+def test_tracker_invalid_type_boolean(schema):
+    """Tests invalid boolean type for tracker."""
+    instance = {"req": "note.changes", "file": "data.db", "tracker": False}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "False is not of type 'string'" in str(excinfo.value)
+
+def test_max_invalid_type_string(schema):
+    """Tests invalid string type for max."""
+    instance = {"req": "note.changes", "file": "data.db", "max": "10"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'10' is not of type 'integer'" in str(excinfo.value)
+
+def test_max_invalid_type_boolean(schema):
+    """Tests invalid boolean type for max."""
+    instance = {"req": "note.changes", "file": "data.db", "max": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'integer'" in str(excinfo.value)
+
+def test_max_invalid_minimum_zero(schema):
+    """Tests invalid zero value for max (minimum is 1)."""
+    instance = {"req": "note.changes", "file": "data.db", "max": 0}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "0 is less than the minimum of 1" in str(excinfo.value)
+
+def test_max_invalid_minimum_negative(schema):
+    """Tests invalid negative value for max (minimum is 1)."""
+    instance = {"req": "note.changes", "file": "data.db", "max": -5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "-5 is less than the minimum of 1" in str(excinfo.value)
+
+def test_max_valid_minimum_one(schema):
+    """Tests valid minimum value for max (1)."""
+    instance = {"req": "note.changes", "file": "data.db", "max": 1}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_max_valid_large_value(schema):
+    """Tests valid large value for max."""
+    instance = {"req": "note.changes", "file": "data.db", "max": 1000}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_start_invalid_type_string(schema):
+    """Tests invalid string type for start."""
+    instance = {"req": "note.changes", "file": "data.db", "start": "true"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_start_invalid_type_integer(schema):
+    """Tests invalid integer type for start."""
+    instance = {"req": "note.changes", "file": "data.db", "start": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_stop_invalid_type_string(schema):
+    """Tests invalid string type for stop."""
+    instance = {"req": "note.changes", "file": "data.db", "stop": "false"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'false' is not of type 'boolean'" in str(excinfo.value)
+
+def test_stop_invalid_type_integer(schema):
+    """Tests invalid integer type for stop."""
+    instance = {"req": "note.changes", "file": "data.db", "stop": 0}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "0 is not of type 'boolean'" in str(excinfo.value)
+
+def test_deleted_invalid_type_string(schema):
+    """Tests invalid string type for deleted."""
+    instance = {"req": "note.changes", "file": "data.db", "deleted": "true"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_deleted_invalid_type_integer(schema):
+    """Tests invalid integer type for deleted."""
+    instance = {"req": "note.changes", "file": "data.db", "deleted": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_delete_invalid_type_string(schema):
+    """Tests invalid string type for delete."""
+    instance = {"req": "note.changes", "file": "data.db", "delete": "false"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'false' is not of type 'boolean'" in str(excinfo.value)
+
+def test_delete_invalid_type_integer(schema):
+    """Tests invalid integer type for delete."""
+    instance = {"req": "note.changes", "file": "data.db", "delete": 0}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "0 is not of type 'boolean'" in str(excinfo.value)
+
+def test_reset_invalid_type_string(schema):
+    """Tests invalid string type for reset."""
+    instance = {"req": "note.changes", "file": "data.db", "reset": "true"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_reset_invalid_type_integer(schema):
+    """Tests invalid integer type for reset."""
+    instance = {"req": "note.changes", "file": "data.db", "reset": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with additional property."""
+    instance = {"req": "note.changes", "file": "data.db", "extra": "not allowed"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_with_cmd(schema):
+    """Tests invalid command with additional property."""
+    instance = {"cmd": "note.changes", "file": "data.db", "unknown": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {"req": "note.changes", "file": "data.db", "extra1": 123, "extra2": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"status": "ok"},
+        {"result": "success"},
+        {"error": "none"},
+        {"message": "retrieved"},
+        {"count": 5},
+        {"timestamp": 1640995200},
+        {"notes": []},
+        {"changes": 3}
+    ]
+    
+    for field_dict in invalid_fields:
+        field_dict["req"] = "note.changes"
+        field_dict["file"] = "test.db"
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_empty_object_invalid(schema):
+    """Tests that empty object is invalid."""
+    instance = {}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file' is a required property" in str(excinfo.value)
+
+def test_request_object_type(schema):
+    """Tests that request must be an object."""
+    invalid_types = [
+        "string",
+        123,
+        True,
+        False,
+        ["array"],
+        None
+    ]
+    
+    for invalid_instance in invalid_types:
+        if invalid_instance is None:
+            continue  # Skip None as it's handled differently
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+        # The error message will vary based on type, just ensure validation fails
+
+def test_tracker_operations(schema):
+    """Tests tracker-related operations."""
+    operations = [
+        {"req": "note.changes", "file": "data.db", "tracker": "tracker1", "start": True},
+        {"req": "note.changes", "file": "data.db", "tracker": "tracker2", "reset": True},
+        {"req": "note.changes", "file": "data.db", "tracker": "tracker3", "stop": True},
+        {"req": "note.changes", "file": "data.db", "tracker": "tracker4", "start": True, "delete": True}
+    ]
+    
+    for operation in operations:
+        jsonschema.validate(instance=operation, schema=schema)
+
+def test_file_parameter_required(schema):
+    """Tests that file parameter is always required."""
+    # Test with req but no file
+    instance = {"req": "note.changes", "tracker": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file' is a required property" in str(excinfo.value)
+    
+    # Test with cmd but no file
+    instance = {"cmd": "note.changes", "max": 5}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file' is a required property" in str(excinfo.value)
+
+def test_database_file_patterns(schema):
+    """Tests various database file naming patterns."""
+    valid_files = [
+        "settings.db",
+        "config.dbs", 
+        "events.dbx",
+        "data.qo",
+        "encrypted.qi",
+        "simple-name.db",
+        "complex_name_with_underscores.dbs",
+        "name-with-dashes.dbx",
+        "123numeric.db",
+        "CamelCase.db"
+    ]
+    
+    for filename in valid_files:
+        instance = {"req": "note.changes", "file": filename}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_note_changes_rsp.py
+++ b/tests/test_note_changes_rsp.py
@@ -1,0 +1,467 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "note.changes.rsp.notecard.api.json"
+
+def test_minimal_valid_rsp(schema):
+    """Tests a minimal valid response (empty object)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_total_field(schema):
+    """Tests valid total field."""
+    instance = {"total": 10}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_changes_field(schema):
+    """Tests valid changes field."""
+    instance = {"changes": 5}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_empty_notes_field(schema):
+    """Tests valid empty notes field."""
+    instance = {"notes": {}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_notes_with_single_entry(schema):
+    """Tests valid notes field with single entry."""
+    instance = {
+        "notes": {
+            "config-update": {
+                "body": {"brightness": 75, "volume": 50},
+                "time": 1609459200
+            }
+        }
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_notes_with_multiple_entries(schema):
+    """Tests valid notes field with multiple entries."""
+    instance = {
+        "notes": {
+            "setting-one": {"body": {"foo": "bar"}, "time": 1598918235},
+            "setting-two": {"body": {"foo": "bat"}, "time": 1598918245},
+            "setting-three": {"body": {"foo": "baz"}, "time": 1598918225}
+        }
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_complete_response(schema):
+    """Tests valid complete response with all fields."""
+    instance = {
+        "total": 4,
+        "changes": 4,
+        "notes": {
+            "setting-one": {"body": {"foo": "bar"}, "time": 1598918235},
+            "setting-two": {"body": {"foo": "bat"}, "time": 1598918245},
+            "setting-three": {"body": {"foo": "baz"}, "time": 1598918225},
+            "setting-four": {"body": {"foo": "foo"}, "time": 1598910532}
+        }
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_no_changes_response(schema):
+    """Tests valid response with no changes."""
+    instance = {
+        "changes": 0,
+        "total": 10,
+        "notes": {}
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_partial_response_total_only(schema):
+    """Tests valid response with only total field."""
+    instance = {"total": 25}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_partial_response_changes_only(schema):
+    """Tests valid response with only changes field."""
+    instance = {"changes": 3}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_partial_response_notes_only(schema):
+    """Tests valid response with only notes field."""
+    instance = {
+        "notes": {
+            "test-note": {"body": {"test": "value"}, "time": 1640995200}
+        }
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_total_invalid_type_string(schema):
+    """Tests invalid string type for total."""
+    instance = {"total": "10"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'10' is not of type 'integer'" in str(excinfo.value)
+
+def test_total_invalid_type_boolean(schema):
+    """Tests invalid boolean type for total."""
+    instance = {"total": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'integer'" in str(excinfo.value)
+
+def test_total_invalid_type_array(schema):
+    """Tests invalid array type for total."""
+    instance = {"total": [10]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_total_valid_zero(schema):
+    """Tests valid zero total."""
+    instance = {"total": 0}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_total_valid_negative(schema):
+    """Tests valid negative total (edge case)."""
+    instance = {"total": -1}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_changes_invalid_type_string(schema):
+    """Tests invalid string type for changes."""
+    instance = {"changes": "5"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'5' is not of type 'integer'" in str(excinfo.value)
+
+def test_changes_invalid_type_boolean(schema):
+    """Tests invalid boolean type for changes."""
+    instance = {"changes": False}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "False is not of type 'integer'" in str(excinfo.value)
+
+def test_changes_invalid_type_array(schema):
+    """Tests invalid array type for changes."""
+    instance = {"changes": [5]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_changes_valid_zero(schema):
+    """Tests valid zero changes."""
+    instance = {"changes": 0}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_changes_valid_negative(schema):
+    """Tests valid negative changes (edge case)."""
+    instance = {"changes": -1}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_notes_invalid_type_string(schema):
+    """Tests invalid string type for notes."""
+    instance = {"notes": "not an object"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'not an object' is not of type 'object'" in str(excinfo.value)
+
+def test_notes_invalid_type_array(schema):
+    """Tests invalid array type for notes."""
+    instance = {"notes": ["note1", "note2"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'object'" in str(excinfo.value)
+
+def test_notes_invalid_type_boolean(schema):
+    """Tests invalid boolean type for notes."""
+    instance = {"notes": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'object'" in str(excinfo.value)
+
+def test_note_entry_missing_body(schema):
+    """Tests invalid note entry missing required body field."""
+    instance = {
+        "notes": {
+            "invalid-note": {"time": 1609459200}
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'body' is a required property" in str(excinfo.value)
+
+def test_note_entry_missing_time(schema):
+    """Tests invalid note entry missing required time field."""
+    instance = {
+        "notes": {
+            "invalid-note": {"body": {"test": "value"}}
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'time' is a required property" in str(excinfo.value)
+
+def test_note_entry_body_invalid_type_string(schema):
+    """Tests invalid string type for note body."""
+    instance = {
+        "notes": {
+            "invalid-note": {"body": "should be object", "time": 1609459200}
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'should be object' is not of type 'object'" in str(excinfo.value)
+
+def test_note_entry_body_invalid_type_array(schema):
+    """Tests invalid array type for note body."""
+    instance = {
+        "notes": {
+            "invalid-note": {"body": ["array", "not", "object"], "time": 1609459200}
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'object'" in str(excinfo.value)
+
+def test_note_entry_time_invalid_type_string(schema):
+    """Tests invalid string type for note time."""
+    instance = {
+        "notes": {
+            "invalid-note": {"body": {"test": "value"}, "time": "1609459200"}
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'1609459200' is not of type 'integer'" in str(excinfo.value)
+
+def test_note_entry_time_invalid_type_boolean(schema):
+    """Tests invalid boolean type for note time."""
+    instance = {
+        "notes": {
+            "invalid-note": {"body": {"test": "value"}, "time": True}
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'integer'" in str(excinfo.value)
+
+def test_note_entry_additional_properties_invalid(schema):
+    """Tests invalid additional properties in note entries."""
+    instance = {
+        "notes": {
+            "invalid-note": {
+                "body": {"test": "value"},
+                "time": 1609459200,
+                "extra": "not allowed"
+            }
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_note_entry_valid_empty_body(schema):
+    """Tests valid note entry with empty body object."""
+    instance = {
+        "notes": {
+            "empty-body-note": {"body": {}, "time": 1609459200}
+        }
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_note_entry_valid_complex_body(schema):
+    """Tests valid note entry with complex body object."""
+    instance = {
+        "notes": {
+            "complex-note": {
+                "body": {
+                    "config": {
+                        "display": {"brightness": 75, "contrast": 80},
+                        "audio": {"volume": 50, "mute": False},
+                        "network": {"ssid": "MyWifi", "connected": True}
+                    },
+                    "metadata": {
+                        "version": "1.2.3",
+                        "timestamp": "2021-01-01T00:00:00Z",
+                        "tags": ["config", "user-settings", "device"]
+                    }
+                },
+                "time": 1609459200
+            }
+        }
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_note_entry_valid_time_formats(schema):
+    """Tests valid time formats (all integers)."""
+    valid_times = [0, 1, 1609459200, 2147483647, -1]  # Various valid integer timestamps
+    
+    for timestamp in valid_times:
+        instance = {
+            "notes": {
+                f"time-test-{timestamp}": {"body": {"test": True}, "time": timestamp}
+            }
+        }
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with additional property."""
+    instance = {"extra": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"status": "ok"},
+        {"message": "changes retrieved"},
+        {"error": "none"},
+        {"result": "success"},
+        {"count": 5},
+        {"timestamp": 1640995200},
+        {"tracker": "tracker-id"},
+        {"file": "data.db"},
+        {"max": 10},
+        {"start": True},
+        {"stop": False},
+        {"deleted": True},
+        {"delete": False},
+        {"reset": True}
+    ]
+    
+    for field_dict in invalid_fields:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests that multiple additional properties are not allowed."""
+    instance = {"status": "ok", "message": "retrieved", "extra": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = [
+        "string",
+        123,
+        True,
+        False,
+        ["array"],
+        None
+    ]
+    
+    for invalid_instance in invalid_types:
+        if invalid_instance is None:
+            continue  # Skip None as it's handled differently
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+        # The error message will vary based on type, just ensure validation fails
+
+def test_response_is_object_type(schema):
+    """Tests that response schema requires object type."""
+    # String should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance="not an object", schema=schema)
+    
+    # Number should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=42, schema=schema)
+    
+    # Array should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=[], schema=schema)
+    
+    # Boolean should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=True, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    # Verify schema has additionalProperties: false
+    assert schema.get("additionalProperties") is False
+
+def test_strict_validation(schema):
+    """Tests that schema enforces strict validation."""
+    # Any additional property should be rejected
+    properties_to_test = [
+        "file", "tracker", "max", "start", "stop", "deleted", "delete", "reset",
+        "cmd", "req", "status", "error", "message", "result", "data", "success",
+        "code", "info", "warning", "timestamp", "count", "index", "position"
+    ]
+    
+    for prop in properties_to_test:
+        instance = {prop: "test"}
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_field_combinations(schema):
+    """Tests various valid field combinations."""
+    combinations = [
+        {"total": 1},
+        {"changes": 2},
+        {"notes": {}},
+        {"total": 5, "changes": 2},
+        {"total": 10, "notes": {}},
+        {"changes": 3, "notes": {"note1": {"body": {"test": True}, "time": 1609459200}}},
+        {"total": 4, "changes": 4, "notes": {"note1": {"body": {"a": 1}, "time": 123}, "note2": {"body": {"b": 2}, "time": 456}}}
+    ]
+    
+    for combo in combinations:
+        jsonschema.validate(instance=combo, schema=schema)
+
+def test_edge_case_values(schema):
+    """Tests edge case values for fields."""
+    edge_cases = [
+        # Large values
+        {"total": 2147483647, "changes": 1000000},
+        # Zero values
+        {"total": 0, "changes": 0},
+        # Negative values (edge case)
+        {"total": -1, "changes": -5},
+        # Mixed scenarios
+        {"total": 100, "changes": 0, "notes": {}},  # No changes but high total
+        {"total": 0, "changes": 5, "notes": {}}     # Changes without total (edge case)
+    ]
+    
+    for case in edge_cases:
+        jsonschema.validate(instance=case, schema=schema)
+
+def test_notes_key_variations(schema):
+    """Tests various note key formats."""
+    key_variations = {
+        "simple": {"body": {"data": 1}, "time": 1609459200},
+        "with-dashes": {"body": {"data": 2}, "time": 1609459201},
+        "with_underscores": {"body": {"data": 3}, "time": 1609459202},
+        "CamelCase": {"body": {"data": 4}, "time": 1609459203},
+        "123numeric": {"body": {"data": 5}, "time": 1609459204},
+        "mixed-Case_123": {"body": {"data": 6}, "time": 1609459205},
+        "very_long_key_name_with_many_parts": {"body": {"data": 7}, "time": 1609459206},
+        "": {"body": {"data": 8}, "time": 1609459207}  # Empty key
+    }
+    
+    instance = {"notes": key_variations}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_api_reference_example(schema):
+    """Tests the exact example from API reference."""
+    instance = {
+        "changes": 4,
+        "total": 4,
+        "notes": {
+            "setting-one": {"body": {"foo": "bar"}, "time": 1598918235},
+            "setting-two": {"body": {"foo": "bat"}, "time": 1598918245},
+            "setting-three": {"body": {"foo": "baz"}, "time": 1598918225},
+            "setting-four": {"body": {"foo": "foo"}, "time": 1598910532}
+        }
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Enhanced note.changes request schema from v0.1.1 to v0.2.1 with all 8 API parameters and proper SKU restrictions
- Enhanced note.changes response schema from v0.1.1 to v0.2.1 with correct nested object structure for notes field
- Created comprehensive test suites with 96 test functions covering all validation scenarios and edge cases

## Changes Made

### Request Schema (note.changes.req.notecard.api.json)
- Added all 8 parameters from API reference: `file` (required), `tracker`, `max`, `start`, `stop`, `deleted`, `delete`, `reset`
- Implemented proper SKU compatibility restrictions (CELL, CELL+WIFI, WIFI - no LORA support)
- Added exact API reference descriptions with proper markdown formatting
- Included 6 comprehensive samples covering peek, pop, reset, deleted notes, and tracker operations
- Enforced minimum value constraint for `max` parameter (≥ 1)

### Response Schema (note.changes.rsp.notecard.api.json)
- Corrected response structure from incorrect boolean/array format to proper API response format
- Added 3 main fields: `total` (integer), `changes` (integer), `notes` (complex object)
- Implemented nested object validation for notes field requiring `body` (object) and `time` (integer) properties
- Added 3 response samples covering various scenarios including empty responses

### Test Coverage
- **tests/test_note_changes_req.py**: 50 test functions covering all request parameters, type validation, required fields, oneOf constraints, and API reference examples
- **tests/test_note_changes_rsp.py**: 46 test functions covering response structure, nested object validation, field types, and edge cases
- All schema samples validate successfully against their respective schemas
- Comprehensive coverage of invalid scenarios and proper error messaging

## Test Results
✅ All 96 tests pass
✅ Schema samples validate successfully
✅ Proper validation of nested object structure for response notes field
✅ Complete parameter validation for all request fields

🤖 Generated with [Claude Code](https://claude.ai/code)