### PR TITLE
feat: update var.get schemas to v0.2.1 with complete API alignment

### DIFF
--- a/tests/test_var_get_req.py
+++ b/tests/test_var_get_req.py
@@ -1,0 +1,196 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "var.get.req.notecard.api.json"
+
+def test_valid_requests(schema):
+    """Tests valid request and command formats with name parameter."""
+    valid_requests = [
+        {"req": "var.get", "name": "status"},
+        {"cmd": "var.get", "name": "temperature"},
+        {"req": "var.get", "name": "sensor_data"},
+        {"cmd": "var.get", "name": "config_value"},
+        {"req": "var.get", "name": "status", "file": "sensors.db"},
+        {"cmd": "var.get", "name": "data", "file": "vars.db"}
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"name": "status"}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {
+        "req": "var.get",
+        "cmd": "var.get",
+        "name": "status"
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {
+        "req": "wrong.api",
+        "name": "status"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'var.get' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {
+        "cmd": "wrong.api",
+        "name": "status"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'var.get' was expected" in str(excinfo.value)
+
+def test_missing_name_parameter(schema):
+    """Tests invalid request missing required name parameter."""
+    invalid_requests = [
+        {"req": "var.get"},
+        {"cmd": "var.get"}
+    ]
+    
+    for request in invalid_requests:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=request, schema=schema)
+
+def test_invalid_name_type(schema):
+    """Tests invalid type for name parameter."""
+    invalid_name_types = [
+        {"req": "var.get", "name": 123},
+        {"req": "var.get", "name": True},
+        {"req": "var.get", "name": []},
+        {"req": "var.get", "name": {}},
+        {"cmd": "var.get", "name": None}
+    ]
+    
+    for instance in invalid_name_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_file_type(schema):
+    """Tests invalid type for file parameter."""
+    invalid_file_types = [
+        {"req": "var.get", "name": "test", "file": 123},
+        {"req": "var.get", "name": "test", "file": True},
+        {"req": "var.get", "name": "test", "file": []},
+        {"req": "var.get", "name": "test", "file": {}},
+        {"cmd": "var.get", "name": "test", "file": None}
+    ]
+    
+    for instance in invalid_file_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
+
+def test_file_parameter_optional(schema):
+    """Tests that file parameter is optional."""
+    valid_requests = [
+        {"req": "var.get", "name": "status"},  # No file parameter
+        {"cmd": "var.get", "name": "data"},    # No file parameter
+        {"req": "var.get", "name": "temp", "file": "sensors.db"},  # With file
+        {"cmd": "var.get", "name": "config", "file": "vars.db"}    # With file
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with additional property."""
+    instance = {
+        "req": "var.get",
+        "name": "status",
+        "extra": "not allowed"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {
+        "req": "var.get",
+        "name": "status",
+        "force": True,
+        "timeout": 30
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_variable_retrieval_scenarios(schema):
+    """Tests various realistic variable retrieval scenarios."""
+    scenarios = [
+        {"req": "var.get", "name": "status"},
+        {"req": "var.get", "name": "temperature", "file": "sensors.db"},
+        {"req": "var.get", "name": "humidity"},
+        {"req": "var.get", "name": "config_value", "file": "config.db"},
+        {"req": "var.get", "name": "device_status"},
+        {"cmd": "var.get", "name": "last_reading", "file": "data.db"},
+        {"cmd": "var.get", "name": "system_info"},
+        {"req": "var.get", "name": "user_preference", "file": "vars.db"}
+    ]
+    
+    for scenario in scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_request_type_validation(schema):
+    """Tests that request must be an object."""
+    invalid_types = ["string", 123, True, False, ["array"]]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_req_cmd_validation(schema):
+    """Tests req/cmd mutual exclusion and name requirement."""
+    # Only req with name should pass
+    jsonschema.validate(instance={"req": "var.get", "name": "test"}, schema=schema)
+    
+    # Only cmd with name should pass  
+    jsonschema.validate(instance={"cmd": "var.get", "name": "test"}, schema=schema)
+    
+    # Both req and cmd should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance={"req": "var.get", "cmd": "var.get", "name": "test"}, schema=schema)
+    
+    # Empty object should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance={}, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_empty_name_string(schema):
+    """Tests empty name string validation."""
+    valid_requests = [
+        {"req": "var.get", "name": ""},
+        {"cmd": "var.get", "name": ""}
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_var_get_rsp.py
+++ b/tests/test_var_get_rsp.py
@@ -22,7 +22,10 @@ def test_valid_value_response(schema):
         {"value": 42},
         {"value": 0},
         {"value": -10},
-        {"value": 1000}
+        {"value": 1000},
+        {"value": 23.5},
+        {"value": -12.34},
+        {"value": 0.0}
     ]
     
     for response in valid_responses:
@@ -65,8 +68,7 @@ def test_invalid_value_type(schema):
         {"value": True},
         {"value": []},
         {"value": {}},
-        {"value": None},
-        {"value": 12.34}  # Should be integer, not float
+        {"value": None}
     ]
     
     for instance in invalid_value_types:
@@ -141,13 +143,16 @@ def test_variable_retrieval_scenarios(schema):
     """Tests realistic variable retrieval response scenarios."""
     scenarios = [
         {"text": "open"},        # String value
-        {"value": 23},          # Temperature reading  
+        {"value": 23},          # Integer temperature reading  
+        {"value": 23.5},        # Float temperature reading
         {"flag": True},         # Boolean status
         {"text": "error"},      # Error message
         {"value": 0},           # Zero value
+        {"value": 0.0},         # Zero float value
         {"flag": False},        # False flag
         {"text": "active"},     # Status text
-        {"value": -5},          # Negative value
+        {"value": -5},          # Negative integer value
+        {"value": -12.34},      # Negative float value
         {}                      # Empty response (no variable found)
     ]
     
@@ -196,16 +201,22 @@ def test_strict_validation(schema):
             jsonschema.validate(instance=instance, schema=schema)
         assert "Additional properties are not allowed" in str(excinfo.value)
 
-def test_integer_edge_cases(schema):
-    """Tests edge cases for integer value field."""
-    valid_integer_responses = [
+def test_number_edge_cases(schema):
+    """Tests edge cases for numeric value field."""
+    valid_number_responses = [
         {"value": 0},
+        {"value": 0.0},
         {"value": -1},
+        {"value": -1.0},
         {"value": 2147483647},   # Max 32-bit signed int
-        {"value": -2147483648}   # Min 32-bit signed int
+        {"value": -2147483648},  # Min 32-bit signed int
+        {"value": 1.7976931348623157e+308},  # Large float
+        {"value": -1.7976931348623157e+308}, # Large negative float
+        {"value": 2.2250738585072014e-308},  # Small positive float
+        {"value": -2.2250738585072014e-308}  # Small negative float
     ]
     
-    for response in valid_integer_responses:
+    for response in valid_number_responses:
         jsonschema.validate(instance=response, schema=schema)
 
 def test_validate_samples_from_schema(schema, schema_samples):

--- a/tests/test_var_get_rsp.py
+++ b/tests/test_var_get_rsp.py
@@ -1,0 +1,222 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "var.get.rsp.notecard.api.json"
+
+def test_valid_text_response(schema):
+    """Tests valid response with text field."""
+    valid_responses = [
+        {"text": "open"},
+        {"text": "closed"},
+        {"text": "active"},
+        {"text": ""}
+    ]
+    
+    for response in valid_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_valid_value_response(schema):
+    """Tests valid response with value field."""
+    valid_responses = [
+        {"value": 42},
+        {"value": 0},
+        {"value": -10},
+        {"value": 1000}
+    ]
+    
+    for response in valid_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_valid_flag_response(schema):
+    """Tests valid response with flag field."""
+    valid_responses = [
+        {"flag": True},
+        {"flag": False}
+    ]
+    
+    for response in valid_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_valid_empty_response(schema):
+    """Tests valid empty response (all fields optional)."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_text_type(schema):
+    """Tests invalid type for text field."""
+    invalid_text_types = [
+        {"text": 123},
+        {"text": True},
+        {"text": []},
+        {"text": {}},
+        {"text": None}
+    ]
+    
+    for instance in invalid_text_types:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "is not of type 'string'" in str(excinfo.value)
+
+def test_invalid_value_type(schema):
+    """Tests invalid type for value field."""
+    invalid_value_types = [
+        {"value": "123"},
+        {"value": True},
+        {"value": []},
+        {"value": {}},
+        {"value": None},
+        {"value": 12.34}  # Should be integer, not float
+    ]
+    
+    for instance in invalid_value_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_flag_type(schema):
+    """Tests invalid type for flag field."""
+    invalid_flag_types = [
+        {"flag": "true"},
+        {"flag": 1},
+        {"flag": 0},
+        {"flag": []},
+        {"flag": {}},
+        {"flag": None}
+    ]
+    
+    for instance in invalid_flag_types:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "is not of type 'boolean'" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with additional property."""
+    instance = {
+        "text": "open",
+        "extra": "not allowed"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid response with multiple additional properties."""
+    instance = {
+        "text": "open",
+        "name": "status",
+        "timestamp": 1640995200
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"text": "open", "name": "status"},
+        {"value": 42, "id": "temperature"},
+        {"flag": True, "status": "ok"},
+        {"text": "test", "error": "none"},
+        {"value": 10, "result": "success"},
+        {"flag": False, "message": "retrieved"},
+        {"text": "data", "timestamp": 1640995200},
+        {"value": 25, "unit": "celsius"},
+        {"flag": True, "source": "sensor"}
+    ]
+    
+    for field_dict in invalid_fields:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = ["string", 123, True, False, ["array"]]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_variable_retrieval_scenarios(schema):
+    """Tests realistic variable retrieval response scenarios."""
+    scenarios = [
+        {"text": "open"},        # String value
+        {"value": 23},          # Temperature reading  
+        {"flag": True},         # Boolean status
+        {"text": "error"},      # Error message
+        {"value": 0},           # Zero value
+        {"flag": False},        # False flag
+        {"text": "active"},     # Status text
+        {"value": -5},          # Negative value
+        {}                      # Empty response (no variable found)
+    ]
+    
+    for scenario in scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_all_fields_optional(schema):
+    """Tests that all response fields are optional."""
+    valid_responses = [
+        {},                    # No fields
+        {"text": "value"},     # Only text
+        {"value": 42},         # Only value  
+        {"flag": True}         # Only flag
+    ]
+    
+    for response in valid_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_multiple_fields_allowed(schema):
+    """Tests that multiple response fields can be present together."""
+    # Note: While the API typically returns one field, the schema allows multiple
+    valid_responses = [
+        {"text": "status", "value": 1},
+        {"text": "active", "flag": True},
+        {"value": 42, "flag": False},
+        {"text": "test", "value": 10, "flag": True}
+    ]
+    
+    for response in valid_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_strict_validation(schema):
+    """Tests that schema enforces strict validation."""
+    properties_to_test = [
+        "name", "id", "status", "error", "message", "result", "data",
+        "timestamp", "unit", "source", "type", "format", "encoding"
+    ]
+    
+    for prop in properties_to_test:
+        instance = {"text": "test", prop: "value"}
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_integer_edge_cases(schema):
+    """Tests edge cases for integer value field."""
+    valid_integer_responses = [
+        {"value": 0},
+        {"value": -1},
+        {"value": 2147483647},   # Max 32-bit signed int
+        {"value": -2147483648}   # Min 32-bit signed int
+    ]
+    
+    for response in valid_integer_responses:
+        jsonschema.validate(instance=response, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/var.get.req.notecard.api.json
+++ b/var.get.req.notecard.api.json
@@ -4,11 +4,10 @@
     "title": "var.get Request Application Programming Interface (API) Schema",
     "description": "Retrieves a Note from a DB Notefile. Provides a simpler interface to the note.get API.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
-        "name": {
-            "description": "Name of the variable to get",
-            "type": "string"
-        },
         "cmd": {
             "description": "Command for the Notecard (no response)",
             "const": "var.get"
@@ -16,31 +15,63 @@
         "req": {
             "description": "Request for the Notecard (expects response)",
             "const": "var.get"
+        },
+        "name": {
+            "description": "The unique Note ID.",
+            "type": "string"
+        },
+        "file": {
+            "description": "The name of the DB Notefile that contains the Note to retrieve. Default value is `vars.db`.",
+            "type": "string"
         }
     },
     "oneOf": [
         {
             "required": [
-                "req"
+                "req",
+                "name"
             ],
             "properties": {
                 "req": {
                     "const": "var.get"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "string"
                 }
             }
         },
         {
             "required": [
-                "cmd"
+                "cmd",
+                "name"
             ],
             "properties": {
                 "cmd": {
                     "const": "var.get"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "string"
                 }
             }
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Retrieve Variable with Default File",
+            "description": "Retrieve a variable named 'status' from the default 'vars.db' DB Notefile.",
+            "json": "{\"req\": \"var.get\", \"name\": \"status\"}"
+        },
+        {
+            "title": "Retrieve Variable with Specific File",
+            "description": "Retrieve a variable named 'temperature' from the 'sensors.db' DB Notefile.",
+            "json": "{\"req\": \"var.get\", \"name\": \"temperature\", \"file\": \"sensors.db\"}"
+        }
+    ]
 }

--- a/var.get.rsp.notecard.api.json
+++ b/var.get.rsp.notecard.api.json
@@ -14,7 +14,7 @@
         },
         "value": {
             "description": "The numeric value stored in the DB Notefile.",
-            "type": "integer"
+            "type": "number"
         },
         "flag": {
             "description": "The boolean value stored in the DB Notefile.",

--- a/var.get.rsp.notecard.api.json
+++ b/var.get.rsp.notecard.api.json
@@ -2,17 +2,41 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/var.get.rsp.notecard.api.json",
     "title": "var.get Response Application Programming Interface (API) Schema",
+    "description": "Response containing a Note value from a DB Notefile.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
-        "name": {
-            "description": "Name of the variable",
+        "text": {
+            "description": "The string-based value stored in the DB Notefile.",
             "type": "string"
         },
-        "text": {
-            "description": "Value of the variable",
-            "type": "string"
+        "value": {
+            "description": "The numeric value stored in the DB Notefile.",
+            "type": "integer"
+        },
+        "flag": {
+            "description": "The boolean value stored in the DB Notefile.",
+            "type": "boolean"
         }
     },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Text Value Response",
+            "description": "Response containing a string value from the DB Notefile.",
+            "json": "{\"text\": \"open\"}"
+        },
+        {
+            "title": "Numeric Value Response",
+            "description": "Response containing a numeric value from the DB Notefile.",
+            "json": "{\"value\": 42}"
+        },
+        {
+            "title": "Boolean Flag Response",
+            "description": "Response containing a boolean value from the DB Notefile.",
+            "json": "{\"flag\": true}"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- Enhanced existing var.get schemas from v0.1.1 to v0.2.1 standards
- Complete rewrite of response schema to match API reference exactly
- Added proper field hierarchy ordering and SKU compatibility for all supported Notecards
- Implemented comprehensive test suites with full validation coverage

## Changes Made
- **var.get.req.notecard.api.json**: Enhanced to v0.2.1 with optional file parameter, proper oneOf validation requiring name parameter, and updated samples matching API reference
- **var.get.rsp.notecard.api.json**: Complete rewrite from incorrect schema structure to proper text/value/flag response fields, removed incorrect name field, added comprehensive samples
- **tests/test_var_get_req.py**: Comprehensive test coverage for request schema including file parameter validation
- **tests/test_var_get_rsp.py**: Comprehensive test coverage for response schema with all three response field types

## API Reference Alignment
- ✅ Request schema now includes both required `name` and optional `file` parameters
- ✅ Response schema correctly implements `text`, `value`, and `flag` response members
- ✅ Samples match the exact API reference examples
- ✅ All field descriptions match API reference documentation

## Test Results
✅ All 35 tests pass validation

🤖 Generated with [Claude Code](https://claude.ai/code)