### PR TITLE
feat: rewrite ntn.gps API schemas to v0.2.1 with complete API alignment

### DIFF
--- a/ntn.gps.req.notecard.api.json
+++ b/ntn.gps.req.notecard.api.json
@@ -4,16 +4,10 @@
     "title": "ntn.gps Request Application Programming Interface (API) Schema",
     "description": "Determines whether a Notecard should override a paired Starnote's GPS/GNSS location with its own GPS/GNSS location. The paired Starnote uses its own GPS/GNSS location by default.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
-        "mode": {
-            "description": "GPS mode",
-            "type": "string",
-            "enum": [
-                "continuous",
-                "periodic",
-                "off"
-            ]
-        },
         "cmd": {
             "description": "Command for the Notecard (no response)",
             "const": "ntn.gps"
@@ -21,6 +15,14 @@
         "req": {
             "description": "Request for the Notecard (expects response)",
             "const": "ntn.gps"
+        },
+        "on": {
+            "description": "When `true`, a Starnote will use the GPS/GNSS location from its paired Notecard, instead of its own GPS/GNSS location.",
+            "type": "boolean"
+        },
+        "off": {
+            "description": "When `true`, a paired Starnote will use its own GPS/GNSS location. This is the default configuration.",
+            "type": "boolean"
         }
     },
     "oneOf": [
@@ -46,6 +48,31 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Enable Notecard GPS Override",
+            "description": "Configure Starnote to use the paired Notecard's GPS/GNSS location.",
+            "json": "{\"req\": \"ntn.gps\", \"on\": true}"
+        },
+        {
+            "title": "Use Starnote's Own GPS",
+            "description": "Configure Starnote to use its own GPS/GNSS location (default).",
+            "json": "{\"req\": \"ntn.gps\", \"off\": true}"
+        },
+        {
+            "title": "Query Current GPS Configuration",
+            "description": "Request current GPS/GNSS location configuration.",
+            "json": "{\"req\": \"ntn.gps\"}"
+        }
+    ],
+    "annotations": [
+        {
+            "title": "note",
+            "description": "This API is only available as of Notecard firmware v6.2.3."
+        },
+        {
+            "title": "note", 
+            "description": "See the [Starnote Quickstart](https://dev.blues.io/quickstart/starnote-quickstart) for more information."
+        }
+    ]
 }

--- a/ntn.gps.rsp.notecard.api.json
+++ b/ntn.gps.rsp.notecard.api.json
@@ -3,12 +3,30 @@
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/ntn.gps.rsp.notecard.api.json",
     "title": "ntn.gps Response Application Programming Interface (API) Schema",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
-        "mode": {
-            "description": "Current GPS mode",
-            "type": "string"
+        "on": {
+            "description": "Returned and `true` if a Starnote will use the GPS/GNSS location from its paired Notecard.",
+            "type": "boolean"
+        },
+        "off": {
+            "description": "Returned and `true` if a paired Starnote will use its own GPS/GNSS location.",
+            "type": "boolean"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Starnote Using Own GPS",
+            "description": "Response indicating Starnote is using its own GPS/GNSS location (default).",
+            "json": "{\"off\": true}"
+        },
+        {
+            "title": "Starnote Using Notecard GPS",
+            "description": "Response indicating Starnote is using paired Notecard's GPS/GNSS location.",
+            "json": "{\"on\": true}"
+        }
+    ]
 }

--- a/tests/test_ntn_gps_req.py
+++ b/tests/test_ntn_gps_req.py
@@ -1,0 +1,264 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "ntn.gps.req.notecard.api.json"
+
+def test_valid_req_enable_notecard_gps(schema):
+    """Tests a valid request to enable Notecard GPS override."""
+    instance = {
+        "req": "ntn.gps",
+        "on": True
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_enable_notecard_gps(schema):
+    """Tests a valid command to enable Notecard GPS override."""
+    instance = {
+        "cmd": "ntn.gps",
+        "on": True
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_use_starnote_gps(schema):
+    """Tests a valid request to use Starnote's own GPS."""
+    instance = {
+        "req": "ntn.gps",
+        "off": True
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_use_starnote_gps(schema):
+    """Tests a valid command to use Starnote's own GPS."""
+    instance = {
+        "cmd": "ntn.gps",
+        "off": True
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_query_configuration(schema):
+    """Tests a valid request to query current GPS configuration."""
+    instance = {
+        "req": "ntn.gps"
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd_query_configuration(schema):
+    """Tests a valid command to query current GPS configuration."""
+    instance = {
+        "cmd": "ntn.gps"
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_req_with_both_parameters(schema):
+    """Tests a valid request with both on and off parameters."""
+    # Note: API allows both parameters to be present
+    instance = {
+        "req": "ntn.gps",
+        "on": True,
+        "off": False
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_boolean_combinations(schema):
+    """Tests various valid boolean combinations."""
+    combinations = [
+        {"req": "ntn.gps", "on": True},
+        {"req": "ntn.gps", "on": False},
+        {"req": "ntn.gps", "off": True},
+        {"req": "ntn.gps", "off": False},
+        {"cmd": "ntn.gps", "on": True},
+        {"cmd": "ntn.gps", "off": True},
+        {"req": "ntn.gps", "on": True, "off": False},
+        {"req": "ntn.gps", "on": False, "off": True}
+    ]
+    
+    for combo in combinations:
+        jsonschema.validate(instance=combo, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"on": True}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {
+        "req": "ntn.gps",
+        "cmd": "ntn.gps",
+        "on": True
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {
+        "req": "wrong.api",
+        "on": True
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'ntn.gps' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {
+        "cmd": "wrong.api",
+        "on": True
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'ntn.gps' was expected" in str(excinfo.value)
+
+def test_invalid_on_type_string(schema):
+    """Tests invalid string type for on parameter."""
+    instance = {
+        "req": "ntn.gps",
+        "on": "true"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_on_type_integer(schema):
+    """Tests invalid integer type for on parameter."""
+    instance = {
+        "req": "ntn.gps",
+        "on": 1
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_off_type_string(schema):
+    """Tests invalid string type for off parameter."""
+    instance = {
+        "req": "ntn.gps",
+        "off": "true"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_off_type_integer(schema):
+    """Tests invalid integer type for off parameter."""
+    instance = {
+        "req": "ntn.gps",
+        "off": 1
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with additional property."""
+    instance = {
+        "req": "ntn.gps",
+        "on": True,
+        "extra": "not allowed"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {
+        "req": "ntn.gps",
+        "on": True,
+        "extra1": 123,
+        "extra2": "test"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_starnote_gps_scenarios(schema):
+    """Tests realistic Starnote GPS configuration scenarios."""
+    scenarios = [
+        # Enable Notecard GPS override for better accuracy
+        {
+            "req": "ntn.gps",
+            "on": True
+        },
+        # Return to default Starnote GPS
+        {
+            "cmd": "ntn.gps",
+            "off": True
+        },
+        # Query current configuration
+        {
+            "req": "ntn.gps"
+        },
+        # Explicit configuration with both parameters
+        {
+            "req": "ntn.gps",
+            "on": False,
+            "off": True
+        }
+    ]
+    
+    for scenario in scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_ntn_compatibility_scenarios(schema):
+    """Tests NTN (satellite) specific GPS scenarios."""
+    ntn_scenarios = [
+        # Use Notecard GPS for satellite communication
+        {
+            "req": "ntn.gps",
+            "on": True
+        },
+        # Use Starnote's dedicated GPS receiver
+        {
+            "req": "ntn.gps",
+            "off": True
+        },
+        # Command to switch GPS source without response
+        {
+            "cmd": "ntn.gps",
+            "on": True
+        }
+    ]
+    
+    for scenario in ntn_scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_edge_case_boolean_values(schema):
+    """Tests edge cases with boolean values."""
+    edge_cases = [
+        {"req": "ntn.gps", "on": True, "off": False},
+        {"req": "ntn.gps", "on": False, "off": True},
+        {"cmd": "ntn.gps", "on": False, "off": False},
+        {"cmd": "ntn.gps", "on": True, "off": True}
+    ]
+    
+    for case in edge_cases:
+        jsonschema.validate(instance=case, schema=schema)
+
+def test_request_type_validation(schema):
+    """Tests that request must be an object."""
+    invalid_types = ["string", 123, True, False, ["array"]]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_ntn_gps_rsp.py
+++ b/tests/test_ntn_gps_rsp.py
@@ -1,0 +1,213 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "ntn.gps.rsp.notecard.api.json"
+
+def test_valid_empty_response(schema):
+    """Tests a valid empty response."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_starnote_gps_response(schema):
+    """Tests valid response indicating Starnote is using its own GPS."""
+    instance = {"off": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_notecard_gps_response(schema):
+    """Tests valid response indicating Starnote is using Notecard's GPS."""
+    instance = {"on": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_response_with_both_fields(schema):
+    """Tests valid response with both on and off fields."""
+    instance = {
+        "on": False,
+        "off": True
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_boolean_combinations(schema):
+    """Tests various valid boolean combinations."""
+    combinations = [
+        {"on": True},
+        {"on": False},
+        {"off": True},
+        {"off": False},
+        {"on": True, "off": False},
+        {"on": False, "off": True},
+        {"on": False, "off": False},
+        {"on": True, "off": True}
+    ]
+    
+    for combo in combinations:
+        jsonschema.validate(instance=combo, schema=schema)
+
+def test_valid_configuration_states(schema):
+    """Tests various GPS configuration state responses."""
+    states = [
+        # Default state - Starnote using own GPS
+        {"off": True},
+        # Override state - Starnote using Notecard GPS
+        {"on": True},
+        # Explicit state with both values
+        {"on": False, "off": True},
+        {"on": True, "off": False}
+    ]
+    
+    for state in states:
+        jsonschema.validate(instance=state, schema=schema)
+
+def test_invalid_on_type_string(schema):
+    """Tests invalid string type for on field."""
+    instance = {"on": "true"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_on_type_integer(schema):
+    """Tests invalid integer type for on field."""
+    instance = {"on": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_off_type_string(schema):
+    """Tests invalid string type for off field."""
+    instance = {"off": "true"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'true' is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_off_type_integer(schema):
+    """Tests invalid integer type for off field."""
+    instance = {"off": 1}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "1 is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with additional property."""
+    instance = {
+        "on": True,
+        "extra": "not allowed"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid response with multiple additional properties."""
+    instance = {
+        "off": True,
+        "extra1": 123,
+        "extra2": "test"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = ["string", 123, True, False, ["array"]]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_starnote_response_scenarios(schema):
+    """Tests realistic Starnote GPS response scenarios."""
+    scenarios = [
+        # Default configuration response
+        {"off": True},
+        # Notecard GPS override enabled response  
+        {"on": True},
+        # Query response showing default state
+        {"on": False, "off": True},
+        # Query response showing override state
+        {"on": True, "off": False},
+        # Empty response (no configuration set)
+        {}
+    ]
+    
+    for scenario in scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_ntn_gps_state_responses(schema):
+    """Tests NTN GPS state response scenarios."""
+    ntn_responses = [
+        # Starnote using own GPS for satellite communication
+        {"off": True},
+        # Starnote using Notecard GPS for better accuracy
+        {"on": True},
+        # Configuration query showing both states
+        {"on": False, "off": True},
+        {"on": True, "off": False}
+    ]
+    
+    for response in ntn_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_boolean_field_edge_cases(schema):
+    """Tests edge cases with boolean field values."""
+    edge_cases = [
+        {"on": True, "off": True},    # Both true (edge case)
+        {"on": False, "off": False},  # Both false (edge case)
+        {"on": True, "off": False},   # Consistent override state
+        {"on": False, "off": True}    # Consistent default state
+    ]
+    
+    for case in edge_cases:
+        jsonschema.validate(instance=case, schema=schema)
+
+def test_minimal_responses(schema):
+    """Tests minimal valid response formats."""
+    minimal_responses = [
+        {},                # Empty response
+        {"on": True},      # Only on field
+        {"off": True},     # Only off field
+        {"on": False},     # Only on field with false
+        {"off": False}     # Only off field with false
+    ]
+    
+    for response in minimal_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_response_field_validation(schema):
+    """Tests that response field types are correctly validated."""
+    # Valid boolean fields should pass
+    valid_responses = [
+        {"on": True}, {"on": False},
+        {"off": True}, {"off": False}
+    ]
+    
+    for response in valid_responses:
+        jsonschema.validate(instance=response, schema=schema)
+    
+    # Invalid field types should fail
+    invalid_field_types = [
+        {"on": "invalid"}, {"off": "invalid"},
+        {"on": 123}, {"off": 456},
+        {"on": []}, {"off": {}}
+    ]
+    
+    for invalid_response in invalid_field_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_response, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Completely rewrite ntn.gps API schemas to match official API reference documentation
- Fix incorrect implementation: replace 'mode' enum with proper 'on'/'off' boolean parameters
- Add comprehensive test coverage for Starnote GPS configuration functionality

## Changes Made
### Request Schema (ntn.gps.req.notecard.api.json)
- **Breaking change**: Replace incorrect `mode` enum with proper `on` and `off` boolean parameters
- Update version from v0.1.1 to v0.2.1 with proper field ordering
- Add SKU restrictions for CELL, CELL+WIFI, WIFI platforms
- Add comprehensive samples covering enable/disable/query scenarios
- Add firmware version annotations (v6.2.3+) and Starnote documentation references

### Response Schema (ntn.gps.rsp.notecard.api.json)  
- **Breaking change**: Replace `mode` string field with `on` and `off` boolean fields
- Update version from v0.1.1 to v0.2.1 with proper field ordering
- Add strict `additionalProperties: false` validation
- Add comprehensive samples showing both GPS configuration states

### Test Coverage
- Add comprehensive test suite with 44 tests covering all scenarios
- 24 request schema tests: parameter validation, type checking, edge cases
- 20 response schema tests: field validation, boolean combinations, state responses
- All tests pass successfully

## Test Results
```bash
pipenv run pytest tests/test_ntn_gps_req.py tests/test_ntn_gps_rsp.py -v
============================== 44 passed in 0.12s ==============================
```

## API Functionality
The corrected ntn.gps API properly handles Starnote GPS configuration:
- `on: true` - Starnote uses paired Notecard's GPS/GNSS location
- `off: true` - Starnote uses its own GPS/GNSS location (default)
- Query requests return current GPS configuration state

🤖 Generated with [Claude Code](https://claude.ai/code)