### PR TITLE
feat: enhance note.template API schemas to v0.2.1 with complete API alignment

### DIFF
--- a/note.template.req.notecard.api.json
+++ b/note.template.req.notecard.api.json
@@ -48,6 +48,7 @@
             "type": "boolean"
         }
     },
+    "required": ["file"],
     "oneOf": [
         {
             "required": [

--- a/note.template.rsp.notecard.api.json
+++ b/note.template.rsp.notecard.api.json
@@ -2,9 +2,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/note.template.rsp.notecard.api.json",
     "title": "note.template Response Application Programming Interface (API) Schema",
+    "description": "Response from setting or verifying a Note template on a Notefile.",
     "type": "object",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
         "bytes": {
             "description": "The number of bytes that will be transmitted to Notehub, per Note, before compression.",
@@ -27,10 +29,22 @@
             "type": "string"
         }
     },
+    "additionalProperties": false,
     "samples": [
         {
-            "title": "Example Response",
-            "json": "{\"bytes\":40}"
+            "title": "Template Set Response",
+            "description": "Response when template is successfully set, showing bytes per note.",
+            "json": "{\"bytes\": 40}"
+        },
+        {
+            "title": "Template Verify Response",
+            "description": "Response when verifying existing template with all fields.",
+            "json": "{\"template\": true, \"body\": {\"temperature\": 14.1, \"humidity\": 11}, \"bytes\": 40}"
+        },
+        {
+            "title": "Template with Format Response",
+            "description": "Response showing compact format template.",
+            "json": "{\"template\": true, \"format\": \"compact\", \"bytes\": 25}"
         }
     ]
 }

--- a/tests/test_note_template_req.py
+++ b/tests/test_note_template_req.py
@@ -1,43 +1,59 @@
 import pytest
 import jsonschema
+import json
 
 SCHEMA_FILE = "note.template.req.notecard.api.json"
 
-def test_valid_req(schema):
-    """Tests a minimal valid request."""
+def test_valid_req_basic_template(schema):
+    """Tests a valid request with basic template setup."""
     instance = {
-        "req": "note.template"
+        "req": "note.template",
+        "file": "readings.qo",
+        "body": {"new_vals": True, "temperature": 14.1, "humidity": 11, "pump_state": "4"}
     }
     jsonschema.validate(instance=instance, schema=schema)
 
-def test_valid_cmd(schema):
-    """Tests a minimal valid command."""
+def test_valid_cmd_basic_template(schema):
+    """Tests a valid command with basic template setup."""
     instance = {
-        "cmd": "note.template"
+        "cmd": "note.template",
+        "file": "sensor-data.qo",
+        "body": {"temperature": 23.5, "humidity": 65, "status": "active"}
     }
     jsonschema.validate(instance=instance, schema=schema)
 
-def test_invalid_missing_req_cmd(schema):
-    """Tests invalid request missing both req and cmd."""
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"file": "test.qo", "body": {"data": "test"}}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
     instance = {
-        "file": "test.qo"
+        "req": "note.template",
+        "cmd": "note.template",
+        "file": "test.qo",
+        "body": {"data": "test"}
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_missing_file(schema):
+    """Tests invalid request without required file parameter."""
+    instance = {
+        "req": "note.template",
+        "body": {"data": "test"}
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    # Should fail because neither 'req' nor 'cmd' is present
-
-def test_valid_with_file(schema):
-    """Tests valid request with file parameter."""
-    instance = {
-        "req": "note.template",
-        "file": "data.qo"
-    }
-    jsonschema.validate(instance=instance, schema=schema)
+    assert "'file' is a required property" in str(excinfo.value)
 
 def test_valid_with_format(schema):
     """Tests valid request with format parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "format": "compact"
     }
     jsonschema.validate(instance=instance, schema=schema)
@@ -46,6 +62,7 @@ def test_valid_with_body(schema):
     """Tests valid request with body parameter."""
     instance = {
         "req": "note.template",
+        "file": "readings.qo",
         "body": {
             "readings": {
                 "temp": 0,
@@ -84,6 +101,7 @@ def test_invalid_format_type(schema):
     """Tests invalid request with non-string format parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "format": True
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
@@ -94,6 +112,7 @@ def test_invalid_body_type(schema):
     """Tests invalid request with non-object body parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "body": []
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
@@ -113,6 +132,7 @@ def test_invalid_additional_properties(schema):
     """Tests that additional properties are not allowed."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "invalid_property": "should_fail"
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
@@ -123,6 +143,7 @@ def test_valid_verify_parameter(schema):
     """Tests valid request with verify parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "verify": True
     }
     jsonschema.validate(instance=instance, schema=schema)
@@ -131,6 +152,7 @@ def test_invalid_verify_type(schema):
     """Tests invalid request with non-boolean verify parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "verify": "true"
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
@@ -141,6 +163,7 @@ def test_valid_length_parameter(schema):
     """Tests valid request with length parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "length": 250
     }
     jsonschema.validate(instance=instance, schema=schema)
@@ -149,6 +172,7 @@ def test_invalid_length_type(schema):
     """Tests invalid request with non-integer length parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "length": "250"
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
@@ -159,6 +183,7 @@ def test_valid_length_negative_one(schema):
     """Tests valid request with length=-1 (now allowed in schema)."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "length": -1
     }
     jsonschema.validate(instance=instance, schema=schema)
@@ -167,6 +192,7 @@ def test_valid_delete_parameter(schema):
     """Tests valid request with delete parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "delete": True
     }
     jsonschema.validate(instance=instance, schema=schema)
@@ -175,6 +201,7 @@ def test_invalid_delete_type(schema):
     """Tests invalid request with non-boolean delete parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "delete": 1
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
@@ -185,6 +212,7 @@ def test_valid_format_compact(schema):
     """Tests valid request with format=compact parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "format": "compact"
     }
     jsonschema.validate(instance=instance, schema=schema)
@@ -193,6 +221,7 @@ def test_invalid_length_too_negative(schema):
     """Tests invalid request with length less than -1."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "length": -2
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
@@ -203,6 +232,7 @@ def test_valid_port_parameter(schema):
     """Tests valid request with port parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "port": 50
     }
     jsonschema.validate(instance=instance, schema=schema)
@@ -211,6 +241,7 @@ def test_invalid_port_type(schema):
     """Tests invalid request with non-integer port parameter."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "port": "50"
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
@@ -221,6 +252,7 @@ def test_invalid_port_too_low(schema):
     """Tests invalid request with port below minimum."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "port": 0
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
@@ -231,8 +263,22 @@ def test_invalid_port_too_high(schema):
     """Tests invalid request with port above maximum."""
     instance = {
         "req": "note.template",
+        "file": "test.qo",
         "port": 101
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
     assert "101 is greater than the maximum of 100" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_note_template_rsp.py
+++ b/tests/test_note_template_rsp.py
@@ -1,139 +1,54 @@
 import pytest
 import jsonschema
+import json
 
 SCHEMA_FILE = "note.template.rsp.notecard.api.json"
 
-def test_minimal_valid_response(schema):
-    """Tests a minimal valid response (empty object)."""
+def test_valid_empty_response(schema):
+    """Tests a valid empty response."""
     instance = {}
     jsonschema.validate(instance=instance, schema=schema)
 
-def test_valid_success_true(schema):
-    """Tests a valid response with success=true."""
-    instance = {"success": True}
+def test_valid_bytes_response(schema):
+    """Tests valid response with bytes field."""
+    instance = {"bytes": 40}
     jsonschema.validate(instance=instance, schema=schema)
 
-def test_valid_success_false(schema):
-    """Tests a valid response with success=false."""
-    instance = {"success": False}
+def test_valid_template_set_response(schema):
+    """Tests valid response when template is successfully set."""
+    instance = {"bytes": 25}
     jsonschema.validate(instance=instance, schema=schema)
 
-def test_invalid_success_type(schema):
-    """Tests an invalid response with a non-boolean type for success."""
-    # Note: success is not defined in the current schema, so this test should validate
-    # as the schema allows additional properties
-    instance = {"success": "true"}
-    # This should actually pass since success is not defined in the schema
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_valid_with_error(schema):
-    """Tests a valid response with an error message."""
-    instance = {"err": "template validation failed"}
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_invalid_error_type(schema):
-    """Tests response with potential additional fields like error."""
-    # Since additionalProperties is not false, this should be valid
-    instance = {"err": "template validation failed"}
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_response_with_both_success_and_error(schema):
-    """Tests response that might contain both success and error fields."""
-    # This could be valid depending on the actual API behavior
+def test_valid_template_verify_response(schema):
+    """Tests valid response when verifying existing template."""
     instance = {
-        "success": False,
-        "err": "invalid template format"
+        "template": True,
+        "body": {"temperature": 14.1, "humidity": 11},
+        "bytes": 40
     }
     jsonschema.validate(instance=instance, schema=schema)
 
-def test_response_with_additional_fields(schema):
-    """Tests response with potential additional fields."""
-    # Based on pattern from other schemas, there might be additional response fields
+def test_valid_template_with_format_response(schema):
+    """Tests valid response showing compact format template."""
     instance = {
-        "success": True
+        "template": True,
+        "format": "compact",
+        "bytes": 25
     }
     jsonschema.validate(instance=instance, schema=schema)
 
-def test_empty_response_valid(schema):
-    """Tests that an empty response object is valid."""
-    instance = {}
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_invalid_unknown_property_type(schema):
-    """Tests response with an invalid property type if schema doesn't allow additional properties."""
-    # This test will depend on whether additionalProperties is false in the schema
-    instance = {"unknown_field": 123}
-    try:
-        jsonschema.validate(instance=instance, schema=schema)
-        # If validation passes, the schema allows additional properties
-    except jsonschema.ValidationError:
-        # If validation fails, the schema doesn't allow additional properties
-        pass
-
-def test_valid_template_response(schema):
-    """Tests valid response with template field (boolean)."""
-    instance = {
-        "template": True
-    }
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_invalid_template_type(schema):
-    """Tests invalid response with non-boolean template."""
-    instance = {"template": "invalid"}
-    with pytest.raises(jsonschema.ValidationError) as excinfo:
-        jsonschema.validate(instance=instance, schema=schema)
-    assert "'invalid' is not of type 'boolean'" in str(excinfo.value)
-
-def test_valid_file_response(schema):
-    """Tests valid response with file field."""
-    instance = {"file": "readings.qo"}
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_invalid_file_type(schema):
-    """Tests invalid response with non-string file."""
-    # Note: file is not defined in the current schema, so this should pass
-    # as the schema allows additional properties
-    instance = {"file": 123}
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_valid_length_response(schema):
+def test_valid_template_with_length_response(schema):
     """Tests valid response with length field."""
-    instance = {"length": 250}
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_invalid_length_type(schema):
-    """Tests invalid response with non-integer length."""
-    instance = {"length": "250"}
-    with pytest.raises(jsonschema.ValidationError) as excinfo:
-        jsonschema.validate(instance=instance, schema=schema)
-    assert "'250' is not of type 'integer'" in str(excinfo.value)
-
-def test_valid_format_response(schema):
-    """Tests valid response with format field."""
-    instance = {"format": "compact"}
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_invalid_format_type(schema):
-    """Tests invalid response with non-string format."""
-    instance = {"format": 123}
-    with pytest.raises(jsonschema.ValidationError) as excinfo:
-        jsonschema.validate(instance=instance, schema=schema)
-    assert "123 is not of type 'string'" in str(excinfo.value)
-
-def test_valid_port_response(schema):
-    """Tests valid response with port field."""
-    instance = {"port": 42}
-    jsonschema.validate(instance=instance, schema=schema)
-
-def test_invalid_port_type(schema):
-    """Tests invalid response with non-integer port."""
-    # Note: port is not defined in the current schema, so this should pass
-    # as the schema allows additional properties
-    instance = {"port": "42"}
+    instance = {
+        "template": True,
+        "body": {"sensor": "temp-01", "value": 25.4},
+        "length": 256,
+        "bytes": 32
+    }
     jsonschema.validate(instance=instance, schema=schema)
 
 def test_valid_complete_verify_response(schema):
-    """Tests complete response from verify request."""
+    """Tests complete response from verify request with all fields."""
     instance = {
         "bytes": 40,
         "template": True,
@@ -145,3 +60,77 @@ def test_valid_complete_verify_response(schema):
         "length": 100
     }
     jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_bytes_type(schema):
+    """Tests invalid response with non-integer bytes."""
+    instance = {"bytes": "40"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'40' is not of type 'integer'" in str(excinfo.value)
+
+def test_invalid_template_type(schema):
+    """Tests invalid response with non-boolean template."""
+    instance = {"template": "invalid"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'invalid' is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_body_type(schema):
+    """Tests invalid response with non-object body."""
+    instance = {"body": "should be object"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'should be object' is not of type 'object'" in str(excinfo.value)
+
+def test_invalid_length_type(schema):
+    """Tests invalid response with non-integer length."""
+    instance = {"length": "250"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'250' is not of type 'integer'" in str(excinfo.value)
+
+def test_invalid_format_type(schema):
+    """Tests invalid response with non-string format."""
+    instance = {"format": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "123 is not of type 'string'" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with additional property."""
+    instance = {"extra": "not allowed"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid response with multiple additional properties."""
+    instance = {"extra1": 123, "extra2": "test"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = ["string", 123, True, False, ["array"]]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Update note.template.rsp.notecard.api.json from v0.2.0 to v0.2.1 with API reference alignment
- Add required 'file' constraint to note.template.req.notecard.api.json 
- Update comprehensive test coverage for both schemas

## Test plan
- [x] All 44 tests pass successfully
- [x] Schema validation matches API reference documentation
- [x] Both request and response schemas follow v0.2.1 standards

🤖 Generated with [Claude Code](https://claude.ai/code)