### PR TITLE
feat: enhance web.delete schemas with required route validation and comprehensive test coverage

### DIFF
--- a/tests/test_web_delete_req.py
+++ b/tests/test_web_delete_req.py
@@ -1,0 +1,142 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "web.delete.req.notecard.api.json"
+
+def test_valid_req(schema):
+    """Tests a minimal valid request using 'req'."""
+    instance = {"req": "web.delete", "route": "SensorService"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_cmd(schema):
+    """Tests a minimal valid request using 'cmd'."""
+    instance = {"cmd": "web.delete", "route": "SensorService"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_no_req_or_cmd(schema):
+    """Tests invalid request missing req/cmd."""
+    instance = {"route": "SensorService"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not valid under any of the given schemas" in str(excinfo.value)
+
+def test_invalid_both_req_and_cmd(schema):
+    """Tests invalid request having both req and cmd."""
+    instance = {"req": "web.delete", "cmd": "web.delete", "route": "SensorService"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is valid under each of" in str(excinfo.value)
+
+def test_invalid_req_value(schema):
+    """Tests invalid value for req."""
+    instance = {"req": "invalid.req", "route": "SensorService"}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_cmd_value(schema):
+    """Tests invalid value for cmd."""
+    instance = {"cmd": "invalid.cmd", "route": "SensorService"}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_with_route_and_name(schema):
+    """Tests valid request with route and name."""
+    instance = {"req": "web.delete", "route": "SensorService", "name": "/deleteReading?id=1"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_with_content(schema):
+    """Tests valid request with content type."""
+    instance = {"req": "web.delete", "route": "SensorService", "content": "application/json"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_with_seconds(schema):
+    """Tests valid request with timeout."""
+    instance = {"req": "web.delete", "route": "SensorService", "seconds": 120}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_seconds_type(schema):
+    """Tests invalid type for seconds."""
+    instance = {"req": "web.delete", "route": "SensorService", "seconds": "120"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_valid_with_async(schema):
+    """Tests valid request with async flag."""
+    instance = {"req": "web.delete", "route": "SensorService", "async": True}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_async_type(schema):
+    """Tests invalid type for async."""
+    instance = {"req": "web.delete", "route": "SensorService", "async": "true"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'boolean'" in str(excinfo.value)
+
+def test_valid_with_file_and_note(schema):
+    """Tests valid request with file and note parameters."""
+    instance = {"req": "web.delete", "route": "SensorService", "file": "response.dbx", "note": "response1"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_file_type(schema):
+    """Tests invalid type for file."""
+    instance = {"req": "web.delete", "route": "SensorService", "file": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_invalid_note_type(schema):
+    """Tests invalid type for note."""
+    instance = {"req": "web.delete", "route": "SensorService", "note": 123}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid request with an additional property."""
+    instance = {"req": "web.delete", "route": "SensorService", "extra": "field"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+
+def test_valid_complex_request(schema):
+    """Tests a complex valid request with multiple parameters."""
+    instance = {
+        "req": "web.delete",
+        "route": "SensorService",
+        "name": "/deleteReading?id=1",
+        "content": "application/json",
+        "seconds": 90
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_async_request(schema):
+    """Tests a valid asynchronous request with file storage."""
+    instance = {
+        "req": "web.delete",
+        "route": "DataService",
+        "name": "/bulk-delete",
+        "async": True,
+        "file": "delete-response.dbx",
+        "note": "bulk-delete-001"
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_missing_route(schema):
+    """Tests invalid request missing required route parameter."""
+    instance = {"req": "web.delete"}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+        jsonschema.validate(instance=instance, schema=schema)

--- a/tests/test_web_delete_rsp.py
+++ b/tests/test_web_delete_rsp.py
@@ -1,0 +1,143 @@
+import pytest
+import jsonschema
+import json
+
+SCHEMA_FILE = "web.delete.rsp.notecard.api.json"
+
+def test_valid_minimal(schema):
+    """Tests a minimal valid response with just result."""
+    instance = {"result": 204}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_with_body(schema):
+    """Tests a valid response with a body object."""
+    instance = {"result": 200, "body": {"message": "Resource deleted successfully"}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_with_payload(schema):
+    """Tests a valid response with base64 payload."""
+    instance = {"result": 200, "payload": "SGVsbG8gV29ybGQ="}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_with_status(schema):
+    """Tests a valid response with status (32-character hex-encoded MD5 sum)."""
+    instance = {"result": 200, "status": "5d41402abc4b2a76b9719d911017c592"}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_complete_response(schema):
+    """Tests a complete response with all possible fields."""
+    instance = {
+        "result": 200,
+        "body": {"message": "Success", "deleted_count": 1},
+        "payload": "SGVsbG8gV29ybGQ=",
+        "status": "5d41402abc4b2a76b9719d911017c592"
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_result_type(schema):
+    """Tests invalid type for result (should be integer)."""
+    instance = {"result": "204"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'integer'" in str(excinfo.value)
+
+def test_invalid_body_type(schema):
+    """Tests invalid type for body (should be object)."""
+    instance = {"result": 200, "body": "not-an-object"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'object'" in str(excinfo.value)
+
+def test_invalid_payload_type(schema):
+    """Tests invalid type for payload (should be string)."""
+    instance = {"result": 200, "payload": 12345}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_invalid_status_type(schema):
+    """Tests invalid type for status (should be string)."""
+    instance = {"result": 200, "status": 12345}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "is not of type 'string'" in str(excinfo.value)
+
+def test_valid_http_status_codes(schema):
+    """Tests valid HTTP status codes."""
+    for status_code in [200, 204, 400, 401, 404, 500, 502, 503]:
+        instance = {"result": status_code}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_empty_body(schema):
+    """Tests valid response with empty body object."""
+    instance = {"result": 200, "body": {}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_complex_body(schema):
+    """Tests valid response with complex body object."""
+    instance = {
+        "result": 200,
+        "body": {
+            "message": "Delete operation completed",
+            "data": {
+                "deleted_items": ["item1", "item2", "item3"],
+                "deletion_time": "2023-01-01T12:00:00Z",
+                "metadata": {
+                    "total_deleted": 3,
+                    "cascade_deletions": 5
+                }
+            },
+            "warnings": [
+                "Some related records were automatically deleted"
+            ]
+        }
+    }
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_delete_specific_status_codes(schema):
+    """Tests HTTP status codes common for DELETE operations."""
+    # 200 OK - successful deletion with response body
+    instance = {"result": 200, "body": {"deleted": True}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+    # 204 No Content - successful deletion with no response body
+    instance = {"result": 204}
+    jsonschema.validate(instance=instance, schema=schema)
+
+    # 404 Not Found - resource to delete was not found
+    instance = {"result": 404, "body": {"error": "Resource not found"}}
+    jsonschema.validate(instance=instance, schema=schema)
+
+def test_valid_error_responses(schema):
+    """Tests valid error response formats."""
+    error_cases = [
+        (400, {"error": "Bad Request", "message": "Invalid resource ID"}),
+        (401, {"error": "Unauthorized", "message": "Authentication required"}),
+        (403, {"error": "Forbidden", "message": "Insufficient permissions"}),
+        (404, {"error": "Not Found", "message": "Resource does not exist"}),
+        (409, {"error": "Conflict", "message": "Resource cannot be deleted due to dependencies"}),
+        (500, {"error": "Internal Server Error", "message": "Database connection failed"})
+    ]
+
+    for status_code, body in error_cases:
+        instance = {"result": status_code, "body": body}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_invalid_additional_property(schema):
+    """Tests invalid response with additional property (not allowed)."""
+    instance = {"result": 200, "extra": "field"}
+    with pytest.raises(jsonschema.ValidationError) as excinfo:
+        jsonschema.validate(instance=instance, schema=schema)
+    assert "Additional properties are not allowed" in str(excinfo.value)
+
+def test_validate_samples_from_schema(schema, schema_samples):
+    """Tests that samples in the schema definition are valid."""
+    for sample in schema_samples:
+        sample_json_str = sample.get("json")
+        if not sample_json_str:
+            pytest.fail(f"Sample missing 'json' field: {sample.get('description', 'Unnamed sample')}")
+        try:
+            instance = json.loads(sample_json_str)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Failed to parse sample JSON: {sample_json_str}\nError: {e}")
+        jsonschema.validate(instance=instance, schema=schema)

--- a/web.delete.req.notecard.api.json
+++ b/web.delete.req.notecard.api.json
@@ -50,21 +50,29 @@
     "oneOf": [
         {
             "required": [
-                "req"
+                "req",
+                "route"
             ],
             "properties": {
                 "req": {
                     "const": "web.delete"
+                },
+                "route": {
+                    "type": "string"
                 }
             }
         },
         {
             "required": [
-                "cmd"
+                "cmd",
+                "route"
             ],
             "properties": {
                 "cmd": {
                     "const": "web.delete"
+                },
+                "route": {
+                    "type": "string"
                 }
             }
         }

--- a/web.delete.rsp.notecard.api.json
+++ b/web.delete.rsp.notecard.api.json
@@ -2,9 +2,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/blues/notecard-schema/master/web.delete.rsp.notecard.api.json",
     "title": "web.delete Response Application Programming Interface (API) Schema",
+    "description": "Response containing the result of an HTTP or HTTPS DELETE request to an external endpoint.",
     "type": "object",
     "version": "0.2.1",
     "apiVersion": "9.1.1",
+    "skus": ["CELL", "CELL+WIFI", "WIFI"],
     "properties": {
         "result": {
             "description": "The HTTP Status Code",
@@ -24,6 +26,7 @@
             "type": "string"
         }
     },
+    "additionalProperties": false,
     "samples": [
         {
             "description": "Example Response",


### PR DESCRIPTION
## Summary
- Fix critical validation gap by making route parameter required (matching recent web.get/web.post/web.put fixes)
- Complete v0.2.1 compliance for response schema with missing required fields
- **Create first-ever complete test coverage for web.delete API** (36 new tests)
- Enhanced validation coverage for DELETE-specific scenarios and HTTP status codes

## Key Changes
- **Required route validation**: Prevents invalid requests missing essential route parameter
- **Response schema completion**: Added description, skus, and additionalProperties fields
- **Comprehensive test suite**: Full request/response validation with DELETE-specific test cases
- **HTTP status validation**: Proper testing of 200, 204, 404 and error responses

## Test plan  
- [x] All 2980+ existing tests pass (gained 36 new tests)
- [x] Route parameter requirement properly enforced
- [x] Response schema strict validation working correctly
- [x] Schema samples validate successfully  
- [x] DELETE-specific status codes properly tested
- [x] Error response formats validated
- [x] Backward compatibility maintained for valid requests

🤖 Generated with [Claude Code](https://claude.ai/code)