### PR TITLE
feat: enhance note.update schemas to v0.2.1 with complete API alignment

### DIFF
--- a/note.update.req.notecard.api.json
+++ b/note.update.req.notecard.api.json
@@ -2,26 +2,12 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/note.update.req.notecard.api.json",
     "title": "note.update Request Application Programming Interface (API) Schema",
-    "description": "Updates a Note in a DB Notefile by its ID, replacing the existing body and/or payload.",
+    "description": "Updates a Note in a **DB Notefile** by its ID, replacing the existing `body` and/or `payload`.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
-        "file": {
-            "description": "Name of the notefile to update the note in",
-            "type": "string"
-        },
-        "note": {
-            "description": "ID of the note to update",
-            "type": "string"
-        },
-        "body": {
-            "description": "Updated note body data",
-            "type": "object"
-        },
-        "payload": {
-            "description": "Updated binary payload data",
-            "type": "string",
-            "format": "binary"
-        },
         "cmd": {
             "description": "Command for the Notecard (no response)",
             "const": "note.update"
@@ -29,8 +15,33 @@
         "req": {
             "description": "Request for the Notecard (expects response)",
             "const": "note.update"
+        },
+        "file": {
+            "description": "The name of the DB Notefile that contains the Note to update.",
+            "type": "string"
+        },
+        "note": {
+            "description": "The unique Note ID.",
+            "type": "string"
+        },
+        "body": {
+            "description": "A JSON object to add to the Note. A Note must have either a `body` or `payload`, and can have both.",
+            "type": "object"
+        },
+        "payload": {
+            "description": "A base64-encoded binary payload. A Note must have either a `body` or `payload`, and can have both.",
+            "type": "string"
+        },
+        "verify": {
+            "description": "If set to `true` and using a templated Notefile, the Notefile will be written to flash immediately, rather than being cached in RAM and written to flash later.",
+            "type": "boolean"
         }
     },
+    "required": ["file", "note"],
+    "anyOf": [
+        {"required": ["body"]},
+        {"required": ["payload"]}
+    ],
     "oneOf": [
         {
             "required": [
@@ -54,6 +65,31 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Update Note Body",
+            "description": "Update a note with new JSON body content.",
+            "json": "{\"req\": \"note.update\", \"file\": \"my-settings.db\", \"note\": \"measurements\", \"body\": {\"interval\": 60}}"
+        },
+        {
+            "title": "Update Note Payload",
+            "description": "Update a note with new base64 payload data.",
+            "json": "{\"req\": \"note.update\", \"file\": \"data.db\", \"note\": \"sensor-1\", \"payload\": \"SGVsbG8gV29ybGQ=\"}"
+        },
+        {
+            "title": "Update with Body and Payload",
+            "description": "Update a note with both body and payload.",
+            "json": "{\"req\": \"note.update\", \"file\": \"config.db\", \"note\": \"device-config\", \"body\": {\"enabled\": true}, \"payload\": \"YWRkaXRpb25hbERhdGE=\"}"
+        },
+        {
+            "title": "Update with Verification",
+            "description": "Update a note in templated Notefile with immediate flash write.",
+            "json": "{\"req\": \"note.update\", \"file\": \"template.db\", \"note\": \"user-setting\", \"body\": {\"theme\": \"dark\"}, \"verify\": true}"
+        },
+        {
+            "title": "Update with Command",
+            "description": "Update a note using command syntax (no response expected).",
+            "json": "{\"cmd\": \"note.update\", \"file\": \"cache.db\", \"note\": \"temp-data\", \"body\": {\"status\": \"updated\"}}"
+        }
+    ]
 }

--- a/note.update.rsp.notecard.api.json
+++ b/note.update.rsp.notecard.api.json
@@ -2,13 +2,18 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/note.update.rsp.notecard.api.json",
     "title": "note.update Response Application Programming Interface (API) Schema",
+    "description": "Response confirming Note update in a DB Notefile.",
     "type": "object",
-    "properties": {
-        "success": {
-            "description": "Whether the update was successful",
-            "type": "boolean"
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
+    "properties": {},
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Successful Update Response",
+            "description": "Empty response confirming successful note update.",
+            "json": "{}"
         }
-    },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    ]
 }

--- a/tests/test_note_update_req.py
+++ b/tests/test_note_update_req.py
@@ -1,0 +1,311 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "note.update.req.notecard.api.json"
+
+def test_valid_req_with_body(schema):
+    """Tests a valid request with body."""
+    instance = {"req": "note.update", "file": "my-settings.db", "note": "measurements", "body": {"interval": 60}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_with_body(schema):
+    """Tests a valid command with body."""
+    instance = {"cmd": "note.update", "file": "config.db", "note": "setting-1", "body": {"enabled": True}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_payload(schema):
+    """Tests a valid request with payload."""
+    instance = {"req": "note.update", "file": "data.db", "note": "sensor-1", "payload": "SGVsbG8gV29ybGQ="}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_body_and_payload(schema):
+    """Tests a valid request with both body and payload."""
+    instance = {
+        "req": "note.update", 
+        "file": "config.db", 
+        "note": "device-config", 
+        "body": {"enabled": True}, 
+        "payload": "YWRkaXRpb25hbERhdGE="
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_verify(schema):
+    """Tests a valid request with verify parameter."""
+    instance = {
+        "req": "note.update", 
+        "file": "template.db", 
+        "note": "user-setting", 
+        "body": {"theme": "dark"}, 
+        "verify": True
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_api_reference_example(schema):
+    """Tests the exact example from API reference."""
+    instance = {
+        "req": "note.update",
+        "file": "my-settings.db",
+        "note": "measurements",
+        "body": {"interval": 60}
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_db_file_extensions(schema):
+    """Tests various valid database file extensions."""
+    db_files = ["settings.db", "config.dbx", "cache.dbs", "template.db"]
+    
+    for db_file in db_files:
+        instance = {"req": "note.update", "file": db_file, "note": "test-note", "body": {"data": "test"}}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_complex_body(schema):
+    """Tests valid request with complex body object."""
+    instance = {
+        "req": "note.update",
+        "file": "complex.db",
+        "note": "config",
+        "body": {
+            "settings": {
+                "display": {"brightness": 75, "contrast": 80},
+                "network": {"ssid": "MyWifi", "connected": True}
+            },
+            "sensors": [
+                {"type": "temperature", "enabled": True},
+                {"type": "humidity", "enabled": False}
+            ]
+        }
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_empty_body(schema):
+    """Tests valid request with empty body object."""
+    instance = {"req": "note.update", "file": "data.db", "note": "empty-test", "body": {}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_base64_payloads(schema):
+    """Tests various valid base64 payload patterns."""
+    base64_patterns = [
+        "SGVsbG8gV29ybGQ=",           # Hello World
+        "VGhpcyBpcyBhIHRlc3Q=",       # This is a test
+        "YWJjZGVmZ2hpamtsbW5vcA==",   # abcdefghijklmnop
+        "MTIzNDU2Nzg5MA==",           # 1234567890
+        ""                            # Empty string
+    ]
+    
+    for payload in base64_patterns:
+        instance = {"req": "note.update", "file": "data.db", "note": "test", "payload": payload}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"file": "data.db", "note": "test", "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {"req": "note.update", "cmd": "note.update", "file": "data.db", "note": "test", "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {"req": "wrong.api", "file": "data.db", "note": "test", "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'note.update' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {"cmd": "wrong.api", "file": "data.db", "note": "test", "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'note.update' was expected" in str(excinfo.value)
+
+def test_invalid_missing_file(schema):
+    """Tests invalid request without required file parameter."""
+    instance = {"req": "note.update", "note": "test", "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'file' is a required property" in str(excinfo.value)
+
+def test_invalid_missing_note(schema):
+    """Tests invalid request without required note parameter."""
+    instance = {"req": "note.update", "file": "data.db", "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'note' is a required property" in str(excinfo.value)
+
+def test_invalid_missing_body_and_payload(schema):
+    """Tests invalid request without either body or payload."""
+    instance = {"req": "note.update", "file": "data.db", "note": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    # Should fail anyOf validation requiring either body or payload
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_file_invalid_type_integer(schema):
+    """Tests invalid integer type for file."""
+    instance = {"req": "note.update", "file": 123, "note": "test", "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_file_invalid_type_boolean(schema):
+    """Tests invalid boolean type for file."""
+    instance = {"req": "note.update", "file": True, "note": "test", "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'string'" in str(excinfo.value)
+
+def test_note_invalid_type_integer(schema):
+    """Tests invalid integer type for note."""
+    instance = {"req": "note.update", "file": "data.db", "note": 456, "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "456 is not of type 'string'" in str(excinfo.value)
+
+def test_note_invalid_type_array(schema):
+    """Tests invalid array type for note."""
+    instance = {"req": "note.update", "file": "data.db", "note": ["test-id"], "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_body_invalid_type_string(schema):
+    """Tests invalid string type for body."""
+    instance = {"req": "note.update", "file": "data.db", "note": "test", "body": "should be object"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'should be object' is not of type 'object'" in str(excinfo.value)
+
+def test_body_invalid_type_array(schema):
+    """Tests invalid array type for body."""
+    instance = {"req": "note.update", "file": "data.db", "note": "test", "body": ["array", "not", "object"]}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'object'" in str(excinfo.value)
+
+def test_payload_invalid_type_integer(schema):
+    """Tests invalid integer type for payload."""
+    instance = {"req": "note.update", "file": "data.db", "note": "test", "payload": 12345}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "12345 is not of type 'string'" in str(excinfo.value)
+
+def test_payload_invalid_type_boolean(schema):
+    """Tests invalid boolean type for payload."""
+    instance = {"req": "note.update", "file": "data.db", "note": "test", "payload": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "True is not of type 'string'" in str(excinfo.value)
+
+def test_verify_invalid_type_string(schema):
+    """Tests invalid string type for verify."""
+    instance = {"req": "note.update", "file": "data.db", "note": "test", "body": {"data": "test"}, "verify": "true"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_verify_invalid_type_integer(schema):
+    """Tests invalid integer type for verify."""
+    instance = {"req": "note.update", "file": "data.db", "note": "test", "body": {"data": "test"}, "verify": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with additional property."""
+    instance = {"req": "note.update", "file": "data.db", "note": "test", "body": {"data": "test"}, "extra": "not allowed"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {"req": "note.update", "file": "data.db", "note": "test", "body": {"data": "test"}, "extra1": 123, "extra2": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_database_update_scenarios(schema):
+    """Tests typical database update scenarios."""
+    scenarios = [
+        {"req": "note.update", "file": "settings.db", "note": "config-1", "body": {"enabled": True}},
+        {"req": "note.update", "file": "cache.dbx", "note": "temp-data", "payload": "dXBkYXRlZERhdGE="},
+        {"cmd": "note.update", "file": "logs.db", "note": "error-123", "body": {"resolved": True}},
+        {"req": "note.update", "file": "user-data.db", "note": "profile", "body": {"name": "John"}, "payload": "YXZhdGFy"}
+    ]
+    
+    for scenario in scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_templated_notefile_scenarios(schema):
+    """Tests scenarios for templated Notefiles with verify parameter."""
+    templated_scenarios = [
+        {"req": "note.update", "file": "template.db", "note": "user-1", "body": {"theme": "dark"}, "verify": True},
+        {"cmd": "note.update", "file": "config-template.dbx", "note": "global-setting", "body": {"debug": False}, "verify": False},
+        {"req": "note.update", "file": "user-template.db", "note": "preferences", "payload": "cHJlZnM=", "verify": True}
+    ]
+    
+    for scenario in templated_scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_edge_case_file_names(schema):
+    """Tests edge case file naming patterns."""
+    edge_case_files = [
+        "a.db",                        # Short name
+        "very-long-file-name.dbx",     # Long name
+        "file_with_underscores.db",    # Underscores
+        "file-with-dashes.dbx",        # Dashes
+        "CamelCaseFile.db",           # CamelCase
+        "123numeric.db",              # Starts with numbers
+        "mixed-Case_123.dbx"          # Mixed format
+    ]
+    
+    for filename in edge_case_files:
+        instance = {"req": "note.update", "file": filename, "note": "test", "body": {"data": "test"}}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_edge_case_note_ids(schema):
+    """Tests edge case note ID patterns."""
+    edge_case_notes = [
+        "a",                          # Single character
+        "123",                        # Numeric
+        "note-with-many-dashes",      # Long with dashes
+        "note_with_underscores",      # Underscores
+        "CamelCaseNote",             # CamelCase
+        "note.with.dots",            # Dots
+        "note:with:colons",          # Colons
+        "note/with/slashes"          # Slashes
+    ]
+    
+    for note_id in edge_case_notes:
+        instance = {"req": "note.update", "file": "test.db", "note": note_id, "body": {"data": "test"}}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_boolean_verify_combinations(schema):
+    """Tests various boolean combinations for verify parameter."""
+    combinations = [
+        {"req": "note.update", "file": "test.db", "note": "test", "body": {"data": 1}, "verify": True},
+        {"req": "note.update", "file": "test.db", "note": "test", "body": {"data": 2}, "verify": False},
+        {"cmd": "note.update", "file": "test.db", "note": "test", "payload": "dGVzdA==", "verify": True},
+        {"cmd": "note.update", "file": "test.db", "note": "test", "payload": "dGVzdDI=", "verify": False}
+    ]
+    
+    for combo in combinations:
+        jsonschema.validate(instance=combo, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_note_update_rsp.py
+++ b/tests/test_note_update_rsp.py
@@ -1,0 +1,135 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "note.update.rsp.notecard.api.json"
+
+def test_valid_empty_response(schema):
+    """Tests a valid empty response."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_minimal_response(schema):
+    """Tests the minimal valid response (empty object)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_empty_response_from_api_reference(schema):
+    """Tests the empty response structure as indicated by API reference."""
+    # API reference shows <ResponseMembers /> which indicates empty response
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property_single(schema):
+    """Tests invalid response with single additional property."""
+    instance = {"extra": "not allowed"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_success(schema):
+    """Tests invalid response with legacy success property."""
+    instance = {"success": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"status": "ok"},
+        {"message": "updated"},
+        {"error": "none"},
+        {"result": "success"},
+        {"file": "data.db"},
+        {"note": "test-id"},
+        {"body": {"data": "test"}},
+        {"payload": "dGVzdA=="},
+        {"verify": True},
+        {"updated": True},
+        {"timestamp": 1640995200}
+    ]
+    
+    for field_dict in invalid_fields:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests that multiple additional properties are not allowed."""
+    instance = {"status": "ok", "message": "updated", "success": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = [
+        "string",
+        123,
+        True,
+        False,
+        ["array"]
+    ]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_response_is_object_type(schema):
+    """Tests that response schema requires object type."""
+    # String should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance="not an object", schema=schema)
+    
+    # Number should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=42, schema=schema)
+    
+    # Array should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=[], schema=schema)
+    
+    # Boolean should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=True, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_strict_validation(schema):
+    """Tests that schema enforces strict validation."""
+    properties_to_test = [
+        "file", "note", "body", "payload", "verify", "cmd", "req", 
+        "status", "error", "message", "result", "data", "success",
+        "updated", "timestamp", "total", "changes"
+    ]
+    
+    for prop in properties_to_test:
+        instance = {prop: "test"}
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_empty_object_variations(schema):
+    """Tests various empty object representations."""
+    empty_variations = [
+        {},  # Standard empty object
+    ]
+    
+    for empty_obj in empty_variations:
+        jsonschema.validate(instance=empty_obj, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Enhanced note.update request schema from v0.1.1 to v0.2.1 with exact API reference alignment
- Enhanced note.update response schema from v0.1.1 to v0.2.1 with correct empty response structure
- Created comprehensive test suites with 48 test functions covering all validation scenarios and use cases

## Changes Made

### Request Schema (note.update.req.notecard.api.json)
- **API Alignment**: Updated to match exact API reference specification for DB Notefile updates
- **Parameters**: Added all 5 parameters from API reference:
  - `file` (required): The name of the DB Notefile that contains the Note to update
  - `note` (required): The unique Note ID
  - `body` (conditional): JSON object to add to the Note
  - `payload` (conditional): Base64-encoded binary payload
  - `verify` (optional): Write to flash immediately for templated Notefiles
- **Constraint Validation**: Implemented `anyOf` constraint requiring either `body` OR `payload` (or both) per API requirement
- **Required Fields**: Properly enforced `file` and `note` as required parameters
- **SKU Support**: All platforms supported (CELL, CELL+WIFI, LORA, WIFI)
- **Samples**: Added 5 comprehensive samples covering body updates, payload updates, combined updates, verification, and command syntax
- **Descriptions**: Used exact API reference wording with preserved markdown formatting

### Response Schema (note.update.rsp.notecard.api.json)
- **API Compliance**: Changed from v0.1.1 success boolean to empty response per API reference
- **Response Structure**: API reference shows `<ResponseMembers />` indicating empty successful response
- **Strict Validation**: Implemented `additionalProperties: false` to reject any response fields
- **Legacy Field Removal**: Eliminated `success` field from v0.1.1 schema
- **SKU Support**: All platforms supported matching request schema
- **Samples**: Single sample showing empty successful response `{}`

### Test Coverage
- **tests/test_note_update_req.py**: 35 test functions covering:
  - All parameter validation and type checking
  - Required field constraints (file, note)
  - Body/payload constraint validation (anyOf requiring at least one)
  - oneOf validation for req/cmd patterns
  - Database file extension handling (.db, .dbx, .dbs)
  - Complex body object validation
  - Base64 payload pattern testing
  - Templated Notefile scenarios with verify parameter
  - Edge cases for file names and note IDs
  - API reference example validation

- **tests/test_note_update_rsp.py**: 13 test functions covering:
  - Empty response validation per API reference
  - Strict blocking of additional properties
  - Legacy success field rejection
  - Request field blocking in responses
  - Schema structure validation

## API Reference Compliance
✅ **Request Parameters**: All 5 parameters match API reference exactly
✅ **Response Structure**: Empty response per `<ResponseMembers />` specification
✅ **SKU Support**: All platforms (CELL, CELL+WIFI, LORA, WIFI) supported
✅ **Required Fields**: `file` and `note` properly enforced as required
✅ **Body/Payload Constraint**: Proper validation requiring either body or payload (or both)
✅ **Database Files**: Designed for DB Notefile operations as specified
✅ **Descriptions**: Exact API reference wording with markdown preservation

## Key Features
- **Flexible Content Updates**: Support for JSON body, base64 payload, or both
- **Required Validation**: Must specify file and note ID for DB operations
- **Templated Support**: Verify parameter for immediate flash writes
- **Constraint Logic**: Enforces that at least one of body/payload must be present
- **Empty Response**: Clean success indication via empty response object

## Test Results
✅ All 48 tests pass (35 request + 13 response)
✅ Schema samples validate successfully
✅ Proper validation of required fields and constraints
✅ Comprehensive edge case coverage
✅ API reference example validation
✅ Empty response structure validation

🤖 Generated with [Claude Code](https://claude.ai/code)