### PR TITLE
feat: rewrite ntn.status API schemas to v0.2.1 with complete API alignment

### DIFF
--- a/ntn.status.req.notecard.api.json
+++ b/ntn.status.req.notecard.api.json
@@ -4,6 +4,9 @@
     "title": "ntn.status Request Application Programming Interface (API) Schema",
     "description": "Displays the current status of a Notecard's connection to a paired Starnote.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "cmd": {
             "description": "Command for the Notecard (no response)",
@@ -37,6 +40,11 @@
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Get Starnote Connection Status",
+            "description": "Request current status of Notecard's connection to paired Starnote.",
+            "json": "{\"req\": \"ntn.status\"}"
+        }
+    ]
 }

--- a/ntn.status.rsp.notecard.api.json
+++ b/ntn.status.rsp.notecard.api.json
@@ -2,21 +2,37 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/ntn.status.rsp.notecard.api.json",
     "title": "ntn.status Response Application Programming Interface (API) Schema",
+    "description": "Response showing current status of Notecard's connection to paired Starnote.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
-        "status": {
-            "description": "Status of the Notehub connection",
+        "err": {
+            "description": "This member is present if any errors have occurred while connecting to a paired Starnote, for example: `{\"err\":\"no NTN module is connected {no-ntn-module}\"}`",
             "type": "string"
         },
-        "connected": {
-            "description": "Whether the Notecard is connected to Notehub",
-            "type": "boolean"
-        },
-        "time": {
-            "description": "Current time (Unix epoch seconds)",
-            "type": "integer"
+        "status": {
+            "description": "Details about a Notecard's connection to a paired Starnote, for example: `{\"status\":\"{ntn-idle}{ntn-unknown-location}\"}`",
+            "type": "string"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Starnote Idle Status",
+            "description": "Response showing Starnote connection in idle state.",
+            "json": "{\"status\": \"{ntn-idle}\"}"
+        },
+        {
+            "title": "Starnote Connection Error",
+            "description": "Response showing error when no NTN module is connected.",
+            "json": "{\"err\": \"no NTN module is connected {no-ntn-module}\"}"
+        },
+        {
+            "title": "Starnote Status with Location Info",
+            "description": "Response showing detailed status including location information.",
+            "json": "{\"status\": \"{ntn-idle}{ntn-unknown-location}\"}"
+        }
+    ]
 }

--- a/tests/test_ntn_status_req.py
+++ b/tests/test_ntn_status_req.py
@@ -1,0 +1,135 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "ntn.status.req.notecard.api.json"
+
+def test_valid_requests(schema):
+    """Tests valid request and command formats."""
+    valid_requests = [
+        {"req": "ntn.status"},
+        {"cmd": "ntn.status"}
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {
+        "req": "ntn.status",
+        "cmd": "ntn.status"
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {
+        "req": "wrong.api"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'ntn.status' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {
+        "cmd": "wrong.api"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'ntn.status' was expected" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with additional property."""
+    instance = {
+        "req": "ntn.status",
+        "extra": "not allowed"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {
+        "req": "ntn.status",
+        "extra1": 123,
+        "extra2": "test"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_parameters(schema):
+    """Tests that no parameters are allowed beyond req/cmd."""
+    invalid_parameters = [
+        {"req": "ntn.status", "detailed": True},
+        {"req": "ntn.status", "verbose": True},
+        {"cmd": "ntn.status", "format": "json"},
+        {"req": "ntn.status", "timeout": 30},
+        {"cmd": "ntn.status", "refresh": True}
+    ]
+    
+    for invalid_request in invalid_parameters:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=invalid_request, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_starnote_status_scenarios(schema):
+    """Tests realistic Starnote status request scenarios."""
+    scenarios = [
+        {"req": "ntn.status"},  # Standard status request
+        {"cmd": "ntn.status"},  # Status command without response
+    ]
+    
+    for scenario in scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_request_type_validation(schema):
+    """Tests that request must be an object."""
+    invalid_types = ["string", 123, True, False, ["array"]]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_req_cmd_validation(schema):
+    """Tests req/cmd mutual exclusion and empty object validation."""
+    # Only req should pass
+    jsonschema.validate(instance={"req": "ntn.status"}, schema=schema)
+    
+    # Only cmd should pass  
+    jsonschema.validate(instance={"cmd": "ntn.status"}, schema=schema)
+    
+    # Both req and cmd should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance={"req": "ntn.status", "cmd": "ntn.status"}, schema=schema)
+    
+    # Empty object should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance={}, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_ntn_status_rsp.py
+++ b/tests/test_ntn_status_rsp.py
@@ -1,0 +1,178 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "ntn.status.rsp.notecard.api.json"
+
+def test_valid_empty_response(schema):
+    """Tests a valid empty response."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_status_response(schema):
+    """Tests valid response with status field."""
+    instance = {"status": "{ntn-idle}"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_error_response(schema):
+    """Tests valid response with error field."""
+    instance = {"err": "no NTN module is connected {no-ntn-module}"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_status_with_location_info(schema):
+    """Tests valid response with detailed status including location."""
+    instance = {"status": "{ntn-idle}{ntn-unknown-location}"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_response_combinations(schema):
+    """Tests various valid response combinations."""
+    valid_responses = [
+        {},  # Empty response
+        {"status": "{ntn-idle}"},
+        {"status": "{ntn-connecting}"},
+        {"status": "{ntn-idle}{ntn-unknown-location}"},
+        {"status": "{ntn-transmitting}{ntn-location-known}"},
+        {"err": "no NTN module is connected {no-ntn-module}"},
+        {"err": "connection timeout"},
+        {"status": "{ntn-idle}", "err": "warning message"},  # Both fields allowed
+    ]
+    
+    for response in valid_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_invalid_status_type(schema):
+    """Tests invalid type for status field."""
+    invalid_status_types = [
+        {"status": 123},
+        {"status": True},
+        {"status": []},
+        {"status": {}}
+    ]
+    
+    for instance in invalid_status_types:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "is not of type 'string'" in str(excinfo.value)
+
+def test_invalid_err_type(schema):
+    """Tests invalid type for err field."""
+    invalid_err_types = [
+        {"err": 123},
+        {"err": True},
+        {"err": []},
+        {"err": {}}
+    ]
+    
+    for instance in invalid_err_types:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "is not of type 'string'" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with additional property."""
+    instance = {
+        "status": "{ntn-idle}",
+        "extra": "not allowed"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid response with multiple additional properties."""
+    instance = {
+        "status": "{ntn-idle}",
+        "connected": True,
+        "time": 1640995200
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = ["string", 123, True, False, ["array"]]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_starnote_status_responses(schema):
+    """Tests realistic Starnote status response scenarios."""
+    scenarios = [
+        # Standard idle status
+        {"status": "{ntn-idle}"},
+        # Connection error
+        {"err": "no NTN module is connected {no-ntn-module}"},
+        # Status with location info
+        {"status": "{ntn-idle}{ntn-unknown-location}"},
+        # Transmitting status
+        {"status": "{ntn-transmitting}"},
+        # Multiple status flags
+        {"status": "{ntn-connecting}{ntn-location-known}"},
+        # Empty response (no status available)
+        {}
+    ]
+    
+    for scenario in scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_error_scenarios(schema):
+    """Tests various error response scenarios."""
+    error_scenarios = [
+        {"err": "no NTN module is connected {no-ntn-module}"},
+        {"err": "connection timeout"},
+        {"err": "authentication failed"},
+        {"err": "satellite not in range"},
+        {"err": "hardware error"}
+    ]
+    
+    for scenario in error_scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_status_flag_patterns(schema):
+    """Tests various status flag patterns."""
+    status_patterns = [
+        {"status": "{ntn-idle}"},
+        {"status": "{ntn-connecting}"},
+        {"status": "{ntn-transmitting}"},
+        {"status": "{ntn-receiving}"},
+        {"status": "{ntn-unknown-location}"},
+        {"status": "{ntn-location-known}"},
+        {"status": "{ntn-idle}{ntn-unknown-location}"},
+        {"status": "{ntn-connecting}{ntn-location-known}"},
+        {"status": "{ntn-transmitting}{ntn-location-known}"}
+    ]
+    
+    for pattern in status_patterns:
+        jsonschema.validate(instance=pattern, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_optional_fields_validation(schema):
+    """Tests that all response fields are optional."""
+    # All these should be valid since all fields are optional
+    valid_responses = [
+        {},  # No fields
+        {"status": "{ntn-idle}"},  # Only status
+        {"err": "error message"},  # Only err
+        {"status": "{ntn-idle}", "err": "warning"}  # Both fields
+    ]
+    
+    for response in valid_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)


### PR DESCRIPTION
## Summary
- Rewrite ntn.status API schemas to match official API reference documentation
- Fix incorrect response schema: replace wrong fields with proper err and status fields
- Update from v0.1.1 to v0.2.1 with comprehensive test coverage

## Test plan
- [x] All 29 tests pass successfully
- [x] Schema validation matches API reference documentation
- [x] Both request and response schemas follow v0.2.1 standards

🤖 Generated with [Claude Code](https://claude.ai/code)