### PR TITLE
feat: update var.set schemas to v0.2.1 with complete API alignment

### DIFF
--- a/tests/test_var_set_req.py
+++ b/tests/test_var_set_req.py
@@ -1,0 +1,306 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "var.set.req.notecard.api.json"
+
+def test_valid_text_requests(schema):
+    """Tests valid request formats with text parameter."""
+    valid_requests = [
+        {"req": "var.set", "name": "status", "text": "open"},
+        {"cmd": "var.set", "name": "message", "text": "hello"},
+        {"req": "var.set", "name": "status", "text": "active", "file": "sensors.db"},
+        {"cmd": "var.set", "name": "config", "text": "enabled", "sync": True}
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_valid_value_requests(schema):
+    """Tests valid request formats with value parameter."""
+    valid_requests = [
+        {"req": "var.set", "name": "temperature", "value": 23},
+        {"cmd": "var.set", "name": "count", "value": 0},
+        {"req": "var.set", "name": "humidity", "value": 65, "file": "sensors.db"},
+        {"cmd": "var.set", "name": "reading", "value": -10, "sync": True}
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_valid_flag_requests(schema):
+    """Tests valid request formats with flag parameter."""
+    valid_requests = [
+        {"req": "var.set", "name": "active", "flag": True},
+        {"cmd": "var.set", "name": "enabled", "flag": False},
+        {"req": "var.set", "name": "running", "flag": True, "file": "status.db"},
+        {"cmd": "var.set", "name": "connected", "flag": False, "sync": True}
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request with neither req nor cmd."""
+    instance = {"name": "status", "text": "open"}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request with both req and cmd."""
+    instance = {
+        "req": "var.set",
+        "cmd": "var.set",
+        "name": "status",
+        "text": "open"
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_req_value(schema):
+    """Tests invalid req value."""
+    instance = {
+        "req": "wrong.api",
+        "name": "status",
+        "text": "open"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'var.set' was expected" in str(excinfo.value)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid cmd value."""
+    instance = {
+        "cmd": "wrong.api",
+        "name": "status",
+        "text": "open"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "'var.set' was expected" in str(excinfo.value)
+
+def test_missing_name_parameter(schema):
+    """Tests invalid request missing required name parameter."""
+    invalid_requests = [
+        {"req": "var.set", "text": "open"},
+        {"cmd": "var.set", "value": 42},
+        {"req": "var.set", "flag": True}
+    ]
+    
+    for request in invalid_requests:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=request, schema=schema)
+
+def test_missing_value_parameter(schema):
+    """Tests invalid request missing required value parameter (text, value, or flag)."""
+    invalid_requests = [
+        {"req": "var.set", "name": "status"},
+        {"cmd": "var.set", "name": "temperature"},
+        {"req": "var.set", "name": "active", "file": "test.db"},
+        {"cmd": "var.set", "name": "config", "sync": True}
+    ]
+    
+    for request in invalid_requests:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=request, schema=schema)
+
+def test_invalid_name_type(schema):
+    """Tests invalid type for name parameter."""
+    invalid_name_types = [
+        {"req": "var.set", "name": 123, "text": "open"},
+        {"req": "var.set", "name": True, "value": 42},
+        {"req": "var.set", "name": [], "flag": False},
+        {"req": "var.set", "name": {}, "text": "test"},
+        {"cmd": "var.set", "name": None, "value": 10}
+    ]
+    
+    for instance in invalid_name_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_file_type(schema):
+    """Tests invalid type for file parameter."""
+    invalid_file_types = [
+        {"req": "var.set", "name": "test", "text": "value", "file": 123},
+        {"req": "var.set", "name": "test", "value": 42, "file": True},
+        {"req": "var.set", "name": "test", "flag": False, "file": []},
+        {"req": "var.set", "name": "test", "text": "test", "file": {}},
+        {"cmd": "var.set", "name": "test", "value": 10, "file": None}
+    ]
+    
+    for instance in invalid_file_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_text_type(schema):
+    """Tests invalid type for text parameter."""
+    invalid_text_types = [
+        {"req": "var.set", "name": "test", "text": 123},
+        {"req": "var.set", "name": "test", "text": True},
+        {"req": "var.set", "name": "test", "text": []},
+        {"req": "var.set", "name": "test", "text": {}},
+        {"cmd": "var.set", "name": "test", "text": None}
+    ]
+    
+    for instance in invalid_text_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_value_type(schema):
+    """Tests invalid type for value parameter."""
+    invalid_value_types = [
+        {"req": "var.set", "name": "test", "value": "123"},
+        {"req": "var.set", "name": "test", "value": True},
+        {"req": "var.set", "name": "test", "value": []},
+        {"req": "var.set", "name": "test", "value": {}},
+        {"cmd": "var.set", "name": "test", "value": None},
+        {"req": "var.set", "name": "test", "value": 12.34}  # Should be integer
+    ]
+    
+    for instance in invalid_value_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_flag_type(schema):
+    """Tests invalid type for flag parameter."""
+    invalid_flag_types = [
+        {"req": "var.set", "name": "test", "flag": "true"},
+        {"req": "var.set", "name": "test", "flag": 1},
+        {"req": "var.set", "name": "test", "flag": 0},
+        {"req": "var.set", "name": "test", "flag": []},
+        {"req": "var.set", "name": "test", "flag": {}},
+        {"cmd": "var.set", "name": "test", "flag": None}
+    ]
+    
+    for instance in invalid_flag_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_sync_type(schema):
+    """Tests invalid type for sync parameter."""
+    invalid_sync_types = [
+        {"req": "var.set", "name": "test", "text": "value", "sync": "true"},
+        {"req": "var.set", "name": "test", "value": 42, "sync": 1},
+        {"req": "var.set", "name": "test", "flag": True, "sync": 0},
+        {"req": "var.set", "name": "test", "text": "test", "sync": []},
+        {"cmd": "var.set", "name": "test", "value": 10, "sync": {}}
+    ]
+    
+    for instance in invalid_sync_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
+
+def test_multiple_value_parameters(schema):
+    """Tests requests with multiple value parameters (should be valid)."""
+    valid_requests = [
+        {"req": "var.set", "name": "test", "text": "hello", "value": 42},
+        {"cmd": "var.set", "name": "test", "text": "active", "flag": True},
+        {"req": "var.set", "name": "test", "value": 10, "flag": False},
+        {"cmd": "var.set", "name": "test", "text": "data", "value": 25, "flag": True}
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_optional_parameters(schema):
+    """Tests that file and sync parameters are optional."""
+    valid_requests = [
+        {"req": "var.set", "name": "status", "text": "open"},  # No optional params
+        {"cmd": "var.set", "name": "count", "value": 5, "file": "data.db"},  # Only file
+        {"req": "var.set", "name": "active", "flag": True, "sync": True},  # Only sync
+        {"cmd": "var.set", "name": "temp", "value": 23, "file": "sensors.db", "sync": False}  # Both optional
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with additional property."""
+    instance = {
+        "req": "var.set",
+        "name": "status",
+        "text": "open",
+        "extra": "not allowed"
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests invalid request with multiple additional properties."""
+    instance = {
+        "req": "var.set",
+        "name": "status",
+        "text": "open",
+        "force": True,
+        "timeout": 30
+    }
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_variable_setting_scenarios(schema):
+    """Tests various realistic variable setting scenarios."""
+    scenarios = [
+        {"req": "var.set", "name": "status", "text": "open"},
+        {"req": "var.set", "name": "temperature", "value": 23, "file": "sensors.db"},
+        {"req": "var.set", "name": "active", "flag": True, "sync": True},
+        {"cmd": "var.set", "name": "humidity", "value": 65},
+        {"cmd": "var.set", "name": "message", "text": "hello world", "file": "messages.db"},
+        {"req": "var.set", "name": "enabled", "flag": False},
+        {"cmd": "var.set", "name": "counter", "value": 0, "sync": False},
+        {"req": "var.set", "name": "config", "text": "production", "file": "config.db", "sync": True}
+    ]
+    
+    for scenario in scenarios:
+        jsonschema.validate(instance=scenario, schema=schema)
+
+def test_request_type_validation(schema):
+    """Tests that request must be an object."""
+    invalid_types = ["string", 123, True, False, ["array"]]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_req_cmd_validation(schema):
+    """Tests req/cmd mutual exclusion and required parameters."""
+    # Valid requests with required parameters
+    jsonschema.validate(instance={"req": "var.set", "name": "test", "text": "value"}, schema=schema)
+    jsonschema.validate(instance={"cmd": "var.set", "name": "test", "value": 42}, schema=schema)
+    
+    # Both req and cmd should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance={"req": "var.set", "cmd": "var.set", "name": "test", "text": "value"}, schema=schema)
+    
+    # Empty object should fail
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance={}, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_empty_string_values(schema):
+    """Tests empty string values for name and text."""
+    valid_requests = [
+        {"req": "var.set", "name": "", "text": "value"},
+        {"req": "var.set", "name": "test", "text": ""},
+        {"cmd": "var.set", "name": "", "text": "", "file": ""}
+    ]
+    
+    for request in valid_requests:
+        jsonschema.validate(instance=request, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_var_set_rsp.py
+++ b/tests/test_var_set_rsp.py
@@ -1,0 +1,192 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "var.set.rsp.notecard.api.json"
+
+def test_valid_empty_response(schema):
+    """Tests the valid empty response as per API reference."""
+    instance = {}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property_single(schema):
+    """Tests invalid response with single additional property."""
+    instance = {"extra": "not allowed"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_name(schema):
+    """Tests invalid response with legacy name property."""
+    instance = {"name": "status"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_additional_property_text(schema):
+    """Tests invalid response with legacy text property."""
+    instance = {"text": "open"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_common_additional_properties(schema):
+    """Tests that common additional properties are not allowed."""
+    invalid_fields = [
+        {"name": "status"},
+        {"text": "value"},
+        {"value": 42},
+        {"flag": True},
+        {"status": "ok"},
+        {"message": "variable set"},
+        {"error": "none"},
+        {"result": "success"},
+        {"success": True},
+        {"updated": True},
+        {"timestamp": 1640995200},
+        {"file": "vars.db"},
+        {"sync": True}
+    ]
+    
+    for field_dict in invalid_fields:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=field_dict, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_invalid_multiple_additional_properties(schema):
+    """Tests that multiple additional properties are not allowed."""
+    instance = {"status": "ok", "message": "variable set", "success": True}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_response_type_validation(schema):
+    """Tests that response must be an object."""
+    invalid_types = ["string", 123, True, False, ["array"]]
+    
+    for invalid_instance in invalid_types:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=invalid_instance, schema=schema)
+
+def test_additional_properties_false(schema):
+    """Tests that additionalProperties is set to false."""
+    assert schema.get("additionalProperties") is False
+
+def test_strict_validation(schema):
+    """Tests that schema enforces strict validation."""
+    properties_to_test = [
+        "name", "text", "value", "flag", "file", "sync", "status", "error", 
+        "message", "result", "data", "success", "updated", "created", "modified",
+        "timestamp", "id", "type", "format", "encoding", "response", "output"
+    ]
+    
+    for prop in properties_to_test:
+        instance = {prop: "test"}
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=instance, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_empty_properties_validation(schema):
+    """Tests that response schema has empty properties and strict validation."""
+    # Schema should have empty properties
+    properties = schema.get("properties", {})
+    assert properties == {}, f"Expected empty properties, got: {properties}"
+    
+    # Only empty object should be valid
+    jsonschema.validate(instance={}, schema=schema)
+    
+    # Any fields should be invalid
+    invalid_responses = [
+        {"any_field": "value"},
+        {"status": "success"}, 
+        {"variable_set": True},
+        {"name": "temperature"},
+        {"text": "updated"}
+    ]
+    
+    for response in invalid_responses:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=response, schema=schema)
+
+def test_variable_set_scenarios(schema):
+    """Tests that only empty response is valid for var.set operations."""
+    # Only empty response should be valid
+    jsonschema.validate(instance={}, schema=schema)
+    
+    # All other responses should be invalid
+    invalid_scenarios = [
+        {"name": "status", "text": "open"},
+        {"success": True},
+        {"updated": True},
+        {"message": "Variable set successfully"},
+        {"result": "ok"},
+        {"error": None},
+        {"timestamp": 1640995200}
+    ]
+    
+    for scenario in invalid_scenarios:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=scenario, schema=schema)
+
+def test_legacy_response_properties_invalid(schema):
+    """Tests that legacy response properties from v0.1.1 are no longer valid."""
+    legacy_properties = [
+        {"name": "temperature"},
+        {"text": "23"},
+        {"name": "status", "text": "active"},
+        {"name": "flag", "text": "true"}
+    ]
+    
+    for legacy_response in legacy_properties:
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            jsonschema.validate(instance=legacy_response, schema=schema)
+        assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_api_reference_compliance(schema):
+    """Tests that response schema complies with API reference (no response members)."""
+    # API reference shows no response members, so only empty object should be valid
+    jsonschema.validate(instance={}, schema=schema)
+    
+    # Any properties should be invalid per API reference
+    potential_properties = [
+        {"text": "value"},
+        {"value": 42},
+        {"flag": True},
+        {"file": "vars.db"},
+        {"sync": True},
+        {"name": "variable"}
+    ]
+    
+    for prop_response in potential_properties:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=prop_response, schema=schema)
+
+def test_schema_structure_validation(schema):
+    """Tests the overall schema structure is correct."""
+    # Check required schema fields
+    assert schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema"
+    assert schema.get("type") == "object"
+    assert schema.get("version") == "0.2.1"
+    assert schema.get("apiVersion") == "9.1.1"
+    assert schema.get("additionalProperties") is False
+    
+    # Check properties is empty
+    assert schema.get("properties") == {}
+    
+    # Check samples exist
+    samples = schema.get("samples", [])
+    assert len(samples) > 0
+    assert all("json" in sample for sample in samples)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+
+        jsonschema.validate(instance=instance, schema=schema)

--- a/var.set.req.notecard.api.json
+++ b/var.set.req.notecard.api.json
@@ -4,15 +4,10 @@
     "title": "var.set Request Application Programming Interface (API) Schema",
     "description": "Adds or updates a Note in a DB Notefile, replacing the existing body with the specified key-value pair where text, value, or flag is the key. Provides a simpler interface to the note.update API.",
     "type": "object",
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
     "properties": {
-        "name": {
-            "description": "Name of the variable to set",
-            "type": "string"
-        },
-        "text": {
-            "description": "Value to set for the variable",
-            "type": "string"
-        },
         "cmd": {
             "description": "Command for the Notecard (no response)",
             "const": "var.set"
@@ -20,31 +15,130 @@
         "req": {
             "description": "Request for the Notecard (expects response)",
             "const": "var.set"
+        },
+        "name": {
+            "description": "The unique Note ID.",
+            "type": "string"
+        },
+        "file": {
+            "description": "The name of the DB Notefile that contains the Note to add or update. Default value is `vars.db`.",
+            "type": "string"
+        },
+        "text": {
+            "description": "The string-based value to be stored in the DB Notefile.",
+            "type": "string"
+        },
+        "value": {
+            "description": "The numeric value to be stored in the DB Notefile.",
+            "type": "integer"
+        },
+        "flag": {
+            "description": "The boolean value to be stored in the DB Notefile.",
+            "type": "boolean"
+        },
+        "sync": {
+            "description": "Set to `true` to immediately sync any changes.",
+            "type": "boolean"
         }
     },
     "oneOf": [
         {
             "required": [
-                "req"
+                "req",
+                "name"
             ],
             "properties": {
                 "req": {
                     "const": "var.set"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "integer"
+                },
+                "flag": {
+                    "type": "boolean"
+                },
+                "sync": {
+                    "type": "boolean"
                 }
-            }
+            },
+            "anyOf": [
+                {
+                    "required": ["text"]
+                },
+                {
+                    "required": ["value"]
+                },
+                {
+                    "required": ["flag"]
+                }
+            ]
         },
         {
             "required": [
-                "cmd"
+                "cmd",
+                "name"
             ],
             "properties": {
                 "cmd": {
                     "const": "var.set"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "integer"
+                },
+                "flag": {
+                    "type": "boolean"
+                },
+                "sync": {
+                    "type": "boolean"
                 }
-            }
+            },
+            "anyOf": [
+                {
+                    "required": ["text"]
+                },
+                {
+                    "required": ["value"]
+                },
+                {
+                    "required": ["flag"]
+                }
+            ]
         }
     ],
     "additionalProperties": false,
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    "samples": [
+        {
+            "title": "Set Text Variable",
+            "description": "Set a text variable named 'status' to 'open' in the default 'vars.db' DB Notefile.",
+            "json": "{\"req\": \"var.set\", \"name\": \"status\", \"text\": \"open\"}"
+        },
+        {
+            "title": "Set Numeric Variable",
+            "description": "Set a numeric variable named 'temperature' to 23 in a specific DB Notefile.",
+            "json": "{\"req\": \"var.set\", \"name\": \"temperature\", \"value\": 23, \"file\": \"sensors.db\"}"
+        },
+        {
+            "title": "Set Boolean Variable with Sync",
+            "description": "Set a boolean variable named 'active' to true and immediately sync changes.",
+            "json": "{\"req\": \"var.set\", \"name\": \"active\", \"flag\": true, \"sync\": true}"
+        }
+    ]
 }

--- a/var.set.rsp.notecard.api.json
+++ b/var.set.rsp.notecard.api.json
@@ -2,17 +2,18 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/var.set.rsp.notecard.api.json",
     "title": "var.set Response Application Programming Interface (API) Schema",
+    "description": "Response confirming successful addition or update of a Note in a DB Notefile.",
     "type": "object",
-    "properties": {
-        "name": {
-            "description": "Name of the variable",
-            "type": "string"
-        },
-        "text": {
-            "description": "Value of the variable",
-            "type": "string"
+    "version": "0.2.1",
+    "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "LORA", "WIFI"],
+    "properties": {},
+    "additionalProperties": false,
+    "samples": [
+        {
+            "title": "Successful Variable Set Response",
+            "description": "Empty response confirming variable has been set successfully.",
+            "json": "{}"
         }
-    },
-    "version": "0.1.1",
-    "apiVersion": "9.1.1"
+    ]
 }


### PR DESCRIPTION
## Summary
- Enhanced existing var.set schemas from v0.1.1 to v0.2.1 standards
- Complete rewrite of both request and response schemas to match API reference exactly
- Added proper field hierarchy ordering and SKU compatibility for all supported Notecards
- Implemented comprehensive test suites with advanced validation logic

## Changes Made
- **var.set.req.notecard.api.json**: Major enhancement with all missing parameters (file, value, flag, sync) and complex validation requiring name + at least one of (text/value/flag)
- **var.set.rsp.notecard.api.json**: Complete rewrite to return empty response per API reference (removed incorrect name/text fields)
- **tests/test_var_set_req.py**: Comprehensive test coverage for complex request validation including anyOf logic
- **tests/test_var_set_rsp.py**: Comprehensive test coverage for strict empty response validation

## API Reference Alignment
- ✅ Request schema supports all parameter types: name (required), file (optional), text/value/flag (at least one required), sync (optional)
- ✅ Complex validation ensures at least one value parameter (text, value, or flag) is provided using anyOf
- ✅ Response schema correctly implements empty response with no members per API reference
- ✅ All parameter descriptions and types match API reference documentation exactly
- ✅ Samples demonstrate all parameter combinations and usage patterns

## Advanced Schema Features
- **Complex Validation**: Uses oneOf + anyOf to require name + at least one of (text/value/flag)
- **Type Safety**: Strict integer validation for value parameter, proper boolean for flag
- **Multiple Value Support**: Allows combining text, value, and flag parameters in single request
- **Default Documentation**: Proper file parameter default value documentation (vars.db)

## Test Results
✅ All 40 tests pass validation

🤖 Generated with [Claude Code](https://claude.ai/code)