### PR TITLE
feat: add OpenAPI 3.1 spec generation with safety semantics

### DIFF
--- a/notecard-api.openapi.json
+++ b/notecard-api.openapi.json
@@ -1,0 +1,12070 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Notecard API",
+    "description": "Machine-generated OpenAPI 3.1 specification for the Blues Notecard API, derived from the notecard-schema JSON Schema files with safety semantics annotations.",
+    "version": "9.1.1",
+    "contact": {
+      "name": "Blues Inc.",
+      "url": "https://blues.com"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "paths": {
+    "/card/attn": {
+      "put": {
+        "operationId": "card_attn",
+        "summary": "Configure hardware notifications from a Notecard to a host MCU.\n\n_**NOTE:** Requires a connection between the Notecard ATTN pin and a GPIO pin on the host MCU._",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.attn",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.attn Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "files": {
+                    "description": "A list of [Notefiles](https://dev.blues.io/api-reference/glossary/#notefile) to watch for file-based interrupts.",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^.+\\.(qo|qi|db|dbs)$"
+                    },
+                    "minItems": 1
+                  },
+                  "mode": {
+                    "description": "A comma-separated list of one or more of the following keywords. Some keywords are only supported on certain types of Notecards.",
+                    "type": "string",
+                    "pattern": "^(?:-all|-env|-files|-location|-motion|-usb|arm|auxgpio|connected|disarm|env|files|location|motion|motionchange|rearm|signal|sleep|usb|watchdog|wireless)(?:,\\s*(?:-all|-env|-files|-location|-motion|-usb|arm|auxgpio|connected|disarm|env|files|location|motion|motionchange|rearm|signal|sleep|usb|watchdog|wireless))*\\s*$",
+                    "x-sub-descriptions": [
+                      {
+                        "const": "",
+                        "description": "Queries the current ATTN pin state.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "arm",
+                        "description": "Clear \"files\" events and cause the ATTN pin to go LOW. After an event occurs or \"seconds\" has elapsed, the ATTN pin will then go HIGH (a.k.a. \"fires\"). If \"seconds\" is 0, no timeout will be scheduled. If ATTN is armed, calling `arm` again will disarm (briefly pulling ATTN HIGH), then arm (non-idempotent).",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "auxgpio",
+                        "description": "When armed, causes ATTN to fire if an AUX GPIO input changes. Disable by using `-auxgpio`.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.4.1"
+                      },
+                      {
+                        "const": "connected",
+                        "description": "When armed, will cause ATTN to fire whenever the module connects to cellular. Disable with `-connected`.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "disarm",
+                        "description": "Causes ATTN pin to go HIGH if it had been LOW.\n\nPassing both `\"disarm\"` and `\"-all\"` clears all ATTN monitors currently set.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.2.1"
+                      },
+                      {
+                        "const": "env",
+                        "description": "When armed, causes ATTN to fire if an environment variable changes on the Notecard. Disable by using `-env`.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.4.1"
+                      },
+                      {
+                        "const": "files",
+                        "description": "When armed, will cause ATTN to fire if any of the \"files\" are modified. Disable by using `-files`.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "location",
+                        "description": "When armed, will cause ATTN to fire whenever the Notecard GPS module makes a position fix. Disable by using `-location`.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "motion",
+                        "description": "When armed, will cause ATTN to fire whenever the accelerometer detects module motion. Disable with `-motion`.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "motionchange",
+                        "description": "When armed, will cause ATTN to fire whenever the `card.motion.mode` changes from \"moving\" to \"stopped\" (or vice versa). Learn how to configure this feature [in this guide](https://dev.blues.io/guides-and-tutorials/notecard-guides/asset-tracking-with-gps/#wake-host-or-send-note-on-motion-status-change).",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "6.1.1"
+                      },
+                      {
+                        "const": "rearm",
+                        "description": "Will arm ATTN if not already armed. Otherwise, resets the values of `mode`, `files`, and `seconds` specified in the initial `arm` or `rearm` request (idempotent).",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "signal",
+                        "description": "When armed, will cause ATTN to fire whenever the Notecard receives a [signal](https://dev.blues.io/api-reference/glossary/#signal).",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "sleep",
+                        "description": "Instruct the Notecard to pull the ATTN pin low for a period of time, and optionally keep a payload in memory. Can be used by the host to sleep the host MCU.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "usb",
+                        "description": "When armed, will enable USB power events firing the ATTN pin. Disable with `-usb`.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "watchdog",
+                        "description": "Not an \"arm\" mode, rather will cause the ATTN pin to go from HIGH to LOW, then HIGH if the notecard fails to receive any JSON requests for \"seconds.\" In this mode, \"seconds\" must be >= 60.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "wireless",
+                        "description": "Instruct the Notecard to fire the ATTN pin whenever the `card.wireless` [status](https://dev.blues.io/api-reference/notecard-api/card-requests/#card-wireless) changes.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      }
+                    ]
+                  },
+                  "off": {
+                    "description": "When `true`, completely disables ATTN processing and sets the pin OFF. This setting is retained across device restarts.",
+                    "type": "boolean",
+                    "x-min-api-version": "7.2.1"
+                  },
+                  "on": {
+                    "description": "When `true`, enables ATTN processing. This setting is retained across device restarts.",
+                    "type": "boolean"
+                  },
+                  "payload": {
+                    "description": "When using `sleep` mode, a payload of data from the host that the Notecard should hold in memory until retrieved by the host.",
+                    "type": "string",
+                    "format": "binary",
+                    "contentEncoding": "base64"
+                  },
+                  "seconds": {
+                    "description": "To set an ATTN timeout when arming, or when using `sleep`.\n\n_**NOTE:** When the Notecard is in `continuous` mode, the `seconds` timeout is serviced by a routine that wakes every 15 seconds. You can predict when the device will wake, by rounding up to the nearest 15 second interval._",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "start": {
+                    "description": "When using `sleep` mode and the host has reawakened, request the Notecard to return the stored `payload`.",
+                    "type": "boolean"
+                  },
+                  "verify": {
+                    "description": "When `true`, returns the current attention mode configuration, if any.",
+                    "type": "boolean",
+                    "x-min-api-version": "3.2.1"
+                  }
+                },
+                "additionalProperties": false,
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "pattern": "(^watchdog$|^watchdog,|,*\\s*watchdog\\s*,|,*\\s*watchdog$)"
+                        }
+                      },
+                      "required": [
+                        "mode"
+                      ]
+                    },
+                    "then": {
+                      "properties": {
+                        "seconds": {
+                          "minimum": 60
+                        }
+                      },
+                      "required": [
+                        "seconds"
+                      ]
+                    },
+                    "else": {
+                      "if": {
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "pattern": "(^sleep$|^sleep,|,*\\s*sleep\\s*,|,*\\s*sleep$)"
+                          }
+                        },
+                        "required": [
+                          "mode"
+                        ]
+                      },
+                      "then": {
+                        "properties": {
+                          "seconds": {
+                            "minimum": -1
+                          }
+                        },
+                        "required": [
+                          "seconds"
+                        ]
+                      },
+                      "else": {
+                        "not": {
+                          "required": [
+                            "seconds"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "pattern": "(^files$|^files,|,*\\s*files\\s*,|,*\\s*files$)"
+                        }
+                      },
+                      "required": [
+                        "mode"
+                      ]
+                    },
+                    "then": {
+                      "required": [
+                        "files"
+                      ]
+                    },
+                    "else": {
+                      "not": {
+                        "required": [
+                          "files"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Connected",
+            "description": "Configure the Notecard to perform an interrupt on a successful connection to Notehub.",
+            "json": "{\"req\":\"card.attn\",\"mode\":\"arm,connected\"}"
+          },
+          {
+            "title": "Files",
+            "description": "Configure the Notecard to perform an interrupt on the `data.qi` and `my-settings.db` Notefiles.",
+            "json": "{\"req\":\"card.attn\",\"mode\":\"arm,files\",\"files\":[\"data.qi\",\"my-settings.db\"]}"
+          },
+          {
+            "title": "Location",
+            "description": "Configure the Notecard to perform an interrupt when the Notecard makes a position fix.",
+            "json": "{\"req\":\"card.attn\",\"mode\":\"arm,location\"}"
+          },
+          {
+            "title": "Motion",
+            "description": "Configure the Notecard to perform an interrupt when the Notecard detects motion.",
+            "json": "{\"req\":\"card.attn\",\"mode\":\"arm,motion\"}"
+          },
+          {
+            "title": "Signal",
+            "description": "Configure the Notecard to perform an interrupt when the Notecard receives a signal.",
+            "json": "{\"req\":\"card.attn\",\"mode\":\"arm,signal\"}"
+          },
+          {
+            "title": "Watchdog",
+            "description": "Configure the Notecard to function as a watchdog timer with a 60 second timeout.",
+            "json": "{\"req\":\"card.attn\",\"mode\":\"watchdog\",\"seconds\":60}"
+          },
+          {
+            "title": "Sleep With Payload",
+            "description": "Configure the Notecard to instruct the host MCU to sleep for a period of time.",
+            "json": "{\"req\":\"card.attn\",\"mode\":\"sleep\",\"seconds\":3600,\"payload\":\"ewogICJpbnRlcnZhbHMiOiI2MCwxMiwxNCIKfQ==\"}"
+          },
+          {
+            "title": "Retrieve Payload",
+            "description": "Retrieve a payload from the Notecard after sleep.",
+            "json": "{\"req\":\"card.attn\",\"start\":true}"
+          },
+          {
+            "title": "Disarm all Modes",
+            "description": "Disarm all interrupts.",
+            "json": "{\"req\":\"card.attn\",\"mode\":\"disarm,-all\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "files": {
+                      "description": "A list of files changed since `file` attention mode was set. In addition, this field will include keywords to signify the occurrence of other attention mode triggers:",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "x-sub-descriptions": [
+                        {
+                          "const": "connected",
+                          "description": "Indicates that the ATTN pin fired due to the Notecard connecting to the network.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "env",
+                          "description": "Indicates that the ATTN pin fired due to an environment variable change on the Notecard.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "LORA",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "files",
+                          "description": "Indicates that the ATTN pin fired due to a change in one or more monitored Notefiles.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "LORA",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "location",
+                          "description": "Indicates that the ATTN pin fired due to the GPS module making a position fix.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "motion",
+                          "description": "Indicates that the ATTN pin fired due to the accelerometer detecting motion.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "timeout",
+                          "description": "Indicates that the ATTN pin fired due to the timeout period specified in `seconds` elapsing.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "LORA",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "watchdog",
+                          "description": "Indicates that the ATTN pin fired due to the watchdog timer expiring.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "WIFI"
+                          ]
+                        }
+                      ],
+                      "minItems": 1
+                    },
+                    "off": {
+                      "description": "This field is present and set to `true` if ATTN processing has been disabled with the `off` argument.",
+                      "type": "boolean",
+                      "x-min-api-version": "7.2.1"
+                    },
+                    "payload": {
+                      "description": "When using `sleep` mode with a `payload`, the payload provided by the host to the Notecard.",
+                      "type": "string",
+                      "contentEncoding": "base64",
+                      "x-skus": [
+                        "CELL",
+                        "CELL+WIFI",
+                        "WIFI"
+                      ]
+                    },
+                    "set": {
+                      "description": "Reflects the state of the attention pin. The `set` field is `true` when the attention pin is `HIGH`, otherwise the `set` field will not be present when the attention pin is `LOW`.",
+                      "type": "boolean"
+                    },
+                    "time": {
+                      "description": "When using `sleep` mode with a `payload`, the time (UNIX Epoch time) that the payload was stored by the Notecard.",
+                      "type": "integer",
+                      "x-skus": [
+                        "CELL",
+                        "CELL+WIFI",
+                        "WIFI"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.attn Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "description": "Example Response",
+                "json": "{\"files\": [\"data.qi\", \"modified\"], \"set\": true}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/aux": {
+      "put": {
+        "operationId": "card_aux",
+        "summary": "Configure various uses of the general-purpose I/O (GPIO) pins `AUX1`-`AUX4` on the Notecard edge connector for tracking applications and simple GPIO sensing and counting tasks.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.aux",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.aux Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "connected": {
+                    "description": "If `true`, defers the sync of the state change Notefile to the next sync as configured by the `hub.set` request.",
+                    "type": "boolean",
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ],
+                    "x-min-api-version": "3.3.1"
+                  },
+                  "count": {
+                    "description": "When used with `\"mode\":\"neo-monitor\"` or `\"mode\":\"track-neo-monitor\"`, this controls the number of NeoPixels to use in a strip. Possible values are `1`, `2`, or `5`.",
+                    "type": "integer",
+                    "enum": [
+                      -1,
+                      1,
+                      2,
+                      5
+                    ],
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ],
+                    "x-min-api-version": "3.5.1"
+                  },
+                  "file": {
+                    "description": "The name of the Notefile used to report state changes when used in conjunction with `\"sync\": true`. Default Notefile name is `_button.qo`.",
+                    "type": "string",
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ],
+                    "x-min-api-version": "3.3.1"
+                  },
+                  "gps": {
+                    "description": "If `true`, along with `\"mode\":\"track\"` the Notecard supports the use of an external GPS module. This argument is deprecated. Use the `card.aux.serial` request with a `mode` of `\"gps\"` instead.",
+                    "type": "boolean",
+                    "deprecated": true
+                  },
+                  "limit": {
+                    "description": "If `true`, along with `\"mode\":\"track\"` and `gps:true` the Notecard will disable concurrent modem use during GPS tracking.",
+                    "type": "boolean",
+                    "x-min-api-version": "3.4.1"
+                  },
+                  "max": {
+                    "description": "When in `gpio` mode, if an `AUX` pin is configured as a `count` type, the maximum number of samples of duration `seconds`, after which all subsequent counts are added to the final sample. Passing `0` or omitting this value will provide a single incrementing count of rising edges on the pin.",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "mode": {
+                    "description": "The AUX mode. Must be one of the following keywords. Some keywords are only supported on certain types of Notecards.",
+                    "type": "string",
+                    "enum": [
+                      "dfu",
+                      "gpio",
+                      "led",
+                      "monitor",
+                      "motion",
+                      "neo",
+                      "neo-monitor",
+                      "off",
+                      "rgb",
+                      "rgb-monitor",
+                      "track",
+                      "track-monitor",
+                      "track-neo-monitor",
+                      "track-rgb-monitor",
+                      "-"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "dfu",
+                        "description": "Enable the Notecard's `AUX1` pin for [Outboard Firmware Updates](/notehub/host-firmware-updates/notecard-outboard-firmware-update). When enabled, `AUX1` is active `LOW` when a DFU is in progress, and `HIGH` otherwise. See [Using DFU Mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-dfu-mode) for more information.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.5.1"
+                      },
+                      {
+                        "const": "gpio",
+                        "description": "Configure the Notecard for GPIO mode with `AUX1` OFF, `AUX2` as an output `LOW`, `AUX3` as an output `HIGH`, and `AUX4` as an input.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "led",
+                        "description": "When wiring LEDs to the Notecard's AUX pins (as is done when using monitor mode), use this mode along with the card.led API to manually enable/disable individual red, green, and/or yellow LEDs.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.5.1"
+                      },
+                      {
+                        "const": "monitor",
+                        "description": "If you plan to place your Notecard in an enclosure, monitor mode can be used to configure inputs and outputs typically placed on the faceplate of a device in order for a technician to test and monitor Notecard activity.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "motion",
+                        "description": "Supplement autonomous tracking with digital inputs and a status output.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "neo",
+                        "description": "When wiring a NeoPixel or NeoPixel strip to the Notecard's AUX2 pin (as is done when using neo-monitor mode), use this mode along with the card.led API to manually enable/disable a single NeoPixel.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.5.1"
+                      },
+                      {
+                        "const": "neo-monitor",
+                        "description": "Similar to monitor mode, neo-monitor mode supports NeoPixel LEDs that can be used to configure inputs and outputs typically placed on the faceplate of a device in order for a technician to test and monitor Notecard activity.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "off",
+                        "description": "Disable AUX mode.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "rgb",
+                        "description": "When wiring an RGB LED to the Notecard's AUX2-4 pins, you may use this mode along with the card.led API to manually enable/disable colors in a single RGB LED.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "9.3.1"
+                      },
+                      {
+                        "const": "rgb-monitor",
+                        "description": "Similar to monitor mode, `rgb-monitor` mode supports a single RGB LED that can be used to configure inputs and outputs typically placed on the faceplate of a device in order for a technician to test and monitor Notecard activity.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "9.3.1"
+                      },
+                      {
+                        "const": "track",
+                        "description": "Enhance Notes in the `_track.qo` Notefile with temperature, pressure, and humidity readings from a connected BME280 sensor.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "track-monitor",
+                        "description": "Combines the functionality of the `track` and `monitor` AUX modes.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.5.1"
+                      },
+                      {
+                        "const": "track-neo-monitor",
+                        "description": "Combines `track` and `monitor` modes while also supporting NeoPixel LEDs that allow for monitoring Notecard activity.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.5.1"
+                      },
+                      {
+                        "const": "track-rgb-monitor",
+                        "description": "Combines `track` and `monitor` modes while also supporting a single RGB LED that allows for monitoring Notecard activity.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "9.3.1"
+                      },
+                      {
+                        "const": "-",
+                        "description": "Resets the AUX mode to its default value (`off`).",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      }
+                    ]
+                  },
+                  "ms": {
+                    "description": "When in `gpio` mode, this argument configures a debouncing interval. With a debouncing interval in place, the Notecard excludes all transitions with a shorter duration than the provided debounce time, in milliseconds. This interval only applies to GPIOs configured with a `usage` of `count`, `count-pulldown`, or `count-pullup`.",
+                    "type": "integer",
+                    "minimum": -1,
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ],
+                    "x-min-api-version": "5.1.1"
+                  },
+                  "offset": {
+                    "description": "When used with `\"mode\":\"neo-monitor\"` or `\"mode\":\"track-neo-monitor\"`, this is the 1-based index in a strip of NeoPixels that determines which single NeoPixel the host can command.",
+                    "type": "integer",
+                    "anyOf": [
+                      {
+                        "const": -1
+                      },
+                      {
+                        "minimum": 1
+                      }
+                    ],
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ]
+                  },
+                  "rate": {
+                    "description": "The AUX UART baud rate for debug communication over the AUXRX and AUXTX pins.",
+                    "enum": [
+                      -1,
+                      300,
+                      600,
+                      1200,
+                      2400,
+                      4800,
+                      9600,
+                      19200,
+                      38400,
+                      57600,
+                      115200,
+                      230400,
+                      460800,
+                      921600
+                    ],
+                    "default": 115200,
+                    "type": "integer",
+                    "x-min-api-version": "3.2.1"
+                  },
+                  "seconds": {
+                    "description": "When in `gpio` mode, if an `AUX` pin is configured as a `count` type, the count of rising edges can be broken into samples of this duration. Passing `0` or omitting this field will total into a single sample.",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "sensitivity": {
+                    "description": "When used with `\"mode\":\"neo-monitor\"` or `\"mode\":\"track-neo-monitor\"`, this controls the brightness of NeoPixel lights, where `100` is the maximum brightness and `1` is the minimum.",
+                    "type": "integer",
+                    "minimum": -1,
+                    "maximum": 100,
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ],
+                    "x-min-api-version": "3.5.1"
+                  },
+                  "start": {
+                    "description": "When in `gpio` mode, if an `AUX` pin is configured as a `count` type, set to `true` to reset counters and start incrementing.",
+                    "type": "boolean"
+                  },
+                  "sync": {
+                    "description": "If `true`, for pins set as `input` by `usage`, the Notecard will autonomously report any state changes as new notes in `file`. For pins used as `counter`, the Notecard will use an interrupt to count pulses and will report the total in a new note in `file` unless it has been noted in the previous second.",
+                    "type": "boolean",
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ],
+                    "x-min-api-version": "3.4.1"
+                  },
+                  "usage": {
+                    "description": "An ordered list of pin modes for each AUX pin when in GPIO mode.",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "",
+                        "off",
+                        "high",
+                        "low",
+                        "input",
+                        "input-pulldown",
+                        "input-pullup",
+                        "count",
+                        "count-pulldown",
+                        "count-pullup"
+                      ]
+                    },
+                    "x-sub-descriptions": [
+                      {
+                        "const": "",
+                        "description": "to leave the pin unchanged.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "off",
+                        "description": "to disable the pin.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "high",
+                        "description": "to set the pin as a `HIGH` output.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "low",
+                        "description": "to set the pin as a `LOW` output.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "input",
+                        "description": "to set the pin as an input.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "input-pulldown",
+                        "description": "to set the pin as a pull-down input.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.3.1"
+                      },
+                      {
+                        "const": "input-pullup",
+                        "description": "to set the pin as a pull-up input.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "LORA",
+                          "WIFI"
+                        ],
+                        "x-min-api-version": "3.3.1"
+                      },
+                      {
+                        "const": "count",
+                        "description": "to set the pin as an input (interrupt) that increments a counter for each rising edge pulse on the pin. It is up to the device's designer to make sure that the signal is either HIGH or LOW at any time, and is never left floating.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "count-pulldown",
+                        "description": "Same as `count` usage, but a pull-down resistor internal to the Notecard will automatically keep the pin from floating.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "count-pullup",
+                        "description": "Same as `count` usage, but a pull-up resistor internal to the Notecard will automatically keep the pin from floating and falling edges of pulses are counted.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "DFU Mode",
+            "description": "Enable the Notecard's `AUX1` pin for [Outboard Firmware Updates](/notehub/host-firmware-updates/notecard-outboard-firmware-update). When enabled, `AUX1` is active `LOW` when a DFU is in progress, and `HIGH` otherwise.",
+            "json": "{\"req\": \"card.aux\", \"mode\": \"dfu\"}"
+          },
+          {
+            "title": "GPIO Mode",
+            "description": "Configure the Notecard for GPIO mode with `AUX1` OFF, `AUX2` as an output `LOW`, `AUX3` as an output `HIGH`, and `AUX4` as an input.",
+            "json": "{\"req\": \"card.aux\", \"mode\": \"gpio\", \"usage\": [\"off\", \"low\", \"high\", \"input\"]}"
+          },
+          {
+            "title": "GPIO Mode With Count",
+            "description": "Configure the Notecard for GPIO mode with `AUX1` OFF, `AUX2` as an output `LOW`, `AUX3` as an output `HIGH`, and `AUX4` as a count.",
+            "json": "{\"req\": \"card.aux\", \"mode\": \"gpio\", \"usage\": [\"off\", \"low\", \"high\", \"count\"], \"seconds\": 2, \"max\": 5, \"start\": true}"
+          },
+          {
+            "title": "GPIO Mode With Notefile",
+            "description": "Configure GPIO mode with automatic state change reporting to a Notefile.",
+            "json": "{\"req\": \"card.aux\", \"mode\": \"gpio\", \"usage\": [\"off\", \"low\", \"high\", \"input\"], \"sync\": true, \"file\": \"statechange.qo\"}"
+          },
+          {
+            "title": "Monitor Mode",
+            "description": "Configure inputs and outputs typically placed on the faceplate of a device for technicians to test and monitor Notecard activity.",
+            "json": "{\"req\": \"card.aux\", \"mode\": \"monitor\"}"
+          },
+          {
+            "title": "Neo-Monitor Mode",
+            "description": "Enable neo-monitor mode which supports NeoPixel LEDs for monitoring Notecard activity.",
+            "json": "{\"req\": \"card.aux\", \"mode\": \"neo-monitor\"}"
+          },
+          {
+            "title": "Motion Mode",
+            "description": "Supplement autonomous tracking with digital inputs and a status output.",
+            "json": "{\"req\": \"card.aux\", \"mode\": \"motion\"}"
+          },
+          {
+            "title": "Setting AUX UART Baud",
+            "description": "Configure the AUX UART baud rate for debug communication.",
+            "json": "{\"req\": \"card.aux\", \"rate\": 9600}"
+          },
+          {
+            "title": "Track Mode",
+            "description": "Enhance Notes with temperature, pressure, and humidity readings from a connected BME280 sensor.",
+            "json": "{\"req\": \"card.aux\", \"mode\": \"track\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "description": "The current AUX `mode`, or `off` if not set.",
+                      "type": "string",
+                      "enum": [
+                        "busy-monitor",
+                        "dfu",
+                        "gpio",
+                        "led",
+                        "led-monitor",
+                        "motion",
+                        "neo",
+                        "neo-monitor",
+                        "off",
+                        "rgb",
+                        "rgb-monitor",
+                        "track",
+                        "track-led-monitor",
+                        "track-neo-monitor",
+                        "track-rgb-monitor"
+                      ]
+                    },
+                    "power": {
+                      "description": "If `true`, indicates the Notecard has USB (main) power. This parameter only appears in the body of the Note in Notehub if using `\"sync\":true`.",
+                      "type": "boolean",
+                      "x-min-api-version": "3.3.1"
+                    },
+                    "seconds": {
+                      "description": "When in AUX `gpio` mode, and if `count` is enabled on an AUX pin, the number of seconds per sample.",
+                      "type": "integer"
+                    },
+                    "state": {
+                      "description": "When in AUX `gpio` mode, the state of each AUX pin.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "high": {
+                            "type": "boolean"
+                          },
+                          "low": {
+                            "type": "boolean"
+                          },
+                          "input": {
+                            "type": "boolean"
+                          },
+                          "count": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "x-sub-descriptions": [
+                        {
+                          "const": "",
+                          "description": "`{}` when the pin is off.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "LORA",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "high",
+                          "description": "`{\"high\": true}` when the pin is high.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "LORA",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "low",
+                          "description": "`{\"low\": true}` when the pin is low.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "LORA",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "input",
+                          "description": "`{\"input\": true}` when the pin is input.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "LORA",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "count",
+                          "description": "`{\"count\": [4]}` where each item in the array is the count per sample.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "WIFI"
+                          ]
+                        }
+                      ]
+                    },
+                    "time": {
+                      "description": "When in AUX `gpio` mode, and if `count` is enabled on an AUX pin, the time that counting started.",
+                      "type": "integer",
+                      "format": "unix-time"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.aux Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "GPIO Mode Response",
+                "description": "Example response showing GPIO mode configuration with pin states.",
+                "json": "{\"mode\": \"gpio\", \"state\": [{}, {\"low\": true}, {\"high\": true}, {\"count\": [3]}], \"time\": 1592587637, \"seconds\": 2}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/aux/serial": {
+      "put": {
+        "operationId": "card_aux_serial",
+        "summary": "Configure various uses of the AUXTX and AUXRX pins on the Notecard's edge connector.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.aux.serial",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "3.4.1",
+        "x-title": "card.aux.serial Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "duration": {
+                    "description": "If using `\"mode\": \"accel\"`, specify a sampling duration for the Notecard accelerometer.",
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "description": "If `true`, along with `\"mode\":\"gps\"` the Notecard will disable concurrent modem use during GPS tracking.",
+                    "type": "boolean"
+                  },
+                  "max": {
+                    "description": "The maximum amount of data, in bytes, that can be sent in a single transmission before the Notecard pauses to allow the host to process incoming data. This value should be set to the size of the host's serial receive buffer minus `1`, which represents the number of bytes the host can absorb before the sender must delay due to the absence of flow control. For example, `note-arduino`` uses a buffer size of `(SERIAL_RX_BUFFER_SIZE - 1)`.",
+                    "type": "integer"
+                  },
+                  "minutes": {
+                    "description": "When using `\"mode\": \"notify,dfu\"`, specify an interval for notifying the host.",
+                    "type": "integer",
+                    "x-min-api-version": "5.1.1"
+                  },
+                  "mode": {
+                    "description": "The AUX mode. Must be one of the following:",
+                    "type": "string",
+                    "pattern": "^(?:req|gps|notify(?:,(?:accel|signals|env|dfu)(?:,(?:accel|signals|env|dfu))*)?)$",
+                    "x-sub-descriptions": [
+                      {
+                        "const": "req",
+                        "description": "(Default) for request/response monitoring on the AUX pins."
+                      },
+                      {
+                        "const": "gps",
+                        "description": "Use an external GPS/GNSS module on the AUX pins. Using an external GPS/GNSS module allows you to acquire GPS/GNSS location while Notecard is connected to Notehub in `continuous` mode. Learn more at [Using AUX Serial GPS Mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-aux-serial-gps-mode)."
+                      },
+                      {
+                        "const": "notify",
+                        "description": "Used along with one or more of the `notify` options to send streaming data or notification data over the AUX pins. When used alone, preserves existing notification settings."
+                      },
+                      {
+                        "const": "notify,accel",
+                        "description": "Used to stream readings from the onboard accelerometer over AUX."
+                      },
+                      {
+                        "const": "notify,signals",
+                        "description": "Used to notify the host of any [Inbound Signals](/guides-and-tutorials/notecard-guides/minimizing-latency/#using-inbound-signals) from Notehub."
+                      },
+                      {
+                        "const": "notify,env",
+                        "description": "Used to notify the host of Environment Variable changes over AUX."
+                      },
+                      {
+                        "const": "notify,dfu",
+                        "description": "Used to notify the host that the Notecard has downloaded updated host firmware."
+                      }
+                    ]
+                  },
+                  "ms": {
+                    "description": "The delay in milliseconds before sending a buffer of `max` size.",
+                    "type": "integer"
+                  },
+                  "rate": {
+                    "description": "The baud rate or speed at which information is transmitted over AUX serial. The default is `115200` unless using GPS, in which case the default is `9600`.",
+                    "type": "integer",
+                    "x-min-api-version": "4.1.1"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Enable GPS Mode",
+            "description": "Configure AUX serial for external GPS communication. Using an external GPS/GNSS module allows you to acquire GPS/GNSS location while Notecard is connected to Notehub in `continuous` mode. Learn more at [Using AUX Serial GPS Mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-aux-serial-gps-mode).",
+            "json": "{\"req\": \"card.aux.serial\", \"mode\": \"gps\"}"
+          },
+          {
+            "title": "Enable DFU Notifications",
+            "description": "Configure AUX serial for DFU notifications with timeout.",
+            "json": "{\"req\": \"card.aux.serial\", \"mode\": \"notify,dfu\", \"minutes\": 5}"
+          },
+          {
+            "title": "Enable Environment Notifications",
+            "description": "Configure AUX serial for environment variable change notifications.",
+            "json": "{\"req\": \"card.aux.serial\", \"mode\": \"notify,env\"}"
+          },
+          {
+            "title": "Request Mode",
+            "description": "Set AUX serial to request mode for command/response communication.",
+            "json": "{\"req\": \"card.aux.serial\", \"mode\": \"req\"}"
+          },
+          {
+            "title": "Accelerometer Mode",
+            "description": "Send raw readings from the onboard accelerometer over AUX every 500 ms.",
+            "json": "{\"req\": \"card.aux.serial\", \"mode\": \"notify,accel\", \"duration\": 500}"
+          },
+          {
+            "title": "Signal Mode",
+            "description": "Turn on Inbound Signals from Notehub for low-latency communication.",
+            "json": "{\"req\": \"card.aux.serial\", \"mode\": \"notify,signals\"}"
+          },
+          {
+            "title": "Multiple Mode",
+            "description": "Subscribe to multiple notifications at once.",
+            "json": "{\"req\": \"card.aux.serial\", \"mode\": \"notify,accel,env\", \"duration\": 500}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "description": "The current AUX `mode`.",
+                      "type": "string"
+                    },
+                    "rate": {
+                      "description": "The baud rate or speed at which information is transmitted over AUX serial.",
+                      "type": "integer",
+                      "x-min-api-version": "4.1.1"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.aux.serial Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "AUX Serial Status",
+                "description": "Example response showing current AUX serial configuration.",
+                "json": "{\"mode\": \"req\", \"rate\": 115200}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/binary": {
+      "get": {
+        "operationId": "card_binary_query",
+        "summary": "View the status of the binary storage area of the Notecard and optionally clear any data and related `card.binary` variables. See the guide on [Sending and Receiving Large Binary Objects](/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects) for best practices when using `card.binary`.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.binary",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "5.3.1",
+        "x-title": "card.binary Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "delete",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Clear the COBS area on the Notecard and reset all related arguments previously set by a card.binary request."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "View Binary Status",
+            "description": "Check the status of binary storage area.",
+            "json": "{\"req\": \"card.binary\"}"
+          },
+          {
+            "title": "Reset Binary Data",
+            "description": "Clear the COBS area and reset binary variables.",
+            "json": "{\"req\": \"card.binary\", \"delete\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "cobs": {
+                      "description": "The size of COBS-encoded data stored in the reserved area (without the trailing \n).",
+                      "type": "integer"
+                    },
+                    "connected": {
+                      "description": "Returns true if the Notecard is connected to the network.",
+                      "type": "boolean"
+                    },
+                    "err": {
+                      "description": "If present, a string describing the error that occurred during transmission.",
+                      "type": "string"
+                    },
+                    "length": {
+                      "description": "The amount of unencoded data currently stored (in bytes).",
+                      "type": "integer"
+                    },
+                    "max": {
+                      "description": "The space available (in bytes) for storing unencoded data on the Notecard.",
+                      "type": "integer"
+                    },
+                    "status": {
+                      "description": "The MD5 checksum calculated for the entire unencoded buffer.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.binary Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Binary Status Response",
+                "description": "Example response showing binary storage status.",
+                "json": "{\"connected\": true, \"max\": 130554, \"status\": \"ce6fdef565eeecf14ab38d83643b922d\", \"length\": 4, \"cobs\": 5}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "5.3.1"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "card_binary_delete",
+        "summary": "View the status of the binary storage area of the Notecard and optionally clear any data and related `card.binary` variables. See the guide on [Sending and Receiving Large Binary Objects](/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects) for best practices when using `card.binary`.",
+        "x-safety": "destructive",
+        "x-notecard-request": "card.binary",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "delete"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "5.3.1",
+        "x-title": "card.binary Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "delete": {
+                    "description": "Clear the COBS area on the Notecard and reset all related arguments previously set by a card.binary request.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "View Binary Status",
+            "description": "Check the status of binary storage area.",
+            "json": "{\"req\": \"card.binary\"}"
+          },
+          {
+            "title": "Reset Binary Data",
+            "description": "Clear the COBS area and reset binary variables.",
+            "json": "{\"req\": \"card.binary\", \"delete\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "cobs": {
+                      "description": "The size of COBS-encoded data stored in the reserved area (without the trailing \n).",
+                      "type": "integer"
+                    },
+                    "connected": {
+                      "description": "Returns true if the Notecard is connected to the network.",
+                      "type": "boolean"
+                    },
+                    "err": {
+                      "description": "If present, a string describing the error that occurred during transmission.",
+                      "type": "string"
+                    },
+                    "length": {
+                      "description": "The amount of unencoded data currently stored (in bytes).",
+                      "type": "integer"
+                    },
+                    "max": {
+                      "description": "The space available (in bytes) for storing unencoded data on the Notecard.",
+                      "type": "integer"
+                    },
+                    "status": {
+                      "description": "The MD5 checksum calculated for the entire unencoded buffer.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.binary Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Binary Status Response",
+                "description": "Example response showing binary storage status.",
+                "json": "{\"connected\": true, \"max\": 130554, \"status\": \"ce6fdef565eeecf14ab38d83643b922d\", \"length\": 4, \"cobs\": 5}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "5.3.1"
+          }
+        }
+      }
+    },
+    "/card/binary/get": {
+      "post": {
+        "operationId": "card_binary_get",
+        "summary": "Returns binary data stored in the binary storage area of the Notecard. The response to this API command first returns the JSON-formatted response object, then the binary data.\n\nSee the guide on [Sending and Receiving Large Binary Objects](/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects) for best practices when using `card.binary`.",
+        "x-safety": "non-idempotent",
+        "x-notecard-request": "card.binary.get",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "5.3.1",
+        "x-title": "card.binary.get Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "cobs": {
+                    "description": "The size of the COBS-encoded data you are expecting to be returned (in bytes).",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "length": {
+                    "description": "Used along with `offset`, the number of bytes to retrieve from the binary storage area of the Notecard.",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "offset": {
+                    "description": "Used along with `length`, the number of bytes to offset the binary payload from 0 when retrieving binary data from the binary storage area of the Notecard. Primarily used when retrieving multiple fragments of a binary payload from the Notecard.",
+                    "type": "integer",
+                    "minimum": -1
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Get All Binary Data",
+            "description": "Retrieve all binary data from storage area.",
+            "json": "{\"req\": \"card.binary.get\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "err": {
+                      "description": "If present, a string describing the error that occurred during transmission",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "The MD5 checksum of the data returned, after it has been decoded",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.binary.get Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Binary Data Response",
+                "description": "Example response with MD5 checksum.",
+                "json": "{\"status\":\"ce6fdef565eeecf14ab38d83643b922d\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "5.3.1"
+          }
+        }
+      }
+    },
+    "/card/binary/put": {
+      "post": {
+        "operationId": "card_binary_put",
+        "summary": "Adds binary data to the binary storage area of the Notecard. The Notecard expects to receive binary data immediately following the usage of this API command.\n\nSee the guide on [Sending and Receiving Large Binary Objects](/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects) for best practices when using `card.binary`.",
+        "x-safety": "non-idempotent",
+        "x-notecard-request": "card.binary.put",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "5.3.1",
+        "x-title": "card.binary.put Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "cobs": {
+                    "description": "The size of the COBS-encoded data (in bytes).",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "offset": {
+                    "description": "The number of bytes to offset the binary payload from 0 when appending the binary data to the binary storage area of the Notecard. Primarily used when sending multiple fragments of one binary payload to the Notecard.",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "status": {
+                    "description": "The MD5 checksum of the data, before it has been encoded.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Put Binary Data",
+            "description": "Send binary data with MD5 checksum.",
+            "json": "{\"req\": \"card.binary.put\", \"cobs\": 5, \"status\": \"ce6fdef565eeecf14ab38d83643b922d\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "err": {
+                      "description": "If present, a string describing the error that occurred during transmission",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.binary.put Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "5.3.1"
+          }
+        }
+      }
+    },
+    "/card/carrier": {
+      "put": {
+        "operationId": "card_carrier",
+        "summary": "Uses the `AUX_CHARGING` pin on the Notecard edge connector to notify the Notecard that the pin is connected to a Notecarrier that supports charging, using open-drain.\n\nOnce set, `{\"charging\":true}` will appear in a response if the Notecarrier is currently indicating that charging is in progress.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.carrier",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.carrier Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "description": "The `AUX_CHARGING` mode. Set to `\"charging\"` to tell the Notecard that `AUX_CHARGING` is connected to a Notecarrier that supports charging on `AUX_CHARGING`. Set to `\"-\"` or `\"off\"` to turn off the `AUX_CHARGING` detection.",
+                    "type": "string",
+                    "enum": [
+                      "charging",
+                      "-",
+                      "off"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "charging",
+                        "description": "Tell the Notecard that `AUX_CHARGING` is connected to a Notecarrier that supports charging on `AUX_CHARGING`."
+                      },
+                      {
+                        "const": "-",
+                        "description": "Turn off `AUX_CHARGING` detection."
+                      },
+                      {
+                        "const": "off",
+                        "description": "Turn off `AUX_CHARGING` detection."
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Enable Charging Mode",
+            "description": "Set the `AUX_CHARGING` mode to charging.",
+            "json": "{\"req\": \"card.carrier\", \"mode\": \"charging\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "charging": {
+                      "description": "Will display `true` when in `AUX_CHARGING` `\"charging\"` mode.",
+                      "type": "boolean"
+                    },
+                    "mode": {
+                      "description": "The current `AUX_CHARGING` `mode`, or `off` if not set.",
+                      "type": "string",
+                      "enum": [
+                        "charging",
+                        "off"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.carrier Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Charging Status Response",
+                "description": "Example response showing charging mode status.",
+                "json": "{\"mode\": \"charging\", \"charging\": true}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/contact": {
+      "get": {
+        "operationId": "card_contact_query",
+        "summary": "Used to set or retrieve information about the Notecard maintainer. Once set, this information is synced to Notehub.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.contact",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.contact Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "email"
+            },
+            "description": "Set the email address of the Notecard maintainer."
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Set the name of the Notecard maintainer."
+          },
+          {
+            "name": "org",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Set the organization name of the Notecard maintainer."
+          },
+          {
+            "name": "role",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Set the role of the Notecard maintainer."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Set Contact Information",
+            "description": "Set contact information for the Notecard maintainer.",
+            "json": "{\"req\": \"card.contact\", \"name\": \"Tom Turkey\", \"org\": \"Blues\", \"role\": \"Head of Security\", \"email\": \"tom@blues.com\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "description": "Email address of the Notecard maintainer.",
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "name": {
+                      "description": "Name of the Notecard maintainer.",
+                      "type": "string"
+                    },
+                    "org": {
+                      "description": "Organization name of the Notecard maintainer.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role of the Notecard maintainer.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.contact Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Get Contact Information",
+                "description": "Example response showing contact information.",
+                "json": "{\"name\": \"Tom Turkey\", \"org\": \"Blues\", \"role\": \"Head of Security\", \"email\": \"tom@blues.com\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "put": {
+        "operationId": "card_contact_set",
+        "summary": "Used to set or retrieve information about the Notecard maintainer. Once set, this information is synced to Notehub.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.contact",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires_any": [
+            "name",
+            "email",
+            "org",
+            "role"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.contact Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "description": "Set the email address of the Notecard maintainer.",
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "name": {
+                    "description": "Set the name of the Notecard maintainer.",
+                    "type": "string"
+                  },
+                  "org": {
+                    "description": "Set the organization name of the Notecard maintainer.",
+                    "type": "string"
+                  },
+                  "role": {
+                    "description": "Set the role of the Notecard maintainer.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Set Contact Information",
+            "description": "Set contact information for the Notecard maintainer.",
+            "json": "{\"req\": \"card.contact\", \"name\": \"Tom Turkey\", \"org\": \"Blues\", \"role\": \"Head of Security\", \"email\": \"tom@blues.com\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "description": "Email address of the Notecard maintainer.",
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "name": {
+                      "description": "Name of the Notecard maintainer.",
+                      "type": "string"
+                    },
+                    "org": {
+                      "description": "Organization name of the Notecard maintainer.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role of the Notecard maintainer.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.contact Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Get Contact Information",
+                "description": "Example response showing contact information.",
+                "json": "{\"name\": \"Tom Turkey\", \"org\": \"Blues\", \"role\": \"Head of Security\", \"email\": \"tom@blues.com\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/dfu": {
+      "put": {
+        "operationId": "card_dfu",
+        "summary": "Used to configure a Notecard for [Notecard Outboard Firmware Update](/notehub/host-firmware-updates/notecard-outboard-firmware-update).",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.dfu",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.dfu Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "description": "The `mode` argument allows you to control whether a Notecard's `AUX` pins (default) or `ALT_DFU` pins are used for [Notecard Outboard Firmware Update](/notehub/host-firmware-updates/notecard-outboard-firmware-update). This argument is only supported on Notecards that have `ALT_DFU` pins, which includes all versions of Notecard Cell+WiFi, non-legacy versions of Notecard Cellular, and Notecard WiFi v2.",
+                    "type": "string",
+                    "enum": [
+                      "altdfu",
+                      "aux"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "altdfu",
+                        "description": "Enable the Notecard's `ALT_DFU` pins (instead of the `AUX` pins) for use with Notecard Outboard Firmware Update."
+                      },
+                      {
+                        "const": "aux",
+                        "description": "Return the Notecard's `ALT_DFU` pins to their default state of `AUX`."
+                      }
+                    ]
+                  },
+                  "name": {
+                    "description": "One of the supported classes of host MCU. Supported MCU classes are `\"esp32\"`, `\"stm32\"`, `\"stm32-bi\"`, `\"mcuboot\"` (added in v5.3.1), and `\"-\"`, which resets the configuration. The \"bi\" in `\"stm32-bi\"` stands for \"boot inverted\", and the `\"stm32-bi\"` option should be used on STM32 family boards where the hardware boot pin is assumed to be active low, instead of active high. Supported MCUs can be found on the [Notecarrier F datasheet](/datasheets/notecarrier-datasheet/notecarrier-f-v1-3).",
+                    "type": "string",
+                    "enum": [
+                      "esp32",
+                      "stm32",
+                      "stm32-bi",
+                      "mcuboot",
+                      "-"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "esp32",
+                        "description": "ESP32 microcontroller family."
+                      },
+                      {
+                        "const": "stm32",
+                        "description": "STM32 microcontroller family."
+                      },
+                      {
+                        "const": "stm32-bi",
+                        "description": "STM32 microcontroller family with boot inverted (boot pin active low)."
+                      },
+                      {
+                        "const": "mcuboot",
+                        "description": "MCUboot compatible microcontroller (added in v5.3.1)."
+                      },
+                      {
+                        "const": "-",
+                        "description": "Resets the configuration."
+                      }
+                    ]
+                  },
+                  "off": {
+                    "description": "Set to `true` to disable Notecard Outboard Firmware Update from occurring.",
+                    "type": "boolean"
+                  },
+                  "on": {
+                    "description": "Set to `true` to enable Notecard Outboard Firmware Update.",
+                    "type": "boolean"
+                  },
+                  "seconds": {
+                    "description": "When used with `\"off\":true`, disable Notecard Outboard Firmware Update operations for the specified number of `seconds`.",
+                    "type": "integer"
+                  },
+                  "start": {
+                    "description": "Set to `true` to enable the host RESET if previously disabled with `\"stop\":true`.",
+                    "type": "boolean"
+                  },
+                  "stop": {
+                    "description": "Set to `true` to disable the host RESET that is normally performed on the host MCU when the Notecard starts up (in order to ensure a clean startup), and also when the Notecard wakes up the host MCU after the expiration of a `card.attn` \"sleep\" operation. If `true`, the host MCU will not be reset in these two conditions.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Configure STM32 DFU",
+            "description": "Enable DFU for STM32 microcontroller.",
+            "json": "{\"req\": \"card.dfu\", \"name\": \"stm32\", \"on\": true}"
+          },
+          {
+            "title": "Configure ESP32 DFU",
+            "description": "Enable DFU for ESP32 microcontroller.",
+            "json": "{\"cmd\": \"card.dfu\", \"name\": \"esp32\", \"on\": true}"
+          },
+          {
+            "title": "Enable Alternative DFU Pins",
+            "description": "Use ALT_DFU pins instead of AUX pins on Cell+WiFi.",
+            "json": "{\"req\": \"card.dfu\", \"mode\": \"altdfu\"}"
+          },
+          {
+            "title": "Disable DFU Temporarily",
+            "description": "Disable DFU for 3600 seconds.",
+            "json": "{\"req\": \"card.dfu\", \"off\": true, \"seconds\": 3600}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "description": "The class of MCU that the Notecard is currently configured to support for Outboard DFU.",
+                      "type": "string",
+                      "enum": [
+                        "",
+                        "esp32",
+                        "stm32",
+                        "stm32-bi",
+                        "mcuboot"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.dfu Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "DFU Status Response",
+                "description": "Example response showing current DFU configuration.",
+                "json": "{\"name\": \"stm32\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/illumination": {
+      "get": {
+        "operationId": "card_illumination",
+        "summary": "This request returns an illumination reading (in lux) from an OPT3001 ambient light sensor connected to Notecard's I2C bus. If no OPT3001 sensor is detected, this request returns an \u201cillumination sensor is not available\u201d error.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.illumination",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "9.1.1",
+        "x-title": "card.illumination Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Get Illumination",
+            "description": "Read current Lux value from the attached OPT3001 sensor.",
+            "json": "{\"req\": \"card.illumination\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "number",
+                      "description": "An illumination reading (in lux) from the attached OPT3001 sensor."
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.illumination Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "description": "Example Response",
+                "json": "{\"value\": 8806.4}"
+              }
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/io": {
+      "put": {
+        "operationId": "card_io",
+        "summary": "Can be used to override the Notecard's I2C address from its default of `0x17` and change behaviors of the onboard LED and USB port.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.io",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "7.4.1",
+        "x-title": "card.io Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "i2c": {
+                    "description": "The alternate address to use for I2C communication. Pass `-1` to [reset](https://dev.blues.io/notecard/notecard-walkthrough/essential-requests/#resetting-request-argument-values) to the default address",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "Used to control the Notecard's IO behavior, including USB port, LED, I2C master, NTN fallback.",
+                    "type": "string",
+                    "enum": [
+                      "-usb",
+                      "usb",
+                      "+usb",
+                      "+busy",
+                      "-busy",
+                      "i2c-master-disable",
+                      "i2c-master-enable",
+                      "+fallback",
+                      "-fallback"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "-usb",
+                        "description": "Set to `\"-usb\"` to disable the Notecard's USB port. Re-enable the USB port with `\"usb\"` or `\"+usb\"`."
+                      },
+                      {
+                        "const": "usb",
+                        "description": "Re-enable the Notecard's USB port after it has been disabled with `\"-usb\"`."
+                      },
+                      {
+                        "const": "+usb",
+                        "description": "Re-enable the Notecard's USB port after it has been disabled with `\"-usb\"`."
+                      },
+                      {
+                        "const": "+busy",
+                        "description": "If set to `\"+busy\"`, the Notecard's LED will be on when the Notecard is awake, and off when the Notecard goes to sleep.",
+                        "x-min-api-version": "7.4.1"
+                      },
+                      {
+                        "const": "-busy",
+                        "description": "Resets `\"+busy\"` to its default, making the onboard LED blink only during Notecard flash memory operations."
+                      },
+                      {
+                        "const": "i2c-master-disable",
+                        "description": "Disables Notecard acting as an I2C master. Re-enable by using `\"i2c-master-enable\"`.",
+                        "x-min-api-version": "9.1.1"
+                      },
+                      {
+                        "const": "i2c-master-enable",
+                        "description": "Re-enables the Notecard to act as an I2C master after it has been disabled with `\"i2c-master-disable\"`.",
+                        "x-min-api-version": "9.1.1"
+                      },
+                      {
+                        "const": "+fallback",
+                        "description": "Setting `\"+fallback\"` while Notecard is paired with a Starnote device forces fallback mode: WiFi and cellular are automatically failed over, and all traffic goes through NTN. This state persists across reboots and therefore is discouraged for use in production deployments because it can incur unexpectedly high satellite data costs.",
+                        "x-min-api-version": "8.2.1"
+                      },
+                      {
+                        "const": "-fallback",
+                        "description": "Resets `\"+fallback\"` to its default state, ensuring fallback mode is only enabled if cellular/WiFi are not available."
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Change I2C Address",
+            "description": "Change the Notecard's I2C address from its default of `0x17` to `0x18`.",
+            "json": "{\"req\": \"card.io\", \"i2c\": 24}"
+          },
+          {
+            "title": "Keep LED On While Notecard Awake.",
+            "description": "Keep the onboard LED on while the Notecard is awake.",
+            "json": "{\"req\": \"card.io\", \"mode\": \"+busy\"}"
+          },
+          {
+            "title": "Disable I2C Master.",
+            "description": "Disable the Notecard from acting as an I2C master. Re-enable by using `\"i2c-master-enable\"`.",
+            "json": "{\"req\": \"card.io\", \"mode\": \"i2c-master-disable\"}"
+          },
+          {
+            "title": "Force Fallback Mode For Starnote.",
+            "description": "Force the Notecard to enter fallback mode (cellular/WiFi automatically failed over to NTN).",
+            "json": "{\"req\": \"card.io\", \"mode\": \"+fallback\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response schema for card.io request.",
+            "x-title": "card.io Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/led": {
+      "put": {
+        "operationId": "card_led",
+        "summary": "Used along with the [card.aux API](/api-reference/notecard-api/card-requests/latest#card-aux) to turn connected LEDs on/off, to enable a specific color on an RGB LED, or to manage a single connected NeoPixel.\n\nMonochromatic LEDs must be wired according to the instructions provided in the guide on [Using Monitor Mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-monitor-mode). Please note that the use of monochromatic LEDs is not supported by Notecard for LoRa.\n\nRGB LEDs must be wired according to the instructions provided in the guide on [Using RGB-Monitor Mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-rgb-monitor-mode). Please note that the use of RGB LEDs is not supported by Notecard for LoRa.\n\nNeoPixels must be wired according to the instructions provided in the guide on [Using Neo-Monitor Mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-neo-monitor-mode).",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.led",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "3.5.1",
+        "x-title": "card.led Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "description": "Used to specify the color of the LED to turn on or off.\n\n**Note:** Notecard LoRa does not support monochromatic **LED** or **RGB** modes, only **NeoPixels**.",
+                    "type": "string",
+                    "x-sub-descriptions": [
+                      {
+                        "const": "red",
+                        "description": "Supports **LED**, **RGB**, & **NeoPixel**"
+                      },
+                      {
+                        "const": "green",
+                        "description": "Supports **LED**, **RGB**, & **NeoPixel**"
+                      },
+                      {
+                        "const": "yellow",
+                        "description": "Supports **LED**, **RGB**, & **NeoPixel**"
+                      },
+                      {
+                        "const": "blue",
+                        "description": "Supports **RGB** & **NeoPixel**"
+                      },
+                      {
+                        "const": "cyan",
+                        "description": "Supports **RGB** & **NeoPixel**"
+                      },
+                      {
+                        "const": "magenta",
+                        "description": "Supports **RGB** & **NeoPixel**"
+                      },
+                      {
+                        "const": "orange",
+                        "description": "Supports **NeoPixel**"
+                      },
+                      {
+                        "const": "white",
+                        "description": "Supports **RGB** & **NeoPixel**"
+                      },
+                      {
+                        "const": "gray",
+                        "description": "Supports **NeoPixel**"
+                      }
+                    ],
+                    "enum": [
+                      "red",
+                      "green",
+                      "yellow",
+                      "blue",
+                      "cyan",
+                      "magenta",
+                      "orange",
+                      "white",
+                      "gray"
+                    ]
+                  },
+                  "off": {
+                    "description": "Set to `true` to turn the specified LED or NeoPixel off.",
+                    "type": "boolean"
+                  },
+                  "on": {
+                    "description": "Set to `true` to turn the specified LED or NeoPixel on.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Turn Red LED On",
+            "description": "As shown above, the Notecard must also be in `led` mode and the LED(s) wired according to the instructions provided in the guide on [Using Monitor Mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-monitor-mode).",
+            "json": "[{\"req\": \"card.aux\", \"mode\": \"led\"},{\"req\": \"card.led\", \"mode\": \"red\", \"on\": true}]"
+          },
+          {
+            "title": "Turn Blue NeoPixel On",
+            "description": "As shown above, the Notecard must also be in `neo`, `neo-monitor`, or `track-neo-monitor` mode and the NeoPixel(s) wired according to the instructions provided in the guide on [Using Neo-Monitor Mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-neo-monitor-mode).",
+            "json": "[{\"req\": \"card.aux\", \"mode\": \"neo\"},{\"req\": \"card.led\", \"mode\": \"blue\", \"on\": true}]"
+          },
+          {
+            "title": "Turn Green RGB LED On",
+            "description": "As shown above, the Notecard must also be in `rgb`, `rgb-monitor`, or `track-rgb-monitor` mode and the RGB LED wired according to the instructions provided in the guide on [Using RGB-Monitor Mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-rgb-monitor-mode).",
+            "json": "[{\"req\": \"card.aux\", \"mode\": \"rgb\"},{\"req\": \"card.led\", \"mode\": \"green\", \"on\": true}]"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response schema for card.led request.",
+            "x-title": "card.led Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "3.5.1"
+          }
+        }
+      }
+    },
+    "/card/location": {
+      "get": {
+        "operationId": "card_location",
+        "summary": "Retrieves the last known location of the Notecard and the time at which it was acquired. Use [card.location.mode](/api-reference/notecard-api/card-requests#card-location-mode) to configure location settings.\n\nThis request will return the cell tower location or triangulated location of the most recent session if a GPS/GNSS location is not available.\n\nOn Notecard LoRa this request can only return a location set through the [card.location.mode](/api-reference/notecard-api/card-requests#card-location-mode) request's `\"fixed\"` mode.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.location",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.location Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Get Current Location",
+            "description": "Retrieve the last known location of the Notecard.",
+            "json": "{\"req\": \"card.location\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "description": "The number of consecutive recorded GPS/GNSS failures.",
+                      "type": "integer"
+                    },
+                    "dop": {
+                      "description": "The \"Dilution of Precision\" value from the latest GPS/GNSS reading. The lower the value, the higher the confidence level of the reading. Values can be interpreted in [this Wikipedia table](https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)#Interpretation).",
+                      "type": "number"
+                    },
+                    "lat": {
+                      "description": "The latitude in degrees of the last known location.",
+                      "type": "number"
+                    },
+                    "lon": {
+                      "description": "The longitude in degrees of the last known location.",
+                      "type": "number"
+                    },
+                    "max": {
+                      "description": "If a geofence is enabled by `card.location.mode`, meters from the geofence center.",
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "description": "The GPS/GNSS connection mode. Will be `continuous`, `periodic`, or `off`.",
+                      "type": "string",
+                      "enum": [
+                        "continuous",
+                        "periodic",
+                        "off"
+                      ],
+                      "x-sub-descriptions": [
+                        {
+                          "const": "continuous",
+                          "description": "The Notecard's onboard GPS/GNSS module is enabled for continuous sampling."
+                        },
+                        {
+                          "const": "periodic",
+                          "description": "The Notecard samples location at a specified interval, if the device has moved."
+                        },
+                        {
+                          "const": "off",
+                          "description": "Location mode is off."
+                        }
+                      ]
+                    },
+                    "status": {
+                      "description": "The current status of the Notecard GPS/GNSS connection.",
+                      "type": "string"
+                    },
+                    "time": {
+                      "description": "The time of the location capture.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.location Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "GPS Location Response",
+                "description": "Example response with GPS location data.",
+                "json": "{\"status\": \"GPS updated (58 sec, 41dB SNR, 9 sats) {gps-active} {gps-signal} {gps-sats} {gps}\", \"mode\": \"periodic\", \"lat\": 42.577600, \"lon\": -70.871340, \"time\": 1598554399, \"max\": 25}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/location/mode": {
+      "get": {
+        "operationId": "card_location_mode_query",
+        "summary": "Sets location-related configuration settings. Retrieves the current location mode when passed with no argument.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.location.mode",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.location.mode Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "delete",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Set to `true` to delete the last known location stored in the Notecard."
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "default": "last known latitude"
+            },
+            "description": "When in periodic or continuous mode, providing this value enables [geofencing](/notecard/notecard-walkthrough/time-and-location-requests#geofencing-with-the-notecard). The value you provide for this argument should be the latitude of the center of the geofence, in degrees. When in fixed mode, the value you provide for this argument should be the latitude location of the device itself, in degrees."
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "default": "last known longitude"
+            },
+            "description": "When in periodic or continuous mode, providing this value enables [geofencing](/notecard/notecard-walkthrough/time-and-location-requests#geofencing-with-the-notecard). The value you provide for this argument should be the longitude of the center of the geofence, in degrees. When in fixed mode, the value you provide for this argument should be the longitude location of the device itself, in degrees."
+          },
+          {
+            "name": "max",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Meters from a geofence center. Used to enable geofence location tracking."
+          },
+          {
+            "name": "minutes",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 5
+            },
+            "description": "When geofence is enabled, the number of minutes the device should be outside the geofence before the Notecard location is tracked."
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "",
+                "off",
+                "periodic",
+                "continuous",
+                "fixed"
+              ],
+              "x-sub-descriptions": [
+                {
+                  "const": "",
+                  "description": "Retrieves the current mode."
+                },
+                {
+                  "const": "off",
+                  "description": "Turns location mode off. Approximate location may still be [ascertained from Notehub](/notecard/notecard-walkthrough/time-and-location-requests#ascertaining-an-approximate-device-location)."
+                },
+                {
+                  "const": "periodic",
+                  "description": "Samples location at a specified interval, if the device has moved."
+                },
+                {
+                  "const": "continuous",
+                  "description": "Enables the Notecard's onboard GPS/GNSS module for continuous sampling, at a maximum frequency of one fix every 5 seconds. When in continuous mode the Notecard samples a new GPS/GNSS reading for every new Note."
+                },
+                {
+                  "const": "fixed",
+                  "description": "Reports the location as a fixed location using the specified `lat` and `lon` coordinates. This is the only supported mode on Notecard LoRa."
+                }
+              ]
+            },
+            "description": "Sets the location mode."
+          },
+          {
+            "name": "seconds",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "anyOf": [
+                {
+                  "const": -1
+                },
+                {
+                  "minimum": 5
+                }
+              ]
+            },
+            "description": "When in `periodic` mode, location will be sampled at this interval, if the Notecard detects motion. If seconds is < 300, during periods of sustained movement the Notecard will leave its onboard GPS/GNSS on continuously to avoid powering the module on and off repeatedly."
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "x-min-api-version": "3.4.1"
+            },
+            "description": "When in `periodic` mode, the number of motion events (registered by the built-in accelerometer) required to trigger GPS to turn on."
+          },
+          {
+            "name": "vseconds",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "In `periodic` mode, overrides `seconds` with a voltage-variable value."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Continuous Mode",
+            "description": "Enable continuous GPS/GNSS sampling.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"continuous\"}"
+          },
+          {
+            "title": "Periodic Mode",
+            "description": "Enable periodic location sampling at 1-hour intervals.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"periodic\", \"seconds\": 3600}"
+          },
+          {
+            "title": "Geofence Mode",
+            "description": "Enable geofencing with specific location and radius.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"periodic\", \"lat\": 42.5776, \"lon\": -70.87134, \"max\": 100, \"minutes\": 2}"
+          },
+          {
+            "title": "Fixed Mode",
+            "description": "Set a fixed location for the device.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"fixed\", \"lat\": 42.5776, \"lon\": -70.87134}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "lat": {
+                      "description": "If geofence is enabled, the geofence center latitude in degrees.",
+                      "type": "number"
+                    },
+                    "lon": {
+                      "description": "If geofence is enabled, the geofence center longitude in degrees.",
+                      "type": "number"
+                    },
+                    "max": {
+                      "description": "If geofence is enabled, the meters from geofence center.",
+                      "type": "integer"
+                    },
+                    "minutes": {
+                      "description": "If geofence is enabled, the currently configured geofence debounce period.",
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "description": "The current location mode.",
+                      "type": "string",
+                      "enum": [
+                        "continuous",
+                        "periodic",
+                        "off",
+                        "fixed"
+                      ],
+                      "x-sub-descriptions": [
+                        {
+                          "const": "continuous",
+                          "description": "Enables the Notecard's onboard GPS/GNSS module for continuous sampling, at a maximum frequency of one fix every 5 seconds. When in continuous mode the Notecard samples a new GPS/GNSS reading for every new Note."
+                        },
+                        {
+                          "const": "periodic",
+                          "description": "Samples location at a specified interval, if the device has moved."
+                        },
+                        {
+                          "const": "off",
+                          "description": "Turns location mode off. Approximate location may still be ascertained from Notehub."
+                        },
+                        {
+                          "const": "fixed",
+                          "description": "Reports the location as a fixed location using the specified `lat` and `lon` coordinates. This is the only supported mode on Notecard LoRa."
+                        }
+                      ]
+                    },
+                    "seconds": {
+                      "description": "If specified, the periodic sample interval.",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "threshold": {
+                      "description": "When in periodic mode, the number of motion events (registered by the built-in accelerometer) required to trigger GPS to turn on.",
+                      "type": "integer",
+                      "x-min-api-version": "3.4.1"
+                    },
+                    "vseconds": {
+                      "description": "If specified, the voltage-variable period.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.location.mode Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Location Mode Response",
+                "description": "Example response showing current location mode configuration.",
+                "json": "{\"mode\": \"continuous\", \"max\": 100, \"lat\": 42.5776, \"lon\": -70.87134, \"minutes\": 2, \"threshold\": 4}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "put": {
+        "operationId": "card_location_mode_set",
+        "summary": "Sets location-related configuration settings. Retrieves the current location mode when passed with no argument.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.location.mode",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires_any": [
+            "mode",
+            "seconds",
+            "lat",
+            "lon"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.location.mode Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "delete": {
+                    "description": "Set to `true` to delete the last known location stored in the Notecard.",
+                    "type": "boolean"
+                  },
+                  "lat": {
+                    "description": "When in periodic or continuous mode, providing this value enables [geofencing](/notecard/notecard-walkthrough/time-and-location-requests#geofencing-with-the-notecard). The value you provide for this argument should be the latitude of the center of the geofence, in degrees. When in fixed mode, the value you provide for this argument should be the latitude location of the device itself, in degrees.",
+                    "type": "number",
+                    "default": "last known latitude"
+                  },
+                  "lon": {
+                    "description": "When in periodic or continuous mode, providing this value enables [geofencing](/notecard/notecard-walkthrough/time-and-location-requests#geofencing-with-the-notecard). The value you provide for this argument should be the longitude of the center of the geofence, in degrees. When in fixed mode, the value you provide for this argument should be the longitude location of the device itself, in degrees.",
+                    "type": "number",
+                    "default": "last known longitude"
+                  },
+                  "max": {
+                    "description": "Meters from a geofence center. Used to enable geofence location tracking.",
+                    "type": "integer"
+                  },
+                  "minutes": {
+                    "description": "When geofence is enabled, the number of minutes the device should be outside the geofence before the Notecard location is tracked.",
+                    "type": "integer",
+                    "default": 5
+                  },
+                  "mode": {
+                    "description": "Sets the location mode.",
+                    "type": "string",
+                    "enum": [
+                      "",
+                      "off",
+                      "periodic",
+                      "continuous",
+                      "fixed"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "",
+                        "description": "Retrieves the current mode."
+                      },
+                      {
+                        "const": "off",
+                        "description": "Turns location mode off. Approximate location may still be [ascertained from Notehub](/notecard/notecard-walkthrough/time-and-location-requests#ascertaining-an-approximate-device-location)."
+                      },
+                      {
+                        "const": "periodic",
+                        "description": "Samples location at a specified interval, if the device has moved."
+                      },
+                      {
+                        "const": "continuous",
+                        "description": "Enables the Notecard's onboard GPS/GNSS module for continuous sampling, at a maximum frequency of one fix every 5 seconds. When in continuous mode the Notecard samples a new GPS/GNSS reading for every new Note."
+                      },
+                      {
+                        "const": "fixed",
+                        "description": "Reports the location as a fixed location using the specified `lat` and `lon` coordinates. This is the only supported mode on Notecard LoRa."
+                      }
+                    ]
+                  },
+                  "seconds": {
+                    "description": "When in `periodic` mode, location will be sampled at this interval, if the Notecard detects motion. If seconds is < 300, during periods of sustained movement the Notecard will leave its onboard GPS/GNSS on continuously to avoid powering the module on and off repeatedly.",
+                    "type": "integer",
+                    "anyOf": [
+                      {
+                        "const": -1
+                      },
+                      {
+                        "minimum": 5
+                      }
+                    ]
+                  },
+                  "threshold": {
+                    "description": "When in `periodic` mode, the number of motion events (registered by the built-in accelerometer) required to trigger GPS to turn on.",
+                    "type": "integer",
+                    "default": 0,
+                    "x-min-api-version": "3.4.1"
+                  },
+                  "vseconds": {
+                    "description": "In `periodic` mode, overrides `seconds` with a voltage-variable value.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Continuous Mode",
+            "description": "Enable continuous GPS/GNSS sampling.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"continuous\"}"
+          },
+          {
+            "title": "Periodic Mode",
+            "description": "Enable periodic location sampling at 1-hour intervals.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"periodic\", \"seconds\": 3600}"
+          },
+          {
+            "title": "Geofence Mode",
+            "description": "Enable geofencing with specific location and radius.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"periodic\", \"lat\": 42.5776, \"lon\": -70.87134, \"max\": 100, \"minutes\": 2}"
+          },
+          {
+            "title": "Fixed Mode",
+            "description": "Set a fixed location for the device.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"fixed\", \"lat\": 42.5776, \"lon\": -70.87134}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "lat": {
+                      "description": "If geofence is enabled, the geofence center latitude in degrees.",
+                      "type": "number"
+                    },
+                    "lon": {
+                      "description": "If geofence is enabled, the geofence center longitude in degrees.",
+                      "type": "number"
+                    },
+                    "max": {
+                      "description": "If geofence is enabled, the meters from geofence center.",
+                      "type": "integer"
+                    },
+                    "minutes": {
+                      "description": "If geofence is enabled, the currently configured geofence debounce period.",
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "description": "The current location mode.",
+                      "type": "string",
+                      "enum": [
+                        "continuous",
+                        "periodic",
+                        "off",
+                        "fixed"
+                      ],
+                      "x-sub-descriptions": [
+                        {
+                          "const": "continuous",
+                          "description": "Enables the Notecard's onboard GPS/GNSS module for continuous sampling, at a maximum frequency of one fix every 5 seconds. When in continuous mode the Notecard samples a new GPS/GNSS reading for every new Note."
+                        },
+                        {
+                          "const": "periodic",
+                          "description": "Samples location at a specified interval, if the device has moved."
+                        },
+                        {
+                          "const": "off",
+                          "description": "Turns location mode off. Approximate location may still be ascertained from Notehub."
+                        },
+                        {
+                          "const": "fixed",
+                          "description": "Reports the location as a fixed location using the specified `lat` and `lon` coordinates. This is the only supported mode on Notecard LoRa."
+                        }
+                      ]
+                    },
+                    "seconds": {
+                      "description": "If specified, the periodic sample interval.",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "threshold": {
+                      "description": "When in periodic mode, the number of motion events (registered by the built-in accelerometer) required to trigger GPS to turn on.",
+                      "type": "integer",
+                      "x-min-api-version": "3.4.1"
+                    },
+                    "vseconds": {
+                      "description": "If specified, the voltage-variable period.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.location.mode Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Location Mode Response",
+                "description": "Example response showing current location mode configuration.",
+                "json": "{\"mode\": \"continuous\", \"max\": 100, \"lat\": 42.5776, \"lon\": -70.87134, \"minutes\": 2, \"threshold\": 4}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "card_location_mode_delete",
+        "summary": "Sets location-related configuration settings. Retrieves the current location mode when passed with no argument.",
+        "x-safety": "destructive",
+        "x-notecard-request": "card.location.mode",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "delete"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.location.mode Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "delete": {
+                    "description": "Set to `true` to delete the last known location stored in the Notecard.",
+                    "type": "boolean"
+                  },
+                  "lat": {
+                    "description": "When in periodic or continuous mode, providing this value enables [geofencing](/notecard/notecard-walkthrough/time-and-location-requests#geofencing-with-the-notecard). The value you provide for this argument should be the latitude of the center of the geofence, in degrees. When in fixed mode, the value you provide for this argument should be the latitude location of the device itself, in degrees.",
+                    "type": "number",
+                    "default": "last known latitude"
+                  },
+                  "lon": {
+                    "description": "When in periodic or continuous mode, providing this value enables [geofencing](/notecard/notecard-walkthrough/time-and-location-requests#geofencing-with-the-notecard). The value you provide for this argument should be the longitude of the center of the geofence, in degrees. When in fixed mode, the value you provide for this argument should be the longitude location of the device itself, in degrees.",
+                    "type": "number",
+                    "default": "last known longitude"
+                  },
+                  "max": {
+                    "description": "Meters from a geofence center. Used to enable geofence location tracking.",
+                    "type": "integer"
+                  },
+                  "minutes": {
+                    "description": "When geofence is enabled, the number of minutes the device should be outside the geofence before the Notecard location is tracked.",
+                    "type": "integer",
+                    "default": 5
+                  },
+                  "mode": {
+                    "description": "Sets the location mode.",
+                    "type": "string",
+                    "enum": [
+                      "",
+                      "off",
+                      "periodic",
+                      "continuous",
+                      "fixed"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "",
+                        "description": "Retrieves the current mode."
+                      },
+                      {
+                        "const": "off",
+                        "description": "Turns location mode off. Approximate location may still be [ascertained from Notehub](/notecard/notecard-walkthrough/time-and-location-requests#ascertaining-an-approximate-device-location)."
+                      },
+                      {
+                        "const": "periodic",
+                        "description": "Samples location at a specified interval, if the device has moved."
+                      },
+                      {
+                        "const": "continuous",
+                        "description": "Enables the Notecard's onboard GPS/GNSS module for continuous sampling, at a maximum frequency of one fix every 5 seconds. When in continuous mode the Notecard samples a new GPS/GNSS reading for every new Note."
+                      },
+                      {
+                        "const": "fixed",
+                        "description": "Reports the location as a fixed location using the specified `lat` and `lon` coordinates. This is the only supported mode on Notecard LoRa."
+                      }
+                    ]
+                  },
+                  "seconds": {
+                    "description": "When in `periodic` mode, location will be sampled at this interval, if the Notecard detects motion. If seconds is < 300, during periods of sustained movement the Notecard will leave its onboard GPS/GNSS on continuously to avoid powering the module on and off repeatedly.",
+                    "type": "integer",
+                    "anyOf": [
+                      {
+                        "const": -1
+                      },
+                      {
+                        "minimum": 5
+                      }
+                    ]
+                  },
+                  "threshold": {
+                    "description": "When in `periodic` mode, the number of motion events (registered by the built-in accelerometer) required to trigger GPS to turn on.",
+                    "type": "integer",
+                    "default": 0,
+                    "x-min-api-version": "3.4.1"
+                  },
+                  "vseconds": {
+                    "description": "In `periodic` mode, overrides `seconds` with a voltage-variable value.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Continuous Mode",
+            "description": "Enable continuous GPS/GNSS sampling.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"continuous\"}"
+          },
+          {
+            "title": "Periodic Mode",
+            "description": "Enable periodic location sampling at 1-hour intervals.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"periodic\", \"seconds\": 3600}"
+          },
+          {
+            "title": "Geofence Mode",
+            "description": "Enable geofencing with specific location and radius.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"periodic\", \"lat\": 42.5776, \"lon\": -70.87134, \"max\": 100, \"minutes\": 2}"
+          },
+          {
+            "title": "Fixed Mode",
+            "description": "Set a fixed location for the device.",
+            "json": "{\"req\": \"card.location.mode\", \"mode\": \"fixed\", \"lat\": 42.5776, \"lon\": -70.87134}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "lat": {
+                      "description": "If geofence is enabled, the geofence center latitude in degrees.",
+                      "type": "number"
+                    },
+                    "lon": {
+                      "description": "If geofence is enabled, the geofence center longitude in degrees.",
+                      "type": "number"
+                    },
+                    "max": {
+                      "description": "If geofence is enabled, the meters from geofence center.",
+                      "type": "integer"
+                    },
+                    "minutes": {
+                      "description": "If geofence is enabled, the currently configured geofence debounce period.",
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "description": "The current location mode.",
+                      "type": "string",
+                      "enum": [
+                        "continuous",
+                        "periodic",
+                        "off",
+                        "fixed"
+                      ],
+                      "x-sub-descriptions": [
+                        {
+                          "const": "continuous",
+                          "description": "Enables the Notecard's onboard GPS/GNSS module for continuous sampling, at a maximum frequency of one fix every 5 seconds. When in continuous mode the Notecard samples a new GPS/GNSS reading for every new Note."
+                        },
+                        {
+                          "const": "periodic",
+                          "description": "Samples location at a specified interval, if the device has moved."
+                        },
+                        {
+                          "const": "off",
+                          "description": "Turns location mode off. Approximate location may still be ascertained from Notehub."
+                        },
+                        {
+                          "const": "fixed",
+                          "description": "Reports the location as a fixed location using the specified `lat` and `lon` coordinates. This is the only supported mode on Notecard LoRa."
+                        }
+                      ]
+                    },
+                    "seconds": {
+                      "description": "If specified, the periodic sample interval.",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "threshold": {
+                      "description": "When in periodic mode, the number of motion events (registered by the built-in accelerometer) required to trigger GPS to turn on.",
+                      "type": "integer",
+                      "x-min-api-version": "3.4.1"
+                    },
+                    "vseconds": {
+                      "description": "If specified, the voltage-variable period.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.location.mode Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Location Mode Response",
+                "description": "Example response showing current location mode configuration.",
+                "json": "{\"mode\": \"continuous\", \"max\": 100, \"lat\": 42.5776, \"lon\": -70.87134, \"minutes\": 2, \"threshold\": 4}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/location/track": {
+      "put": {
+        "operationId": "card_location_track",
+        "summary": "Store location data in a Notefile at the `periodic` interval, or using a specified `heartbeat`.\n\nThis request is only available when the `card.location.mode` request has been set to `periodic`\u2014e.g. `{\"req\":\"card.location.mode\",\"mode\":\"periodic\",\"seconds\":300}`. If you want to track and transmit data simultaneously consider using an [external GPS/GNSS module with the Notecard](/blog/using-an-external-gps-with-the-notecard/).\n\nIf you connect a BME280 sensor on the I2C bus, Notecard will include a temperature, humidity, and pressure reading with each captured Note. If you connect an ENS210 sensor on the I2C bus, Notecard will include a temperature and pressure reading with each captured Note. Learn more in [_track.qo](/api-reference/system-notefiles/#track-qo).",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.location.track",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.location.track Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "description": "The Notefile in which to store tracked location data. See the `_track.qo` Notefile's [documentation](/api-reference/system-notefiles/#track-qo) for details on the format of the data captured.",
+                    "type": "string",
+                    "default": "_track.qo"
+                  },
+                  "heartbeat": {
+                    "description": "When `start` is `true`, set to `true` to enable tracking even when motion is not detected. If using `heartbeat`, also set the `hours` below.",
+                    "type": "boolean"
+                  },
+                  "hours": {
+                    "description": "If `heartbeat` is true, add a heartbeat entry at this hourly interval. Use a negative integer to specify a heartbeat in minutes instead of hours.",
+                    "type": "integer"
+                  },
+                  "payload": {
+                    "description": "A base64-encoded binary payload to be included in the next `_track.qo` Note. See the guide on [Sampling at Predefined Intervals](/notecard/notecard-walkthrough/time-and-location-requests/#sampling-at-predefined-intervals) for more details.",
+                    "type": "string",
+                    "contentEncoding": "base64",
+                    "x-min-api-version": "7.5.2"
+                  },
+                  "start": {
+                    "description": "Set to `true` to start Notefile tracking.",
+                    "type": "boolean"
+                  },
+                  "stop": {
+                    "description": "Set to `true` to stop Notefile tracking.",
+                    "type": "boolean"
+                  },
+                  "sync": {
+                    "description": "Set to `true` to perform an immediate sync to the Notehub each time a new Note is added.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Start",
+            "description": "Start location tracking.",
+            "json": "{\"req\": \"card.location.track\", \"start\": true}"
+          },
+          {
+            "title": "Stop",
+            "description": "Stop location tracking.",
+            "json": "{\"req\": \"card.location.track\", \"stop\": true}"
+          },
+          {
+            "title": "Heartbeat",
+            "description": "Start tracking with heartbeat mode and immediate sync.",
+            "json": "{\"req\": \"card.location.track\", \"start\": true, \"sync\": true, \"heartbeat\": true, \"hours\": 2}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "file": {
+                      "description": "The tracking Notefile, if provided.",
+                      "type": "string"
+                    },
+                    "heartbeat": {
+                      "description": "`true` if heartbeat is enabled.",
+                      "type": "boolean"
+                    },
+                    "minutes": {
+                      "description": "The `heartbeat` interval in minutes, if provided.",
+                      "type": "integer"
+                    },
+                    "seconds": {
+                      "description": "If tracking is enabled and a heartbeat `hours` value is not set, the tracking interval set in `card.location.mode`.",
+                      "type": "integer"
+                    },
+                    "start": {
+                      "description": "`true` if tracking is enabled.",
+                      "type": "boolean"
+                    },
+                    "stop": {
+                      "description": "`true` if tracking is disabled.",
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.location.track Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Location Track Response",
+                "description": "Example response showing tracking configuration with heartbeat enabled.",
+                "json": "{\"start\": true, \"heartbeat\": true, \"file\": \"locations.qo\", \"minutes\": 120}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/monitor": {
+      "put": {
+        "operationId": "card_monitor",
+        "summary": "When a Notecard is in [monitor mode](https://dev.blues.io/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins/#using-monitor-mode), this API is used to configure the general-purpose `AUX1`-`AUX4` pins to test and monitor Notecard activity.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.monitor",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.monitor Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "count": {
+                    "description": "The number of pulses to send to the overridden AUX pin LED. Set this value to `0` to return the LED to its default behavior.",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "mode": {
+                    "description": "Can be set to one of `green`, `red` or `yellow` to temporarily override the behavior of an AUX pin LED.\n\nSee [Using Monitor Mode](https://dev.blues.io/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins/#using-monitor-mode) for additional details.",
+                    "type": "string",
+                    "enum": [
+                      "green",
+                      "red",
+                      "yellow"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "green",
+                        "description": "Temporarily override the behavior of the green AUX pin LED."
+                      },
+                      {
+                        "const": "red",
+                        "description": "Temporarily override the behavior of the red AUX pin LED."
+                      },
+                      {
+                        "const": "yellow",
+                        "description": "Temporarily override the behavior of the yellow AUX pin LED."
+                      }
+                    ]
+                  },
+                  "usb": {
+                    "description": "Set to `true` to configure LED behavior so that it is only active when the Notecard is connected to USB power.",
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Override LED Behavior",
+            "description": "Configure the green LED to pulse 5 times.",
+            "json": "{\"req\":\"card.monitor\", \"mode\":\"green\", \"count\":5}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "x-title": "card.monitor Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/motion": {
+      "get": {
+        "operationId": "card_motion",
+        "summary": "Returns information about the Notecard accelerometer's motion and orientation. Motion tracking must be enabled first with `card.motion.mode`. Otherwise, this request will return `{}`.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.motion",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.motion Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "minutes",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Amount of time to sample for buckets of accelerometer-measured movement. For instance, `5` will sample motion events for the previous five minutes and return a `movements` string with motion counts in each bucket."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Motion with Minutes Sampling",
+            "description": "Request motion information with 2-minute sampling buckets.",
+            "json": "{\"req\": \"card.motion\", \"minutes\": 2}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "alert": {
+                      "description": "`true` if the Notecard's accelerometer detected a free-fall since the last request to `card.motion`.",
+                      "type": "boolean"
+                    },
+                    "count": {
+                      "description": "The number of accelerometer motion events since the `card.motion` request was last made.",
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "description": "Returns the current motion status of the Notecard (e.g. `\"stopped\"` or `\"moving\"`). Learn how to configure this feature [in this guide](/guides-and-tutorials/notecard-guides/asset-tracking-with-gps#wake-host-or-send-note-on-motion-status-change).",
+                      "type": "string"
+                    },
+                    "motion": {
+                      "description": "Time of the last accelerometer motion event.",
+                      "type": "integer"
+                    },
+                    "movements": {
+                      "description": "If the `minutes` argument is provided, a string of base-36 characters, where each character represents the number of accelerometer movements in each bucket during the sample duration. Each character will be a digit 0-9, A-Z to indicate a count of 10-35, or `*` to indicate a count greater than 35.",
+                      "type": "string"
+                    },
+                    "seconds": {
+                      "description": "If the `minutes` argument is provided, the duration of each bucket of sample accelerometer movements.",
+                      "type": "integer"
+                    },
+                    "status": {
+                      "description": "Comma-separated list of accelerometer orientation events that ocurred since the last request to `card.motion`. One or more of the following: `\"face-up\"`, `\"face-down\"`, `\"portrait-up\"`, `\"portrait-down\"`, `\"landscape-right\"`, `\"landscape-left\"`, `\"angled\"`.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "x-title": "card.motion Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Motion Response",
+                "description": "Example response showing motion data with sampling buckets.",
+                "json": "{\"count\": 17, \"status\": \"face-up\", \"alert\": true, \"motion\": 1599741952, \"seconds\": 5, \"movements\": \"520000000000000000000A\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/motion/mode": {
+      "put": {
+        "operationId": "card_motion_mode",
+        "summary": "Configures accelerometer motion monitoring parameters used when providing results to `card.motion`.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.motion.mode",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.motion.mode Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "motion": {
+                    "description": "If `motion` is > 0, a [card.motion](/api-reference/notecard-api/card-requests#card-motion) request will return a `\"mode\"` of `\"moving\"` or `\"stopped\"`. The `motion` value is the threshold for how many motion events in a single bucket will trigger a motion status change.\n\nLearn how to configure this feature [in this guide](/guides-and-tutorials/notecard-guides/asset-tracking-with-gps/#wake-host-or-send-note-on-motion-status-change).",
+                    "type": "integer"
+                  },
+                  "seconds": {
+                    "description": "Period for each bucket of movements to be accumulated when `minutes` is used with `card.motion`.",
+                    "type": "integer"
+                  },
+                  "sensitivity": {
+                    "description": "Used to set the accelerometer sample rate. The default sample rate of 1.6Hz could miss short-duration accelerations (e.g. bumps and jolts), and free fall detection may not work reliably with short falls. The penalty for increasing the sample rate to 25Hz is increased current consumption by ~1.5uA relative to the default `-1` setting.",
+                    "type": "integer",
+                    "default": -1,
+                    "enum": [
+                      -1,
+                      0,
+                      1,
+                      2,
+                      3,
+                      4,
+                      5
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": -1,
+                        "description": "1.6Hz, +/-2G range, 1 milli-G sensitivity"
+                      },
+                      {
+                        "const": 0,
+                        "description": "Not specified. Do not modify the current sample rate."
+                      },
+                      {
+                        "const": 1,
+                        "description": "25Hz, +/- 16G range, 7.8 milli-G sensitivity"
+                      },
+                      {
+                        "const": 2,
+                        "description": "25Hz, +/- 8G range, 3.9 milli-G sensitivity"
+                      },
+                      {
+                        "const": 3,
+                        "description": "25Hz, +/- 4G range, 1.95 milli-G sensitivity"
+                      },
+                      {
+                        "const": 4,
+                        "description": "25Hz, +/- 2G range, 1 milli-G sensitivity"
+                      },
+                      {
+                        "const": 5,
+                        "description": "25Hz, +/- 2G range, 0.25 milli-G sensitivity"
+                      }
+                    ],
+                    "x-min-api-version": "3.3.1"
+                  },
+                  "start": {
+                    "description": "`true` to enable the Notecard accelerometer and start motion tracking.",
+                    "type": "boolean"
+                  },
+                  "stop": {
+                    "description": "`true` to disable the Notecard accelerometer and stop motion tracking.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Start Motion Tracking",
+            "description": "Enable motion tracking with default settings.",
+            "json": "{\"req\": \"card.motion.mode\", \"start\": true}"
+          },
+          {
+            "title": "Configure Motion Tracking with Parameters",
+            "description": "Enable motion tracking with custom sensitivity and bucket duration.",
+            "json": "{\"req\": \"card.motion.mode\", \"start\": true, \"seconds\": 10, \"sensitivity\": 2}"
+          },
+          {
+            "title": "Stop Motion Tracking",
+            "description": "Disable motion tracking.",
+            "json": "{\"req\": \"card.motion.mode\", \"stop\": true}"
+          },
+          {
+            "title": "Configure Motion Status Change",
+            "description": "Set motion threshold for status change detection.",
+            "json": "{\"req\": \"card.motion.mode\", \"motion\": 5, \"seconds\": 60}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response from configuring accelerometer motion monitoring parameters.",
+            "x-title": "card.motion.mode Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/motion/sync": {
+      "put": {
+        "operationId": "card_motion_sync",
+        "summary": "Configures automatic sync triggered by Notecard movement.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.motion.sync",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.motion.sync Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "count": {
+                    "description": "The number of most recent motion buckets to examine.",
+                    "type": "integer"
+                  },
+                  "minutes": {
+                    "description": "The maximum frequency at which sync will be triggered. Even if a `threshold` is set and exceeded, there will only be a single sync for this amount of time.",
+                    "type": "integer"
+                  },
+                  "start": {
+                    "description": "`true` to start motion-triggered syncing.",
+                    "type": "boolean"
+                  },
+                  "stop": {
+                    "description": "`true` to stop motion-triggered syncing.",
+                    "type": "boolean"
+                  },
+                  "threshold": {
+                    "description": "The number of buckets that must indicate motion in order to trigger a sync. If set to `0`, the Notecard will only perform a sync when its orientation changes.",
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Start Motion-Triggered Sync",
+            "description": "Enable motion-triggered syncing with default settings.",
+            "json": "{\"req\": \"card.motion.sync\", \"start\": true}"
+          },
+          {
+            "title": "Configure Motion Sync Parameters",
+            "description": "Set motion sync with specific timing and threshold parameters.",
+            "json": "{\"req\": \"card.motion.sync\", \"start\": true, \"minutes\": 20, \"count\": 20, \"threshold\": 5}"
+          },
+          {
+            "title": "Stop Motion-Triggered Sync",
+            "description": "Disable motion-triggered syncing.",
+            "json": "{\"req\": \"card.motion.sync\", \"stop\": true}"
+          },
+          {
+            "title": "Orientation Change Only",
+            "description": "Configure sync to trigger only on orientation changes.",
+            "json": "{\"req\": \"card.motion.sync\", \"start\": true, \"threshold\": 0, \"minutes\": 10}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response from configuring automatic sync triggered by Notecard movement.",
+            "x-title": "card.motion.sync Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/motion/track": {
+      "put": {
+        "operationId": "card_motion_track",
+        "summary": "Configures automatic capture of Notecard accelerometer motion in a Notefile.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.motion.track",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.motion.track Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "count": {
+                    "description": "The number of most recent motion buckets to examine.",
+                    "type": "integer"
+                  },
+                  "file": {
+                    "description": "The Notefile to use for motion capture Notes. See the [`_motion.qo` Notefile's documentation](/api-reference/system-notefiles#motion-qo) for details on the format of the data captured.",
+                    "type": "string",
+                    "default": "_motion.qo"
+                  },
+                  "minutes": {
+                    "description": "The maximum period to capture Notes in the Notefile.",
+                    "type": "integer"
+                  },
+                  "now": {
+                    "description": "Set to `true` to trigger the immediate creation of a `_motion.qo` event if the orientation of the Notecard changes (overriding the `minutes` setting).",
+                    "type": "boolean"
+                  },
+                  "start": {
+                    "description": "`true` to start motion capture.",
+                    "type": "boolean"
+                  },
+                  "stop": {
+                    "description": "`true` to stop motion capture.",
+                    "type": "boolean"
+                  },
+                  "threshold": {
+                    "description": "The number of buckets that must indicate motion in order to capture.",
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Start Motion Tracking",
+            "description": "Enable motion tracking with default settings.",
+            "json": "{\"req\": \"card.motion.track\", \"start\": true}"
+          },
+          {
+            "title": "Configure Motion Tracking with Custom File",
+            "description": "Set motion tracking with custom parameters and Notefile.",
+            "json": "{\"req\": \"card.motion.track\", \"start\": true, \"minutes\": 20, \"count\": 20, \"threshold\": 5, \"file\": \"movements.qo\"}"
+          },
+          {
+            "title": "Stop Motion Tracking",
+            "description": "Disable motion tracking.",
+            "json": "{\"req\": \"card.motion.track\", \"stop\": true}"
+          },
+          {
+            "title": "Enable Immediate Orientation Changes",
+            "description": "Configure motion tracking with immediate orientation change capture.",
+            "json": "{\"req\": \"card.motion.track\", \"start\": true, \"now\": true, \"minutes\": 15}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response from configuring automatic capture of Notecard accelerometer motion in a Notefile.",
+            "x-title": "card.motion.track Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/power": {
+      "get": {
+        "operationId": "card_power_query",
+        "summary": "The `card.power` API is used to configure a connected Mojo device or to manually request power consumption readings in firmware.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.power",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "8.1.3",
+        "x-title": "card.power Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "minutes",
+            "in": "query",
+            "schema": {
+              "default": 720,
+              "type": "integer"
+            },
+            "description": "How often, in minutes, Notecard should log power consumption in a `_log.qo` Note. The default value is `720` (12 hours)."
+          },
+          {
+            "name": "reset",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Set to `true` to reset the power consumption counters back to 0."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Get Latest Power Consumption Reading",
+            "description": "Request current power consumption data.",
+            "json": "{\"req\": \"card.power\"}"
+          },
+          {
+            "title": "Set Cadence of Readings",
+            "description": "Configure how often power consumption is logged.",
+            "json": "{\"req\": \"card.power\", \"minutes\": 60}"
+          },
+          {
+            "title": "Reset Counters",
+            "description": "Reset power consumption counters back to 0.",
+            "json": "{\"cmd\": \"card.power\", \"reset\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing power consumption readings and environmental data from the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "milliamp_hours": {
+                      "description": "The cumulative number of milliamp hours (mAh) consumed. You can reset this number with this request's `reset` argument.",
+                      "type": "number"
+                    },
+                    "temperature": {
+                      "description": "The temperature from Notecard's onboard sensor in degrees centigrade, including the calibration offset.",
+                      "type": "number"
+                    },
+                    "voltage": {
+                      "description": "The current voltage.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.power Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Power Consumption Response",
+                "description": "Example response with power consumption data.",
+                "json": "{\"temperature\": 26.028314208984398, \"voltage\": 4.200970458984375, \"milliamp_hours\": 3.9566722000000007}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "8.1.3"
+          }
+        }
+      },
+      "put": {
+        "operationId": "card_power_set",
+        "summary": "The `card.power` API is used to configure a connected Mojo device or to manually request power consumption readings in firmware.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.power",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "minutes"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "8.1.3",
+        "x-title": "card.power Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "minutes": {
+                    "description": "How often, in minutes, Notecard should log power consumption in a `_log.qo` Note. The default value is `720` (12 hours).",
+                    "default": 720,
+                    "type": "integer"
+                  },
+                  "reset": {
+                    "description": "Set to `true` to reset the power consumption counters back to 0.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Get Latest Power Consumption Reading",
+            "description": "Request current power consumption data.",
+            "json": "{\"req\": \"card.power\"}"
+          },
+          {
+            "title": "Set Cadence of Readings",
+            "description": "Configure how often power consumption is logged.",
+            "json": "{\"req\": \"card.power\", \"minutes\": 60}"
+          },
+          {
+            "title": "Reset Counters",
+            "description": "Reset power consumption counters back to 0.",
+            "json": "{\"cmd\": \"card.power\", \"reset\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing power consumption readings and environmental data from the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "milliamp_hours": {
+                      "description": "The cumulative number of milliamp hours (mAh) consumed. You can reset this number with this request's `reset` argument.",
+                      "type": "number"
+                    },
+                    "temperature": {
+                      "description": "The temperature from Notecard's onboard sensor in degrees centigrade, including the calibration offset.",
+                      "type": "number"
+                    },
+                    "voltage": {
+                      "description": "The current voltage.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.power Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Power Consumption Response",
+                "description": "Example response with power consumption data.",
+                "json": "{\"temperature\": 26.028314208984398, \"voltage\": 4.200970458984375, \"milliamp_hours\": 3.9566722000000007}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "8.1.3"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "card_power_delete",
+        "summary": "The `card.power` API is used to configure a connected Mojo device or to manually request power consumption readings in firmware.",
+        "x-safety": "destructive",
+        "x-notecard-request": "card.power",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "reset"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "8.1.3",
+        "x-title": "card.power Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "minutes": {
+                    "description": "How often, in minutes, Notecard should log power consumption in a `_log.qo` Note. The default value is `720` (12 hours).",
+                    "default": 720,
+                    "type": "integer"
+                  },
+                  "reset": {
+                    "description": "Set to `true` to reset the power consumption counters back to 0.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Get Latest Power Consumption Reading",
+            "description": "Request current power consumption data.",
+            "json": "{\"req\": \"card.power\"}"
+          },
+          {
+            "title": "Set Cadence of Readings",
+            "description": "Configure how often power consumption is logged.",
+            "json": "{\"req\": \"card.power\", \"minutes\": 60}"
+          },
+          {
+            "title": "Reset Counters",
+            "description": "Reset power consumption counters back to 0.",
+            "json": "{\"cmd\": \"card.power\", \"reset\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing power consumption readings and environmental data from the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "milliamp_hours": {
+                      "description": "The cumulative number of milliamp hours (mAh) consumed. You can reset this number with this request's `reset` argument.",
+                      "type": "number"
+                    },
+                    "temperature": {
+                      "description": "The temperature from Notecard's onboard sensor in degrees centigrade, including the calibration offset.",
+                      "type": "number"
+                    },
+                    "voltage": {
+                      "description": "The current voltage.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.power Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Power Consumption Response",
+                "description": "Example response with power consumption data.",
+                "json": "{\"temperature\": 26.028314208984398, \"voltage\": 4.200970458984375, \"milliamp_hours\": 3.9566722000000007}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "8.1.3"
+          }
+        }
+      }
+    },
+    "/card/random": {
+      "get": {
+        "operationId": "card_random",
+        "summary": "Obtain a single random 32 bit unsigned integer modulo or `count` number of bytes of random data from the Notecard hardware random number generator.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.random",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.random Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "If the `mode` argument is excluded from the request, the Notecard uses this as an upper-limit parameter and returns a random unsigned 32 bit integer between zero and the value provided.\n\nIf `\"mode\":\"payload\"` is used, this argument sets the number of random bytes of data to return in a base64-encoded buffer from the Notecard."
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "schema": {
+              "const": "payload",
+              "type": "string"
+            },
+            "description": "Accepts a single value `\"payload\"` and, if specified, uses the `count` value to determine the number of bytes of random data to generate and return to the host."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Get a Random Number",
+            "description": "Request a random integer between 0 and count-1.",
+            "json": "{\"req\": \"card.random\", \"count\": 100}"
+          },
+          {
+            "title": "Get a Buffer of Random Numbers",
+            "description": "Request random bytes returned as base64-encoded payload.",
+            "json": "{\"req\": \"card.random\", \"mode\": \"payload\", \"count\": 100}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing random number or random data generated by the Notecard's hardware random number generator.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "description": "A random number generated by the Notecard's onboard hardware random number generator.",
+                      "type": "integer"
+                    },
+                    "payload": {
+                      "description": "If using `\"mode\":\"payload\"`, a base64-encoded string with random values, the length of which is specified by the `count` argument.",
+                      "type": "string",
+                      "contentEncoding": "base64"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.random Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Random Number Response",
+                "description": "Example response with a random integer.",
+                "json": "{\"count\": 86}"
+              },
+              {
+                "title": "Random Payload Response",
+                "description": "Example response with base64-encoded random data.",
+                "json": "{\"payload\": \"SGVsbG8gV29ybGQ=\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/restart": {
+      "post": {
+        "operationId": "card_restart",
+        "summary": "Performs a firmware restart of the Notecard.",
+        "x-safety": "non-idempotent",
+        "x-notecard-request": "card.restart",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.restart Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Restart Notecard",
+            "description": "Perform a firmware restart of the Notecard.",
+            "json": "{\"cmd\": \"card.restart\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response from the Notecard restart command. The response is typically empty as the restart occurs immediately.",
+            "x-title": "card.restart Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/restore": {
+      "delete": {
+        "operationId": "card_restore",
+        "summary": "Performs a factory reset on the Notecard and restarts.\n\n*Sending this request without either of the optional arguments below will only reset the Notecard's file system, thus forcing a re-sync of all Notefiles from Notehub.*\n\nOn Notecard LoRa there is no option to retain configuration settings, and providing `\"delete\": true` is required. The Notecard LoRa retains LoRaWAN configuration after factory resets.",
+        "x-safety": "destructive",
+        "x-notecard-request": "card.restore",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.restore Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "connected": {
+                    "description": "Set to `true` to reset the Notecard on Notehub. This will delete and deprovision the Notecard from Notehub the next time the Notecard connects. This also removes any Notefile templates used by this device.\n\nConversely, if `connected` is `false` (or omitted), the Notecard's settings and data will be restored from Notehub the next time the Notecard connects to the previously used Notehub project.",
+                    "type": "boolean"
+                  },
+                  "delete": {
+                    "description": "Set to `true` to reset most Notecard configuration settings. Note that this does not reset stored WiFi credentials or the [alternate I2C address](/notecard/notecard-walkthrough/advanced-notecard-configuration/#change-the-notecard-i2c-address) (if previously set) so the Notecard can still contact the network after a reset.\n\n*The Notecard will be unable to sync with Notehub until the `ProductUID` is set again.*",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Complete Factory Reset",
+            "description": "Reset Notecard configuration and deprovision from Notehub.",
+            "json": "{\"req\": \"card.restore\", \"delete\": true, \"connected\": true}"
+          },
+          {
+            "title": "File System Reset Only",
+            "description": "Reset only the file system, forcing re-sync from Notehub.",
+            "json": "{\"req\": \"card.restore\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response from the Notecard factory reset command. The response is typically empty as the reset and restart occur immediately.",
+            "x-title": "card.restore Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/sleep": {
+      "put": {
+        "operationId": "card_sleep",
+        "summary": "Allows the ESP32-based Notecard WiFi v2 to fall back to a low current draw when idle (this behavior differs from the STM32-based Notecards that have a `STOP` mode where UART and I2C may still operate). Note that this power state is not available if the Notecard is plugged in via USB.\n\nRead more in the guide on using [Deep Sleep Mode on Notecard WiFi v2](/notecard/notecard-walkthrough/low-power-design#deep-sleep-mode-on-notecard-wifi-v2).",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.sleep",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.sleep Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "description": "Set to `\"accel\"` to wake from deep sleep on any movement detected by the onboard accelerometer. Set to `\"-accel\"` to reset to the default setting.",
+                    "type": "string",
+                    "enum": [
+                      "accel",
+                      "-accel"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "accel",
+                        "description": "Wake from deep sleep on any movement detected by the onboard accelerometer."
+                      },
+                      {
+                        "const": "-accel",
+                        "description": "Reset to the default setting."
+                      }
+                    ]
+                  },
+                  "off": {
+                    "description": "Set to `true` to disable the sleep mode on Notecard.",
+                    "type": "boolean"
+                  },
+                  "on": {
+                    "description": "Set to `true` to enable Notecard to sleep once it is idle for >= 30 seconds.",
+                    "type": "boolean"
+                  },
+                  "seconds": {
+                    "description": "The number of seconds the Notecard will wait before entering sleep mode (minimum value is 30).",
+                    "type": "integer",
+                    "anyOf": [
+                      {
+                        "const": -1
+                      },
+                      {
+                        "minimum": 30
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Enable Sleep Mode",
+            "description": "Enable sleep mode with default settings.",
+            "json": "{\"req\": \"card.sleep\", \"on\": true}"
+          },
+          {
+            "title": "Configure Sleep with Accelerometer Wake",
+            "description": "Enable sleep mode with accelerometer wake functionality.",
+            "json": "{\"req\": \"card.sleep\", \"on\": true, \"mode\": \"accel\"}"
+          },
+          {
+            "title": "Custom Sleep Timer",
+            "description": "Set custom wait time before entering sleep mode.",
+            "json": "{\"req\": \"card.sleep\", \"seconds\": 60}"
+          },
+          {
+            "title": "Disable Sleep Mode",
+            "description": "Disable sleep mode functionality.",
+            "json": "{\"cmd\": \"card.sleep\", \"off\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing current sleep mode configuration for Notecard WiFi v2.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "description": "Returns `\"accel\"` if the Notecard is configured to wake from deep sleep on any movement detected by the onboard accelerometer.",
+                      "type": "string"
+                    },
+                    "off": {
+                      "description": "`true` if sleep mode is disabled.",
+                      "type": "boolean"
+                    },
+                    "on": {
+                      "description": "`true` if sleep mode is enabled.",
+                      "type": "boolean"
+                    },
+                    "seconds": {
+                      "description": "The number of seconds the Notecard will wait before entering sleep mode (only included if default settings are overridden).",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.sleep Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Sleep Mode Status",
+                "description": "Example response showing current sleep configuration.",
+                "json": "{\"seconds\": 10, \"mode\": \"accel\", \"on\": true}"
+              }
+            ],
+            "x-skus": [
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/status": {
+      "get": {
+        "operationId": "card_status",
+        "summary": "Returns general information about the Notecard's operating status.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.status",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.status Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Get Notecard Status",
+            "description": "Request general information about the Notecard's operating status.",
+            "json": "{\"req\": \"card.status\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing general information about the Notecard's operating status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "cell": {
+                      "description": "`true` if the modem is currently powered on.",
+                      "type": "boolean"
+                    },
+                    "connected": {
+                      "description": "`true` if connected to Notehub.",
+                      "type": "boolean"
+                    },
+                    "gps": {
+                      "description": "`true` if Notecard's GPS module is currently powered on.",
+                      "type": "boolean",
+                      "x-min-api-version": "3.3.1"
+                    },
+                    "inbound": {
+                      "description": "The effective inbound synchronization period being used by the device. See [Configuring Synchronization Modes](/notecard/notecard-walkthrough/essential-requests/#configuring-synchronization-modes) for details on how Notecard synchronization modes work.",
+                      "type": "integer"
+                    },
+                    "outbound": {
+                      "description": "The effective outbound synchronization period being used by the device. See [Configuring Synchronization Modes](/notecard/notecard-walkthrough/essential-requests/#configuring-synchronization-modes) for details on how Notecard synchronization modes work.",
+                      "type": "integer"
+                    },
+                    "status": {
+                      "description": "General status information.",
+                      "type": "string"
+                    },
+                    "storage": {
+                      "description": "Indicates the percentage of total Notecard storage in use. Note that users can utilize approximately 80% of this total capacity.",
+                      "type": "integer"
+                    },
+                    "sync": {
+                      "description": "`true` if the Notecard has ever connected to Notehub.",
+                      "type": "boolean",
+                      "x-min-api-version": "7.5.1"
+                    },
+                    "time": {
+                      "description": "The UNIX Epoch Time of approximately when the Notecard was first powered up.",
+                      "type": "integer"
+                    },
+                    "usb": {
+                      "description": "`true` if the Notecard is being powered by USB.",
+                      "type": "boolean"
+                    },
+                    "wifi": {
+                      "description": "`true` if the Notecard's WiFi radio is currently powered on.",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.status Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Notecard Status Response",
+                "description": "Example response showing Notecard operating status information.",
+                "json": "{\"status\": \"{normal}\", \"usb\": true, \"storage\": 8, \"time\": 1599684765, \"connected\": true, \"cell\": true, \"sync\": true, \"inbound\": 60, \"outbound\": 360}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/temp": {
+      "get": {
+        "operationId": "card_temp_query",
+        "summary": "Get the current temperature from the Notecard's onboard calibrated temperature sensor.\n\nWhen using a Notecard Cellular or Notecard Cell+WiFi, if you connect a BME280 sensor on the I2C bus the Notecard will add `temperature`, `pressure`, and `humidity` fields to the response. If you connect an ENS210 sensor on the I2C bus the Notecard will add `temperature` and `pressure` fields to the response.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.temp",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.temp Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "minutes",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "If specified, creates a templated `_temp.qo` file that gathers Notecard temperature value at the specified minutes interval. _When using [card.aux track mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-aux-track-mode), the sensor temperature, pressure, and humidity is also included with each Note._"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Overrides `minutes` with a voltage-variable value. For example: `\"usb:15;high:30;normal:60;720\"`. See [Voltage-Variable Sync Behavior](/notecard/notecard-walkthrough/low-power-design#voltage-variable-sync-behavior) for more information on configuring these values."
+          },
+          {
+            "name": "stop",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If set to `true`, the Notecard will stop logging the temperature value at the interval specified with the `minutes` parameter (see above)."
+          },
+          {
+            "name": "sync",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If set to `true`, the Notecard will immediately sync any pending `_temp.qo` Notes created with the `minutes` parameter (see above)."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Get Card Temperature",
+            "description": "Get current temperature from Notecard's onboard sensor.",
+            "json": "{\"req\": \"card.temp\"}"
+          },
+          {
+            "title": "Configure Temperature Tracking",
+            "description": "Set up automatic temperature logging at 30-minute intervals.",
+            "json": "{\"req\": \"card.temp\", \"minutes\": 30}"
+          },
+          {
+            "title": "Stop Temperature Tracking",
+            "description": "Stop automatic temperature logging.",
+            "json": "{\"cmd\": \"card.temp\", \"stop\": true}"
+          },
+          {
+            "title": "Sync Temperature Notes",
+            "description": "Immediately sync pending temperature notes.",
+            "json": "{\"cmd\": \"card.temp\", \"sync\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing temperature readings from the Notecard's onboard sensor and any connected I2C sensors.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "calibration": {
+                      "description": "The calibration differential of the Notecard's onboard sensor.",
+                      "type": "number"
+                    },
+                    "humidity": {
+                      "description": "If the Notecard finds a BME280 sensor on the I2C bus, this field will be set to the humidity percentage value from the connected sensor.",
+                      "type": "number"
+                    },
+                    "pressure": {
+                      "description": "If the Notecard finds a BME280 or ENS210 sensor on the I2C bus, this field will be set to the atmospheric pressure value from the connected sensor in Pascals.",
+                      "type": "number"
+                    },
+                    "temperature": {
+                      "description": "If the Notecard finds a BME280 or ENS210 sensor on the I2C bus, this field will be set to the temperature value from the connected sensor in degrees centigrade.",
+                      "type": "number"
+                    },
+                    "usb": {
+                      "description": "`true` if the Notecard is connected to USB power.",
+                      "type": "boolean"
+                    },
+                    "value": {
+                      "description": "The current temperature from the Notecard's onboard sensor in degrees centigrade, including the calibration offset.",
+                      "type": "number"
+                    },
+                    "voltage": {
+                      "description": "The current voltage.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.temp Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Basic Temperature Response",
+                "description": "Example response with onboard sensor temperature and calibration.",
+                "json": "{\"value\": 27.625, \"calibration\": -3.0}"
+              },
+              {
+                "title": "Extended Sensor Response",
+                "description": "Example response with BME280 sensor data and power information.",
+                "json": "{\"value\": 25.5, \"calibration\": -2.5, \"temperature\": 24.8, \"humidity\": 45.2, \"pressure\": 101325, \"usb\": true, \"voltage\": 4.95}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "put": {
+        "operationId": "card_temp_set",
+        "summary": "Get the current temperature from the Notecard's onboard calibrated temperature sensor.\n\nWhen using a Notecard Cellular or Notecard Cell+WiFi, if you connect a BME280 sensor on the I2C bus the Notecard will add `temperature`, `pressure`, and `humidity` fields to the response. If you connect an ENS210 sensor on the I2C bus the Notecard will add `temperature` and `pressure` fields to the response.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.temp",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires_any": [
+            "minutes",
+            "status",
+            "sync"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.temp Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "minutes": {
+                    "description": "If specified, creates a templated `_temp.qo` file that gathers Notecard temperature value at the specified minutes interval. _When using [card.aux track mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-aux-track-mode), the sensor temperature, pressure, and humidity is also included with each Note._",
+                    "type": "integer"
+                  },
+                  "status": {
+                    "description": "Overrides `minutes` with a voltage-variable value. For example: `\"usb:15;high:30;normal:60;720\"`. See [Voltage-Variable Sync Behavior](/notecard/notecard-walkthrough/low-power-design#voltage-variable-sync-behavior) for more information on configuring these values.",
+                    "type": "string"
+                  },
+                  "stop": {
+                    "description": "If set to `true`, the Notecard will stop logging the temperature value at the interval specified with the `minutes` parameter (see above).",
+                    "type": "boolean"
+                  },
+                  "sync": {
+                    "description": "If set to `true`, the Notecard will immediately sync any pending `_temp.qo` Notes created with the `minutes` parameter (see above).",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Get Card Temperature",
+            "description": "Get current temperature from Notecard's onboard sensor.",
+            "json": "{\"req\": \"card.temp\"}"
+          },
+          {
+            "title": "Configure Temperature Tracking",
+            "description": "Set up automatic temperature logging at 30-minute intervals.",
+            "json": "{\"req\": \"card.temp\", \"minutes\": 30}"
+          },
+          {
+            "title": "Stop Temperature Tracking",
+            "description": "Stop automatic temperature logging.",
+            "json": "{\"cmd\": \"card.temp\", \"stop\": true}"
+          },
+          {
+            "title": "Sync Temperature Notes",
+            "description": "Immediately sync pending temperature notes.",
+            "json": "{\"cmd\": \"card.temp\", \"sync\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing temperature readings from the Notecard's onboard sensor and any connected I2C sensors.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "calibration": {
+                      "description": "The calibration differential of the Notecard's onboard sensor.",
+                      "type": "number"
+                    },
+                    "humidity": {
+                      "description": "If the Notecard finds a BME280 sensor on the I2C bus, this field will be set to the humidity percentage value from the connected sensor.",
+                      "type": "number"
+                    },
+                    "pressure": {
+                      "description": "If the Notecard finds a BME280 or ENS210 sensor on the I2C bus, this field will be set to the atmospheric pressure value from the connected sensor in Pascals.",
+                      "type": "number"
+                    },
+                    "temperature": {
+                      "description": "If the Notecard finds a BME280 or ENS210 sensor on the I2C bus, this field will be set to the temperature value from the connected sensor in degrees centigrade.",
+                      "type": "number"
+                    },
+                    "usb": {
+                      "description": "`true` if the Notecard is connected to USB power.",
+                      "type": "boolean"
+                    },
+                    "value": {
+                      "description": "The current temperature from the Notecard's onboard sensor in degrees centigrade, including the calibration offset.",
+                      "type": "number"
+                    },
+                    "voltage": {
+                      "description": "The current voltage.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.temp Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Basic Temperature Response",
+                "description": "Example response with onboard sensor temperature and calibration.",
+                "json": "{\"value\": 27.625, \"calibration\": -3.0}"
+              },
+              {
+                "title": "Extended Sensor Response",
+                "description": "Example response with BME280 sensor data and power information.",
+                "json": "{\"value\": 25.5, \"calibration\": -2.5, \"temperature\": 24.8, \"humidity\": 45.2, \"pressure\": 101325, \"usb\": true, \"voltage\": 4.95}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "card_temp_delete",
+        "summary": "Get the current temperature from the Notecard's onboard calibrated temperature sensor.\n\nWhen using a Notecard Cellular or Notecard Cell+WiFi, if you connect a BME280 sensor on the I2C bus the Notecard will add `temperature`, `pressure`, and `humidity` fields to the response. If you connect an ENS210 sensor on the I2C bus the Notecard will add `temperature` and `pressure` fields to the response.",
+        "x-safety": "destructive",
+        "x-notecard-request": "card.temp",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "stop"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.temp Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "minutes": {
+                    "description": "If specified, creates a templated `_temp.qo` file that gathers Notecard temperature value at the specified minutes interval. _When using [card.aux track mode](/notecard/notecard-walkthrough/working-with-the-notecard-aux-pins#using-aux-track-mode), the sensor temperature, pressure, and humidity is also included with each Note._",
+                    "type": "integer"
+                  },
+                  "status": {
+                    "description": "Overrides `minutes` with a voltage-variable value. For example: `\"usb:15;high:30;normal:60;720\"`. See [Voltage-Variable Sync Behavior](/notecard/notecard-walkthrough/low-power-design#voltage-variable-sync-behavior) for more information on configuring these values.",
+                    "type": "string"
+                  },
+                  "stop": {
+                    "description": "If set to `true`, the Notecard will stop logging the temperature value at the interval specified with the `minutes` parameter (see above).",
+                    "type": "boolean"
+                  },
+                  "sync": {
+                    "description": "If set to `true`, the Notecard will immediately sync any pending `_temp.qo` Notes created with the `minutes` parameter (see above).",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Get Card Temperature",
+            "description": "Get current temperature from Notecard's onboard sensor.",
+            "json": "{\"req\": \"card.temp\"}"
+          },
+          {
+            "title": "Configure Temperature Tracking",
+            "description": "Set up automatic temperature logging at 30-minute intervals.",
+            "json": "{\"req\": \"card.temp\", \"minutes\": 30}"
+          },
+          {
+            "title": "Stop Temperature Tracking",
+            "description": "Stop automatic temperature logging.",
+            "json": "{\"cmd\": \"card.temp\", \"stop\": true}"
+          },
+          {
+            "title": "Sync Temperature Notes",
+            "description": "Immediately sync pending temperature notes.",
+            "json": "{\"cmd\": \"card.temp\", \"sync\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing temperature readings from the Notecard's onboard sensor and any connected I2C sensors.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "calibration": {
+                      "description": "The calibration differential of the Notecard's onboard sensor.",
+                      "type": "number"
+                    },
+                    "humidity": {
+                      "description": "If the Notecard finds a BME280 sensor on the I2C bus, this field will be set to the humidity percentage value from the connected sensor.",
+                      "type": "number"
+                    },
+                    "pressure": {
+                      "description": "If the Notecard finds a BME280 or ENS210 sensor on the I2C bus, this field will be set to the atmospheric pressure value from the connected sensor in Pascals.",
+                      "type": "number"
+                    },
+                    "temperature": {
+                      "description": "If the Notecard finds a BME280 or ENS210 sensor on the I2C bus, this field will be set to the temperature value from the connected sensor in degrees centigrade.",
+                      "type": "number"
+                    },
+                    "usb": {
+                      "description": "`true` if the Notecard is connected to USB power.",
+                      "type": "boolean"
+                    },
+                    "value": {
+                      "description": "The current temperature from the Notecard's onboard sensor in degrees centigrade, including the calibration offset.",
+                      "type": "number"
+                    },
+                    "voltage": {
+                      "description": "The current voltage.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.temp Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Basic Temperature Response",
+                "description": "Example response with onboard sensor temperature and calibration.",
+                "json": "{\"value\": 27.625, \"calibration\": -3.0}"
+              },
+              {
+                "title": "Extended Sensor Response",
+                "description": "Example response with BME280 sensor data and power information.",
+                "json": "{\"value\": 25.5, \"calibration\": -2.5, \"temperature\": 24.8, \"humidity\": 45.2, \"pressure\": 101325, \"usb\": true, \"voltage\": 4.95}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/time": {
+      "get": {
+        "operationId": "card_time",
+        "summary": "Retrieves current date and time information in UTC. Upon power-up, the Notecard must complete a sync to Notehub in order to obtain time and location data. Before the time is obtained, this request will return `{\"zone\":\"UTC,Unknown\"}`.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.time",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.time Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Get Current Time and Date",
+            "description": "Retrieve current date and time information in UTC with location data if available.",
+            "json": "{\"req\": \"card.time\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing current date and time information in UTC along with location data if available.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "area": {
+                      "description": "The geographic area of the Notecard, if the cell tower is recognized.",
+                      "type": "string"
+                    },
+                    "country": {
+                      "description": "The country where the Notecard is located, if the cell tower is recognized.",
+                      "type": "string"
+                    },
+                    "lat": {
+                      "description": "Latitude of the Notecard, if the cell tower is recognized.",
+                      "type": "number"
+                    },
+                    "lon": {
+                      "description": "Longitude of the Notecard, if the cell tower is recognized.",
+                      "type": "number"
+                    },
+                    "minutes": {
+                      "description": "Number of minutes East of GMT, if the cell tower is recognized.",
+                      "type": "integer"
+                    },
+                    "time": {
+                      "description": "The current time in UTC. Will only populate if the Notecard has completed a sync to Notehub to obtain the time.",
+                      "type": "integer"
+                    },
+                    "zone": {
+                      "description": "The time zone of the Notecard, if the cell tower is recognized.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.time Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Complete Time Response",
+                "description": "Example response with full time and location information.",
+                "json": "{\"time\": 1599769214, \"area\": \"Beverly, MA\", \"zone\": \"CDT,America/New York\", \"minutes\": -300, \"lat\": 42.5776, \"lon\": -70.87134, \"country\": \"US\"}"
+              },
+              {
+                "title": "Time Before Location Sync",
+                "description": "Example response when time is available but location data hasn't been obtained yet.",
+                "json": "{\"zone\": \"UTC,Unknown\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/trace": {
+      "put": {
+        "operationId": "card_trace",
+        "summary": "Enable and disable [trace mode](/support/using-notecard-trace-mode/) on a Notecard for debugging.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.trace",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.trace Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "description": "Set to `\"on\"` to enable trace mode on a Notecard, or `\"off\"` to disable it.",
+                    "type": "string",
+                    "enum": [
+                      "on",
+                      "off"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "on",
+                        "description": "Enable trace mode on the Notecard for debugging."
+                      },
+                      {
+                        "const": "off",
+                        "description": "Disable trace mode on the Notecard."
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Enable Trace Mode",
+            "description": "Enable trace mode for debugging the Notecard.",
+            "json": "{\"req\": \"card.trace\", \"mode\": \"on\"}"
+          },
+          {
+            "title": "Disable Trace Mode",
+            "description": "Disable trace mode on the Notecard.",
+            "json": "{\"cmd\": \"card.trace\", \"mode\": \"off\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response from trace mode configuration request. Returns an empty object upon successful completion.",
+            "x-title": "card.trace Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/transport": {
+      "put": {
+        "operationId": "card_transport",
+        "summary": "Specifies the connectivity protocol to prioritize on the Notecard Cell+WiFi, or when using NTN mode with Starnote and a compatible Notecard.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.transport",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.transport Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "allow": {
+                    "description": "Set to `true` to allow adding Notes to non-compact Notefiles while connected over a non-terrestrial network.\n\nSee [Define NTN vs non-NTN Templates](https://dev.blues.io/starnote/starnote-best-practices/#define-ntn-vs-non-ntn-templates).",
+                    "type": "boolean",
+                    "default": false,
+                    "x-min-api-version": "7.2.1"
+                  },
+                  "method": {
+                    "description": "The connectivity method to enable on the Notecard.",
+                    "type": "string",
+                    "enum": [
+                      "-",
+                      "cell",
+                      "cell-ntn",
+                      "dual-wifi-cell",
+                      "ntn",
+                      "wifi",
+                      "wifi-cell",
+                      "wifi-cell-ntn",
+                      "wifi-ntn"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "-",
+                        "description": "Resets the transport mode to the device default.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "cell",
+                        "description": "Enables **cellular only** on the device.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI"
+                        ]
+                      },
+                      {
+                        "const": "cell-ntn",
+                        "description": "Prioritizes cellular connectivity while falling back to NTN if a cellular connection cannot be established.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI"
+                        ]
+                      },
+                      {
+                        "const": "dual-wifi-cell",
+                        "deprecated": true,
+                        "description": "Deprecated form of `\"wifi-cell\"`",
+                        "x-skus": [
+                          "CELL+WIFI"
+                        ]
+                      },
+                      {
+                        "const": "ntn",
+                        "description": "Enables **NTN (Non-Terrestrial Network)** mode on the device for use with Starnote.",
+                        "x-skus": [
+                          "CELL",
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "wifi",
+                        "description": "Enables **WiFi only** on the device.",
+                        "x-skus": [
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      },
+                      {
+                        "const": "wifi-cell",
+                        "description": "Prioritizes WiFi connectivity while falling back to cellular if a WiFi connection cannot be established. This is the default behavior on Notecard Cell+WiFi.",
+                        "x-skus": [
+                          "CELL+WIFI"
+                        ]
+                      },
+                      {
+                        "const": "wifi-cell-ntn",
+                        "description": "Prioritizes WiFi connectivity while falling back to cellular, and lastly to NTN.",
+                        "x-skus": [
+                          "CELL+WIFI"
+                        ]
+                      },
+                      {
+                        "const": "wifi-ntn",
+                        "description": "Prioritizes WiFi connectivity while falling back to NTN if a WiFi connection cannot be established.",
+                        "x-skus": [
+                          "CELL+WIFI",
+                          "WIFI"
+                        ]
+                      }
+                    ]
+                  },
+                  "seconds": {
+                    "description": "The amount of time a Notecard will spend on any fallback transport before retrying the first transport specified in the `method`. The default is `3600` or 60 minutes.",
+                    "type": "integer",
+                    "minimum": -1,
+                    "default": 3600,
+                    "x-min-api-version": "5.3.1"
+                  },
+                  "umin": {
+                    "description": "Set to `true` to force a longer network transport timeout when using Wideband Notecards.",
+                    "type": "boolean",
+                    "default": false,
+                    "x-min-api-version": "9.1.1"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Set WiFi-Cell Priority",
+            "description": "Configure Notecard Cell+WiFi to prioritize WiFi while falling back to cellular.",
+            "json": "{\"req\": \"card.transport\", \"method\": \"wifi-cell\"}"
+          },
+          {
+            "title": "Enable WiFi Only Mode",
+            "description": "Configure device to use WiFi connectivity only.",
+            "json": "{\"req\": \"card.transport\", \"method\": \"wifi\"}"
+          },
+          {
+            "title": "Enable Cellular Only Mode",
+            "description": "Configure device to use cellular connectivity only.",
+            "json": "{\"req\": \"card.transport\", \"method\": \"cell\"}"
+          },
+          {
+            "title": "Reset to Default Transport",
+            "description": "Reset the transport mode to device default settings.",
+            "json": "{\"cmd\": \"card.transport\", \"method\": \"-\"}"
+          },
+          {
+            "title": "Configure NTN Mode",
+            "description": "Enable NTN (Non-Terrestrial Network) mode for Starnote connectivity.",
+            "json": "{\"req\": \"card.transport\", \"method\": \"ntn\"}"
+          },
+          {
+            "title": "WiFi-Cell-NTN Priority",
+            "description": "Configure triple fallback: WiFi \u2192 cellular \u2192 NTN with custom timeout.",
+            "json": "{\"req\": \"card.transport\", \"method\": \"wifi-cell-ntn\", \"seconds\": 1800}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the current connectivity method configuration of the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "method": {
+                      "description": "The connectivity method currently enabled on the device.",
+                      "type": "string",
+                      "enum": [
+                        "-",
+                        "cell",
+                        "cell-ntn",
+                        "dual-wifi-cell",
+                        "ntn",
+                        "wifi",
+                        "wifi-cell",
+                        "wifi-cell-ntn",
+                        "wifi-ntn"
+                      ],
+                      "x-sub-descriptions": [
+                        {
+                          "const": "-",
+                          "description": "The transport mode is set to the device default.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "cell",
+                          "description": "Cellular only is enabled on the device.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI"
+                          ]
+                        },
+                        {
+                          "const": "cell-ntn",
+                          "description": "Prioritizes cellular connectivity while falling back to NTN if a cellular connection cannot be established.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI"
+                          ]
+                        },
+                        {
+                          "const": "dual-wifi-cell",
+                          "description": "Deprecated form of `\"wifi-cell\"`.",
+                          "x-skus": [
+                            "CELL+WIFI"
+                          ],
+                          "deprecated": true
+                        },
+                        {
+                          "const": "ntn",
+                          "description": "NTN (Non-Terrestrial Network) mode is enabled on the device for use with Starnote.",
+                          "x-skus": [
+                            "CELL",
+                            "CELL+WIFI",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "wifi",
+                          "description": "WiFi only is enabled on the device.",
+                          "x-skus": [
+                            "CELL+WIFI",
+                            "WIFI"
+                          ]
+                        },
+                        {
+                          "const": "wifi-cell",
+                          "description": "Prioritizes WiFi connectivity while falling back to cellular if a WiFi connection cannot be established. This is the default behavior on Notecard Cell+WiFi.",
+                          "x-skus": [
+                            "CELL+WIFI"
+                          ]
+                        },
+                        {
+                          "const": "wifi-cell-ntn",
+                          "description": "Prioritizes WiFi connectivity while falling back to cellular, and lastly to NTN.",
+                          "x-skus": [
+                            "CELL+WIFI"
+                          ]
+                        },
+                        {
+                          "const": "wifi-ntn",
+                          "description": "Prioritizes WiFi connectivity while falling back to NTN if a WiFi connection cannot be established.",
+                          "x-skus": [
+                            "CELL+WIFI",
+                            "WIFI"
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.transport Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "WiFi-Cell Priority Response",
+                "description": "Response showing WiFi-cellular priority transport mode is active.",
+                "json": "{\"method\": \"wifi-cell\"}"
+              },
+              {
+                "title": "Cellular Only Response",
+                "description": "Response showing cellular-only transport mode is active.",
+                "json": "{\"method\": \"cell\"}"
+              },
+              {
+                "title": "NTN Mode Response",
+                "description": "Response showing NTN (Non-Terrestrial Network) transport mode is active.",
+                "json": "{\"method\": \"ntn\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/triangulate": {
+      "put": {
+        "operationId": "card_triangulate",
+        "summary": "Enables or disables a behavior by which the Notecard gathers information about surrounding cell towers and/or WiFi access points with each new Notehub session.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.triangulate",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.triangulate Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "minutes": {
+                    "description": "Minimum delay, in minutes, between triangulation attempts. Use `0` for no time-based suppression.",
+                    "type": "integer",
+                    "default": 0,
+                    "minimum": -1
+                  },
+                  "mode": {
+                    "description": "The triangulation approach to use for determining the Notecard location. The following keywords can be used separately or together in a comma-delimited list, in any order. See [Using Cell Tower & WiFi Triangulation](/notecard/notecard-walkthrough/time-and-location-requests/#using-cell-tower-and-wifi-triangulation) for more information.",
+                    "type": "string",
+                    "pattern": "^(cell(,wifi)?|wifi(,cell)?|-)$",
+                    "x-sub-descriptions": [
+                      {
+                        "const": "cell",
+                        "description": "Enables cell tower scanning to determine the position of the Device."
+                      },
+                      {
+                        "const": "wifi",
+                        "description": "Enables the use of nearby WiFi access points to determine the position of the Device. To leverage this feature, the host will need to provide access point information to the Notecard via the `text` argument in subsequent requests."
+                      },
+                      {
+                        "const": "-",
+                        "description": "Clear the currently-set triangulation mode."
+                      }
+                    ]
+                  },
+                  "on": {
+                    "description": "`true` to instruct the Notecard to triangulate even if the module has not moved. Only takes effect when `set` is `true`.",
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "set": {
+                    "description": "`true` to instruct the module to use the state of the `on` and `usb` arguments.",
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "text": {
+                    "description": "When using WiFi triangulation, a newline-terminated list of WiFi access points obtained by the external module. Format should follow the ESP32's [AT+CWLAP command output](https://docs.espressif.com/projects/esp-at/en/latest/AT_Command_Set/Wi-Fi_AT_Commands.html#cmd-lap).",
+                    "type": "string"
+                  },
+                  "time": {
+                    "description": "When passed with `text`, records the time that the WiFi access point scan was performed. _If not provided, Notecard time is used._",
+                    "type": "integer"
+                  },
+                  "usb": {
+                    "description": "`true` to use perform triangulation only when the Notecard is connected to USB power. Only takes effect when `set` is `true`.",
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Single Mode",
+            "description": "Enable triangulation using cell towers only.",
+            "json": "{\"req\":\"card.triangulate\",\"mode\":\"cell\",\"on\":true,\"set\":true}"
+          },
+          {
+            "title": "Dual Mode",
+            "description": "Enable triangulation using both WiFi and cell towers when connected to USB power.",
+            "json": "{\"req\":\"card.triangulate\",\"mode\":\"wifi,cell\",\"on\":true,\"usb\":true,\"set\":true}"
+          },
+          {
+            "title": "Send WiFi AP Data",
+            "description": "Send a newline-terminated list of WiFi access points to the Notecard for triangulation.",
+            "json": "{\"req\":\"card.triangulate\",\"text\":\"+CWLAP:(4,\\\"Blues\\\",-51,\\\"74:ac:b9:12:12:f8\\\",1)\\n+CWLAP:(3,\\\"AAAA-62DD\\\",-70,\\\"6c:55:e8:91:62:e1\\\",11)\\n+CWLAP:(4,\\\"Blues\\\",-81,\\\"74:ac:b9:11:12:23\\\",1)\\n+CWLAP:(4,\\\"Blues\\\",-82,\\\"74:ac:a9:12:19:48\\\",11)\\n+CWLAP:(4,\\\"Free Parking\\\",-83,\\\"02:18:4a:11:60:31\\\",6)\\n+CWLAP:(5,\\\"GO\\\",-84,\\\"01:13:6a:13:90:30\\\",6)\\n+CWLAP:(4,\\\"AAAA-5C62-2.4\\\",-85,\\\"d8:97:ba:7b:fd:60\\\",1)\\n+CWLAP:(3,\\\"DIRECT-a5-HP MLP50\\\",-86,\\\"fa:da:0c:1b:16:a5\\\",6)\\n+CWLAP:(3,\\\"DIRECT-c6-HP M182 LaserJet\\\",-88,\\\"da:12:65:44:31:c6\\\",6)\\n\\n\"}"
+          },
+          {
+            "title": "Disable Triangulation",
+            "description": "Disable triangulation mode.",
+            "json": "{\"req\":\"card.triangulate\",\"mode\":\"-\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing triangulated location information and triangulation settings.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "length": {
+                      "description": "The length of the `text` buffer provided in the current or a previous request.",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "mode": {
+                      "description": "A comma-separated list indicating the active triangulation modes.",
+                      "type": "string"
+                    },
+                    "motion": {
+                      "description": "Time of last detected Notecard movement.",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "on": {
+                      "description": "`true` if triangulation scans will be performed even if the device has not moved.",
+                      "type": "boolean"
+                    },
+                    "time": {
+                      "description": "Time of last triangulation scan.",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "usb": {
+                      "description": "`true` if triangulation scans will be performed only when the device is USB-powered.",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.triangulate Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Complete Triangulation Response",
+                "description": "Response showing full triangulation configuration and status information.",
+                "json": "{\"usb\":true,\"mode\":\"wifi,cell\",\"length\":443,\"on\":true,\"time\":1606755042,\"motion\":1606757487}"
+              },
+              {
+                "title": "Minimal Triangulation Response",
+                "description": "Response showing basic triangulation mode configuration.",
+                "json": "{\"mode\":\"cell\",\"on\":false}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/usage/get": {
+      "get": {
+        "operationId": "card_usage_get",
+        "summary": "Returns the Notecard's network usage statistics for cellular and WiFi transmissions.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.usage.get",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.usage.get Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "mode",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "total",
+              "enum": [
+                "total",
+                "1hour",
+                "1day",
+                "30day"
+              ],
+              "x-sub-descriptions": [
+                {
+                  "const": "total",
+                  "description": "All stats since the Notecard was activated."
+                },
+                {
+                  "const": "1hour",
+                  "description": "Statistics for the last hour period."
+                },
+                {
+                  "const": "1day",
+                  "description": "Statistics for the last day period."
+                },
+                {
+                  "const": "30day",
+                  "description": "Statistics for the last 30 days period."
+                }
+              ]
+            },
+            "description": "The time period to use for statistics. Must be one of:"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "The number of time periods to look backwards, based on the specified `mode`.\n\nTo accurately determine the start of the calculated time period when using `offset`, use the `time` value of the response. Likewise, to calculate the end of the time period, add the `seconds` value to the `time` value."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Get Total Usage",
+            "description": "Retrieve all cellular and WiFi usage statistics since Notecard activation.",
+            "json": "{\"req\": \"card.usage.get\"}"
+          },
+          {
+            "title": "Get Daily Usage with Offset",
+            "description": "Get usage statistics for a specific day, 5 days ago.",
+            "json": "{\"req\": \"card.usage.get\", \"mode\": \"1day\", \"offset\": 5}"
+          },
+          {
+            "title": "Get Hourly Usage",
+            "description": "Get usage statistics for the current hour period.",
+            "json": "{\"req\": \"card.usage.get\", \"mode\": \"1hour\"}"
+          },
+          {
+            "title": "Get 30-Day Usage",
+            "description": "Get usage statistics for the last 30 days.",
+            "json": "{\"req\": \"card.usage.get\", \"mode\": \"30day\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing cellular and WiFi network usage statistics for the specified time period.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bytes_received": {
+                      "description": "Number of bytes received by the Notecard from Notehub.",
+                      "type": "integer"
+                    },
+                    "bytes_sent": {
+                      "description": "Number of bytes sent by the Notecard to Notehub.",
+                      "type": "integer"
+                    },
+                    "notes_received": {
+                      "description": "Approximate number of notes received by the Notecard from Notehub.",
+                      "type": "integer"
+                    },
+                    "notes_sent": {
+                      "description": "Approximate number of notes sent by the Notecard to Notehub.",
+                      "type": "integer"
+                    },
+                    "seconds": {
+                      "description": "Number of seconds in the analyzed period.",
+                      "type": "integer"
+                    },
+                    "sessions_secure": {
+                      "description": "Number of secure Notehub sessions.",
+                      "type": "integer"
+                    },
+                    "sessions_standard": {
+                      "description": "Number of standard Notehub sessions.",
+                      "type": "integer"
+                    },
+                    "time": {
+                      "description": "Start time of the analyzed period or, if `mode=\"total\"`, the time of activation.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.usage.get Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Complete Usage Statistics",
+                "description": "Example response showing comprehensive cellular and WiFi network usage data.",
+                "json": "{\"seconds\":1291377, \"time\":1598479763, \"bytes_sent\":163577, \"bytes_received\":454565, \"notes_sent\":114, \"notes_received\":26, \"sessions_standard\":143, \"sessions_secure\":31}"
+              },
+              {
+                "title": "Partial Usage Statistics",
+                "description": "Example response with basic cellular and WiFi usage metrics.",
+                "json": "{\"seconds\":3600, \"time\":1700000000, \"bytes_sent\":1024, \"bytes_received\":2048}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/usage/test": {
+      "get": {
+        "operationId": "card_usage_test",
+        "summary": "Calculates a projection of how long the available cellular data quota will last based on the observed usage patterns.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.usage.test",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.usage.test Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of days to use for the test."
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "If you want to analyze a period shorter than one day, the number of hours to use for the test."
+          },
+          {
+            "name": "megabytes",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1024
+            },
+            "description": "The Notecard lifetime cellular data quota (in megabytes) to use for the test."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Test 7-Day Usage Projection",
+            "description": "Calculate data quota projection based on the last 7 days with 500MB quota.",
+            "json": "{\"req\": \"card.usage.test\", \"days\": 7, \"megabytes\": 500}"
+          },
+          {
+            "title": "Test 12-Hour Usage Projection",
+            "description": "Calculate data quota projection based on the last 12 hours.",
+            "json": "{\"req\": \"card.usage.test\", \"hours\": 12}"
+          },
+          {
+            "title": "Default Quota Test",
+            "description": "Test with default 1024MB quota using 30 days of data.",
+            "json": "{\"req\": \"card.usage.test\", \"days\": 30}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing cellular data usage projection and analysis results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bytes_per_day": {
+                      "description": "Average bytes per day used during the test period.",
+                      "type": "integer"
+                    },
+                    "bytes_received": {
+                      "description": "Number of bytes received by the Notecard from Notehub.",
+                      "type": "integer"
+                    },
+                    "bytes_sent": {
+                      "description": "Number of bytes sent by the Notecard to Notehub.",
+                      "type": "integer"
+                    },
+                    "days": {
+                      "description": "The number of days used for the test.",
+                      "type": "integer"
+                    },
+                    "max": {
+                      "description": "The days of projected data available based on test.",
+                      "type": "integer"
+                    },
+                    "notes_received": {
+                      "description": "Number of notes received by the Notecard from Notehub.",
+                      "type": "integer"
+                    },
+                    "notes_sent": {
+                      "description": "Number of notes sent by the Notecard to Notehub.",
+                      "type": "integer"
+                    },
+                    "seconds": {
+                      "description": "Number of seconds in the analyzed period.",
+                      "type": "integer"
+                    },
+                    "sessions_secure": {
+                      "description": "Number of secure Notehub sessions.",
+                      "type": "integer"
+                    },
+                    "sessions_standard": {
+                      "description": "Number of standard Notehub sessions.",
+                      "type": "integer"
+                    },
+                    "time": {
+                      "description": "Time of device activation.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.usage.test Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Complete Usage Test Results",
+                "description": "Example response showing comprehensive usage projection data.",
+                "json": "{\"max\": 12730, \"days\": 7, \"bytes_per_day\": 41136, \"seconds\": 1291377, \"time\": 1598479763, \"bytes_sent\": 163577, \"bytes_received\": 454565, \"notes_sent\": 114, \"notes_received\": 26, \"sessions_standard\": 143, \"sessions_secure\": 31}"
+              },
+              {
+                "title": "Basic Projection Results",
+                "description": "Example response with essential projection metrics.",
+                "json": "{\"max\": 1825, \"days\": 30, \"bytes_per_day\": 56832, \"seconds\": 2592000, \"time\": 1700000000}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/version": {
+      "get": {
+        "operationId": "card_version",
+        "summary": "Returns firmware version information for the Notecard.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.version",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.version Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Get Version Information",
+            "description": "Retrieve firmware version and device information.",
+            "json": "{\"req\": \"card.version\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing firmware version information and device details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "board": {
+                      "description": "The Notecard board version number.",
+                      "type": "string"
+                    },
+                    "body": {
+                      "description": "An object containing Notecard firmware details for programmatic access.",
+                      "type": "object",
+                      "properties": {
+                        "org": {
+                          "description": "Organization name set for the Notecard.",
+                          "type": "string"
+                        },
+                        "product": {
+                          "description": "Product name set for the Notecard.",
+                          "type": "string"
+                        },
+                        "target": {
+                          "description": "Target platform identifier.",
+                          "type": "string"
+                        },
+                        "x-schema-version": {
+                          "description": "Firmware version of the Notecard.",
+                          "type": "string"
+                        },
+                        "ver_major": {
+                          "description": "Major version of the Notecard firmware.",
+                          "type": "integer"
+                        },
+                        "ver_minor": {
+                          "description": "Minor version of the Notecard firmware.",
+                          "type": "integer"
+                        },
+                        "ver_patch": {
+                          "description": "Patch version of the Notecard firmware.",
+                          "type": "integer"
+                        },
+                        "ver_build": {
+                          "description": "Build version of the Notecard firmware.",
+                          "type": "integer"
+                        },
+                        "built": {
+                          "description": "Date and time the Notecard firmware was built.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "cell": {
+                      "description": "If `true`, indicates the Notecard supports cellular connectivity.",
+                      "type": "boolean"
+                    },
+                    "device": {
+                      "description": "The DeviceUID of the Notecard.",
+                      "type": "string"
+                    },
+                    "gps": {
+                      "description": "If `true`, indicates the Notecard has an onboard GPS module.",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "description": "The official name of the device.",
+                      "type": "string"
+                    },
+                    "sku": {
+                      "description": "The Notecard SKU.",
+                      "type": "string"
+                    },
+                    "x-schema-version": {
+                      "description": "The full version number of the Notecard firmware.",
+                      "type": "string"
+                    },
+                    "wifi": {
+                      "description": "If `true`, indicates the Notecard supports WiFi connectivity.",
+                      "type": "boolean",
+                      "x-min-api-version": "5.3.1"
+                    }
+                  },
+                  "required": [
+                    "version"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.version Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Complete Version Response",
+                "description": "Example response showing comprehensive version and device information.",
+                "json": "{\"version\": \"notecard-5.3.1\", \"device\": \"dev:000000000000000\", \"name\": \"Blues Wireless Notecard\", \"sku\": \"NOTE-NBGL\", \"board\": \"1.11\", \"cell\": true, \"gps\": true, \"body\": {\"org\": \"Blues Wireless\", \"product\": \"Notecard\", \"target\": \"r5\", \"version\": \"notecard-5.3.1\", \"ver_major\": 5, \"ver_minor\": 3, \"ver_patch\": 1, \"ver_build\": 371, \"built\": \"Sep  5 2023 12:21:30\"}}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/voltage": {
+      "get": {
+        "operationId": "card_voltage_query",
+        "summary": "Provides the current VMODEM_P voltage level on the Notecard, and provides information about historical voltage trends. When used with the mode argument, configures voltage thresholds based on how the device is powered.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.voltage",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.voltage Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "alert",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "When enabled and the `usb` argument is set to `true`, the Notecard will add an entry to the `health.qo` Notefile when USB power is connected or disconnected."
+          },
+          {
+            "name": "calibration",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "default": 0.35,
+              "x-min-api-version": "7.2.2"
+            },
+            "description": "The offset, in volts, to account for the forward voltage drop of the diode used between the battery and Notecard in either Blues- or customer-designed Notecarriers."
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 720,
+              "maximum": 720
+            },
+            "description": "The number of hours to analyze, up to 720 (30 days)."
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "default",
+                "lipo",
+                "l91",
+                "alkaline",
+                "tad",
+                "lic",
+                "?"
+              ],
+              "default": "default",
+              "x-sub-descriptions": [
+                {
+                  "const": "default",
+                  "description": "Default behavior. Equivalent to `normal:2.5;dead:0`."
+                },
+                {
+                  "const": "lipo",
+                  "description": "LiPo batteries. Equivalent to `usb:4.6;high:4.0;normal:3.5;low:3.2;dead:0`."
+                },
+                {
+                  "const": "l91",
+                  "description": "L91 batteries. Equivalent to `high:5.0;normal:4.5;low:0`."
+                },
+                {
+                  "const": "alkaline",
+                  "description": "Alkaline batteries. Equivalent to `usb:4.6;high:4.2;normal:3.6;low:0`."
+                },
+                {
+                  "const": "tad",
+                  "description": "Tadiran HLC batteries. Equivalent to `usb:4.6;normal:3.2;low:0`."
+                },
+                {
+                  "const": "lic",
+                  "description": "Lithium-ion capacitors. Equivalent to `usb:4.6;high:3.8;normal:3.1;low:0`."
+                },
+                {
+                  "const": "?",
+                  "description": "Query the Notecard for its currently-set thresholds."
+                }
+              ]
+            },
+            "description": "Used to set voltage thresholds based on how the Notecard will be powered, and which can be used to [configure voltage-variable Notecard behavior](/notecard/notecard-walkthrough/low-power-design#low-power-design). Each value is shorthand that assigns a battery voltage reading to a given device state like `high`, `normal`, `low`, and `dead`.\n\n**NOTE:** Setting voltage thresholds is not supported on the Notecard XP."
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Specifies an environment variable to override application default timing values."
+          },
+          {
+            "name": "off",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Disable historic voltage trend calculations."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            },
+            "description": "Number of hours to move into the past before starting analysis."
+          },
+          {
+            "name": "on",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Enable historic voltage trend calculations."
+          },
+          {
+            "name": "set",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Used along with `calibration`, set to `true` to specify a new calibration value."
+          },
+          {
+            "name": "sync",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "When enabled and the `usb` argument is set to `true`, the Notecard will perform a sync when USB power is connected or disconnected."
+          },
+          {
+            "name": "usb",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "x-min-api-version": "3.5.1"
+            },
+            "description": "When enabled, the Notecard will monitor for changes to USB power state."
+          },
+          {
+            "name": "vmax",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "default": 4.5
+            },
+            "description": "Ignore voltage readings above this level when performing calculations."
+          },
+          {
+            "name": "vmin",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "default": 2.5
+            },
+            "description": "Ignore voltage readings below this level when performing calculations."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Get Voltage Trends",
+            "description": "Retrieve voltage information with trend analysis for 300 hours.",
+            "json": "{\"req\": \"card.voltage\", \"hours\": 300, \"vmax\": 4, \"vmin\": 2.2}"
+          },
+          {
+            "title": "Set LiPo Voltage Thresholds",
+            "description": "Configure voltage thresholds for LiPo battery operation.",
+            "json": "{\"req\": \"card.voltage\", \"mode\": \"lipo\"}"
+          },
+          {
+            "title": "Query Current Thresholds",
+            "description": "Query the Notecard for its currently-set voltage thresholds.",
+            "json": "{\"req\": \"card.voltage\", \"mode\": \"?\"}"
+          },
+          {
+            "title": "Enable USB Power Monitoring",
+            "description": "Enable USB power state monitoring with alerts and sync.",
+            "json": "{\"req\": \"card.voltage\", \"usb\": true, \"alert\": true, \"sync\": true}"
+          },
+          {
+            "title": "Enable Historic Voltage Trends",
+            "description": "Enable historic voltage trends tracking.",
+            "json": "{\"req\": \"card.voltage\", \"on\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing current voltage information and historical trend analysis.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "daily": {
+                      "description": "Change of moving average in the last 24 hours, if relevant to the time period analyzed.",
+                      "type": "number"
+                    },
+                    "hours": {
+                      "description": "The number of hours used for trend analysis.",
+                      "type": "integer"
+                    },
+                    "minutes": {
+                      "description": "Represents the Notecard's uptime in minutes. This field is not present when the device is powered via USB.",
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "description": "The current voltage-variable threshold value returned from Notecard.\n\nFor example, if the voltage threshold is `\"usb:4.6;normal:3.5;dead:0\"` and the power source returns a voltage of `3.9`, the mode value would be `\"normal\"`.",
+                      "type": "string"
+                    },
+                    "monthly": {
+                      "description": "Change of moving average in the last 30 days, if relevant to the time period analyzed.",
+                      "type": "number"
+                    },
+                    "usb": {
+                      "description": "`true` if the Notecard is connected to USB power.",
+                      "type": "boolean",
+                      "x-min-api-version": "3.5.1"
+                    },
+                    "value": {
+                      "description": "The current voltage.",
+                      "type": "number"
+                    },
+                    "vavg": {
+                      "description": "The average voltage value during the measured period.",
+                      "type": "number"
+                    },
+                    "vmax": {
+                      "description": "The highest voltage value captured during the measurement period.",
+                      "type": "number"
+                    },
+                    "vmin": {
+                      "description": "The lowest voltage value captured during the measurement period.",
+                      "type": "number"
+                    },
+                    "weekly": {
+                      "description": "Change of moving average in the last 7 days, if relevant to the time period analyzed.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.voltage Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "USB-Powered Voltage Response",
+                "description": "Example response when Notecard is powered via USB.",
+                "json": "{\"usb\": true, \"hours\": 120, \"mode\": \"usb\", \"value\": 5.112190219747135, \"vmin\": 4, \"vmax\": 4, \"vavg\": 4}"
+              },
+              {
+                "title": "Battery-Powered with Trends",
+                "description": "Example response showing battery voltage with trend analysis.",
+                "json": "{\"mode\": \"normal\", \"usb\": false, \"value\": 3.85, \"hours\": 720, \"vmin\": 3.2, \"vmax\": 4.1, \"vavg\": 3.75, \"daily\": -0.05, \"weekly\": -0.3, \"monthly\": -0.8, \"minutes\": 43200}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "put": {
+        "operationId": "card_voltage_set",
+        "summary": "Provides the current VMODEM_P voltage level on the Notecard, and provides information about historical voltage trends. When used with the mode argument, configures voltage thresholds based on how the device is powered.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.voltage",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires_any": [
+            "mode",
+            "set",
+            "usb",
+            "alert",
+            "sync",
+            "on",
+            "off",
+            "calibration",
+            "name"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.voltage Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "alert": {
+                    "description": "When enabled and the `usb` argument is set to `true`, the Notecard will add an entry to the `health.qo` Notefile when USB power is connected or disconnected.",
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "calibration": {
+                    "description": "The offset, in volts, to account for the forward voltage drop of the diode used between the battery and Notecard in either Blues- or customer-designed Notecarriers.",
+                    "type": "number",
+                    "default": 0.35,
+                    "x-min-api-version": "7.2.2"
+                  },
+                  "hours": {
+                    "description": "The number of hours to analyze, up to 720 (30 days).",
+                    "type": "integer",
+                    "default": 720,
+                    "maximum": 720
+                  },
+                  "mode": {
+                    "description": "Used to set voltage thresholds based on how the Notecard will be powered, and which can be used to [configure voltage-variable Notecard behavior](/notecard/notecard-walkthrough/low-power-design#low-power-design). Each value is shorthand that assigns a battery voltage reading to a given device state like `high`, `normal`, `low`, and `dead`.\n\n**NOTE:** Setting voltage thresholds is not supported on the Notecard XP.",
+                    "type": "string",
+                    "enum": [
+                      "default",
+                      "lipo",
+                      "l91",
+                      "alkaline",
+                      "tad",
+                      "lic",
+                      "?"
+                    ],
+                    "default": "default",
+                    "x-sub-descriptions": [
+                      {
+                        "const": "default",
+                        "description": "Default behavior. Equivalent to `normal:2.5;dead:0`."
+                      },
+                      {
+                        "const": "lipo",
+                        "description": "LiPo batteries. Equivalent to `usb:4.6;high:4.0;normal:3.5;low:3.2;dead:0`."
+                      },
+                      {
+                        "const": "l91",
+                        "description": "L91 batteries. Equivalent to `high:5.0;normal:4.5;low:0`."
+                      },
+                      {
+                        "const": "alkaline",
+                        "description": "Alkaline batteries. Equivalent to `usb:4.6;high:4.2;normal:3.6;low:0`."
+                      },
+                      {
+                        "const": "tad",
+                        "description": "Tadiran HLC batteries. Equivalent to `usb:4.6;normal:3.2;low:0`."
+                      },
+                      {
+                        "const": "lic",
+                        "description": "Lithium-ion capacitors. Equivalent to `usb:4.6;high:3.8;normal:3.1;low:0`."
+                      },
+                      {
+                        "const": "?",
+                        "description": "Query the Notecard for its currently-set thresholds."
+                      }
+                    ]
+                  },
+                  "name": {
+                    "description": "Specifies an environment variable to override application default timing values.",
+                    "type": "string"
+                  },
+                  "off": {
+                    "description": "Disable historic voltage trend calculations.",
+                    "type": "boolean"
+                  },
+                  "offset": {
+                    "description": "Number of hours to move into the past before starting analysis.",
+                    "type": "integer",
+                    "default": 0
+                  },
+                  "on": {
+                    "description": "Enable historic voltage trend calculations.",
+                    "type": "boolean"
+                  },
+                  "set": {
+                    "description": "Used along with `calibration`, set to `true` to specify a new calibration value.",
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "sync": {
+                    "description": "When enabled and the `usb` argument is set to `true`, the Notecard will perform a sync when USB power is connected or disconnected.",
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "usb": {
+                    "description": "When enabled, the Notecard will monitor for changes to USB power state.",
+                    "type": "boolean",
+                    "default": false,
+                    "x-min-api-version": "3.5.1"
+                  },
+                  "vmax": {
+                    "description": "Ignore voltage readings above this level when performing calculations.",
+                    "type": "number",
+                    "default": 4.5
+                  },
+                  "vmin": {
+                    "description": "Ignore voltage readings below this level when performing calculations.",
+                    "type": "number",
+                    "default": 2.5
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Get Voltage Trends",
+            "description": "Retrieve voltage information with trend analysis for 300 hours.",
+            "json": "{\"req\": \"card.voltage\", \"hours\": 300, \"vmax\": 4, \"vmin\": 2.2}"
+          },
+          {
+            "title": "Set LiPo Voltage Thresholds",
+            "description": "Configure voltage thresholds for LiPo battery operation.",
+            "json": "{\"req\": \"card.voltage\", \"mode\": \"lipo\"}"
+          },
+          {
+            "title": "Query Current Thresholds",
+            "description": "Query the Notecard for its currently-set voltage thresholds.",
+            "json": "{\"req\": \"card.voltage\", \"mode\": \"?\"}"
+          },
+          {
+            "title": "Enable USB Power Monitoring",
+            "description": "Enable USB power state monitoring with alerts and sync.",
+            "json": "{\"req\": \"card.voltage\", \"usb\": true, \"alert\": true, \"sync\": true}"
+          },
+          {
+            "title": "Enable Historic Voltage Trends",
+            "description": "Enable historic voltage trends tracking.",
+            "json": "{\"req\": \"card.voltage\", \"on\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing current voltage information and historical trend analysis.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "daily": {
+                      "description": "Change of moving average in the last 24 hours, if relevant to the time period analyzed.",
+                      "type": "number"
+                    },
+                    "hours": {
+                      "description": "The number of hours used for trend analysis.",
+                      "type": "integer"
+                    },
+                    "minutes": {
+                      "description": "Represents the Notecard's uptime in minutes. This field is not present when the device is powered via USB.",
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "description": "The current voltage-variable threshold value returned from Notecard.\n\nFor example, if the voltage threshold is `\"usb:4.6;normal:3.5;dead:0\"` and the power source returns a voltage of `3.9`, the mode value would be `\"normal\"`.",
+                      "type": "string"
+                    },
+                    "monthly": {
+                      "description": "Change of moving average in the last 30 days, if relevant to the time period analyzed.",
+                      "type": "number"
+                    },
+                    "usb": {
+                      "description": "`true` if the Notecard is connected to USB power.",
+                      "type": "boolean",
+                      "x-min-api-version": "3.5.1"
+                    },
+                    "value": {
+                      "description": "The current voltage.",
+                      "type": "number"
+                    },
+                    "vavg": {
+                      "description": "The average voltage value during the measured period.",
+                      "type": "number"
+                    },
+                    "vmax": {
+                      "description": "The highest voltage value captured during the measurement period.",
+                      "type": "number"
+                    },
+                    "vmin": {
+                      "description": "The lowest voltage value captured during the measurement period.",
+                      "type": "number"
+                    },
+                    "weekly": {
+                      "description": "Change of moving average in the last 7 days, if relevant to the time period analyzed.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.voltage Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "USB-Powered Voltage Response",
+                "description": "Example response when Notecard is powered via USB.",
+                "json": "{\"usb\": true, \"hours\": 120, \"mode\": \"usb\", \"value\": 5.112190219747135, \"vmin\": 4, \"vmax\": 4, \"vavg\": 4}"
+              },
+              {
+                "title": "Battery-Powered with Trends",
+                "description": "Example response showing battery voltage with trend analysis.",
+                "json": "{\"mode\": \"normal\", \"usb\": false, \"value\": 3.85, \"hours\": 720, \"vmin\": 3.2, \"vmax\": 4.1, \"vavg\": 3.75, \"daily\": -0.05, \"weekly\": -0.3, \"monthly\": -0.8, \"minutes\": 43200}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/wifi": {
+      "put": {
+        "operationId": "card_wifi",
+        "summary": "Sets up a Notecard WiFi to connect to a WiFi access point.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.wifi",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.wifi Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "By default, the Notecard creates a SoftAP (software enabled access point) under the name \"Notecard\". You can use the `name` argument to change the name of the SoftAP to a custom name.\n\nIf you include a `-` at the end of the `name` (for example `\"name\": \"acme-\"`), the Notecard will append the last four digits of the network's MAC address (for example `acme-025c`). This allows you to distinguish between multiple Notecards in SoftAP mode.",
+                    "type": "string"
+                  },
+                  "org": {
+                    "description": "If specified, replaces the Blues logo on the SoftAP page with the provided name.",
+                    "type": "string"
+                  },
+                  "password": {
+                    "description": "The network password of the WiFi access point. Alternatively, use `-` to clear an already set password or to connect to an open access point.",
+                    "type": "string"
+                  },
+                  "ssid": {
+                    "description": "The SSID of the WiFi access point. Alternatively, use `-` to clear an already set SSID.",
+                    "type": "string"
+                  },
+                  "start": {
+                    "description": "Specify `true` to activate SoftAP mode on the Notecard programmatically.",
+                    "type": "boolean"
+                  },
+                  "text": {
+                    "description": "A string containing an array of access points the Notecard should attempt to use. The access points should be provided in the following format:\n\n`[\"FIRST-SSID\",\"FIRST-PASSWORD\"],[\"SECOND-SSID\",\"SECOND-PASSWORD\"]`.\n\nYou may need to escape any quotes used in this argument before passing it to the Notecard. For example, the following is a valid request to pass to a Notecard through the [In-Browser Terminal](https://dev.blues.io/terminal/).\n\n`{\"req\":\"card.wifi\", \"text\":\"[\\\"FIRST-SSID\\\",\\\"FIRST-PASSWORD\\\"]\"}`",
+                    "type": "string",
+                    "x-min-api-version": "7.5.1"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Create a Connection",
+            "description": "Set WiFi SSID and password to connect to an access point.",
+            "json": "{\"req\":\"card.wifi\",\"ssid\":\"<ssid name>\",\"password\":\"<password>\"}"
+          },
+          {
+            "title": "Clear a Connection",
+            "description": "Clear existing WiFi credentials to disconnect.",
+            "json": "{\"req\":\"card.wifi\",\"ssid\":\"-\",\"password\":\"-\"}"
+          },
+          {
+            "title": "Customize the SoftAP",
+            "description": "Configure SoftAP with custom name and organization branding.",
+            "json": "{\"req\":\"card.wifi\",\"name\":\"ACME Inc\",\"org\":\"ACME Inc\"}"
+          },
+          {
+            "title": "Customize the SoftAP w/MAC Address",
+            "description": "Configure SoftAP name with MAC address suffix for unique identification.",
+            "json": "{\"req\":\"card.wifi\",\"name\":\"acme-\",\"org\":\"ACME Inc\"}"
+          },
+          {
+            "title": "Configure Multiple Access Points",
+            "description": "Set up multiple WiFi access points for fallback connectivity.",
+            "json": "{\"req\":\"card.wifi\",\"text\":\"[\\\"FIRST-SSID\\\",\\\"FIRST-PASSWORD\\\"],[\\\"SECOND-SSID\\\",\\\"SECOND-PASSWORD\\\"]\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing WiFi connection status and configuration information from the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "secure": {
+                      "description": "`true` means that the WiFi access point is using Management Frame Protection.",
+                      "type": "boolean"
+                    },
+                    "security": {
+                      "description": "The security protocol the WiFi access point uses.",
+                      "type": "string"
+                    },
+                    "ssid": {
+                      "description": "The SSID of the WiFi access point.",
+                      "type": "string"
+                    },
+                    "x-schema-version": {
+                      "description": "The Silicon Labs WF200 WiFi Transceiver binary version.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.wifi Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Complete WiFi Status Response",
+                "description": "Example response showing comprehensive WiFi connection information.",
+                "json": "{\"secure\":true, \"version\":\"3.12.3\", \"ssid\":\"<ssid name>\", \"security\":\"wpa2-psk\"}"
+              },
+              {
+                "title": "Basic Connection Response",
+                "description": "Example response with basic WiFi access point information.",
+                "json": "{\"ssid\":\"HomeNetwork\", \"security\":\"wpa3\"}"
+              },
+              {
+                "title": "Version Information Response",
+                "description": "Example response showing WiFi transceiver version.",
+                "json": "{\"version\":\"3.12.3\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/wireless": {
+      "put": {
+        "operationId": "card_wireless",
+        "summary": "View the last known network state, or customize the behavior of the modem. _Note: Be careful when using this mode with hardware not on hand as a mistake may cause loss of network and Notehub access._",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.wireless",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.wireless Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "apn": {
+                    "description": "Access Point Name (APN) when using an external SIM. Use `\"-\"` to reset to the Notecard default APN.",
+                    "type": "string"
+                  },
+                  "hours": {
+                    "description": "When using the `method` argument with `\"dual-primary-secondary\"` or `\"dual-secondary-primary\"`, this is the number of hours after which the Notecard will attempt to switch back to the preferred SIM.",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "method": {
+                    "description": "Used when configuring a [Notecard to failover to a different SIM](/guides-and-tutorials/notecard-guides/using-external-sim-cards/#failing-over-to-a-different-sim).",
+                    "type": "string",
+                    "enum": [
+                      "-",
+                      "dual-primary-secondary",
+                      "dual-secondary-primary",
+                      "primary",
+                      "secondary"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "-",
+                        "description": "Resets the Notecard to the default method."
+                      },
+                      {
+                        "const": "dual-primary-secondary",
+                        "description": "Will attempt to register with the internal SIM first, then failover to the external SIM."
+                      },
+                      {
+                        "const": "dual-secondary-primary",
+                        "description": "Will attempt to register with the external SIM first, then failover to the internal SIM."
+                      },
+                      {
+                        "const": "primary",
+                        "description": "Will exclusively use the internal SIM."
+                      },
+                      {
+                        "const": "secondary",
+                        "description": "Will exclusively use the external SIM."
+                      }
+                    ]
+                  },
+                  "mode": {
+                    "description": "Network scan mode. Must be one of:",
+                    "type": "string",
+                    "enum": [
+                      "-",
+                      "auto",
+                      "m",
+                      "nb",
+                      "gprs"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "-",
+                        "description": "Reset to the default mode."
+                      },
+                      {
+                        "const": "auto",
+                        "description": "Perform automatic band scan mode (this is the default mode)."
+                      },
+                      {
+                        "const": "m",
+                        "description": "Restrict the modem to Cat-M1 (applies exclusively to Narrowband Notecard Cellular devices)."
+                      },
+                      {
+                        "const": "nb",
+                        "description": "Restrict the modem to Cat-NB1 (applies exclusively to Narrowband Notecard Cellular devices)."
+                      },
+                      {
+                        "const": "gprs",
+                        "description": "Restrict the modem to EGPRS (applies exclusively to Narrowband Notecard Cellular devices)."
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Current Network State",
+            "description": "Request current network state without any modifications.",
+            "json": "{\"req\":\"card.wireless\"}"
+          },
+          {
+            "title": "Change Scan Mode",
+            "description": "Restrict the modem to Cat-NB1 for narrowband connectivity.",
+            "json": "{\"req\":\"card.wireless\",\"mode\":\"nb\"}"
+          },
+          {
+            "title": "Reset Scan Mode",
+            "description": "Reset network scan mode to default behavior.",
+            "json": "{\"req\":\"card.wireless\",\"mode\":\"-\"}"
+          },
+          {
+            "title": "Set External SIM APN",
+            "description": "Configure APN for external SIM card usage.",
+            "json": "{\"req\":\"card.wireless\",\"apn\":\"myapn.nb\"}"
+          },
+          {
+            "title": "Failover to External SIM",
+            "description": "Configure dual SIM failover with external SIM priority.",
+            "json": "{\"req\":\"card.wireless\",\"apn\":\"myapn.nb\",\"method\":\"dual-primary-secondary\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing wireless connection status, signal quality information, and detailed modem/network data from the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "description": "Number of bars of signal quality.",
+                      "type": "integer"
+                    },
+                    "net": {
+                      "description": "An object with detailed modem, radio access technology, and signal information (details will differ depending on the type of Notecard).",
+                      "type": "object",
+                      "properties": {
+                        "iccid": {
+                          "description": "Integrated Circuit Card Identifier of the SIM card.",
+                          "type": "string"
+                        },
+                        "imsi": {
+                          "description": "International Mobile Subscriber Identity.",
+                          "type": "string"
+                        },
+                        "imei": {
+                          "description": "International Mobile Equipment Identity.",
+                          "type": "string"
+                        },
+                        "modem": {
+                          "description": "Modem firmware version and model information.",
+                          "type": "string"
+                        },
+                        "band": {
+                          "description": "The frequency band being used for communication.",
+                          "type": "string"
+                        },
+                        "rat": {
+                          "description": "Radio Access Technology being used.",
+                          "type": "string"
+                        },
+                        "rssir": {
+                          "description": "Reference Signal Received Power (RSRP) reported by the modem.",
+                          "type": "integer"
+                        },
+                        "rssi": {
+                          "description": "Received Signal Strength Indicator.",
+                          "type": "integer"
+                        },
+                        "rsrp": {
+                          "description": "Reference Signal Received Power.",
+                          "type": "integer"
+                        },
+                        "sinr": {
+                          "description": "Signal to Interference plus Noise Ratio.",
+                          "type": "integer"
+                        },
+                        "rsrq": {
+                          "description": "Reference Signal Received Quality.",
+                          "type": "integer"
+                        },
+                        "bars": {
+                          "description": "Signal strength represented as bars (0-5).",
+                          "type": "integer"
+                        },
+                        "mcc": {
+                          "description": "Mobile Country Code.",
+                          "type": "integer"
+                        },
+                        "mnc": {
+                          "description": "Mobile Network Code.",
+                          "type": "integer"
+                        },
+                        "lac": {
+                          "description": "Location Area Code.",
+                          "type": "integer"
+                        },
+                        "cid": {
+                          "description": "Cell ID.",
+                          "type": "integer"
+                        },
+                        "updated": {
+                          "description": "Unix timestamp of when the network information was last updated.",
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "status": {
+                      "description": "The current status of the wireless connection and modem.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.wireless Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Complete Wireless Status Response",
+                "description": "Example response showing comprehensive wireless connection and signal information.",
+                "json": "{\"status\":\"{modem-off}\",\"count\":1,\"net\":{\"iccid\":\"00000000000000000000\",\"imsi\":\"000000000000000\",\"imei\":\"000000000000000\",\"modem\":\"EG91NAXGAR07A03M1G_BETA0415_01.001.01.001\",\"band\":\"LTE BAND 2\",\"rat\":\"lte\",\"rssir\":-69,\"rssi\":-70,\"rsrp\":-105,\"sinr\":-3,\"rsrq\":-17,\"bars\":1,\"mcc\":310,\"mnc\":410,\"lac\":28681,\"cid\":211150856,\"updated\":1599225076}}"
+              },
+              {
+                "title": "Basic Signal Information",
+                "description": "Example response with basic signal strength and status.",
+                "json": "{\"status\":\"connected\",\"count\":3}"
+              },
+              {
+                "title": "Network Details Response",
+                "description": "Example response showing detailed network information.",
+                "json": "{\"status\":\"searching\",\"count\":2,\"net\":{\"band\":\"LTE BAND 12\",\"rat\":\"lte\",\"rssi\":-85,\"bars\":2,\"mcc\":310,\"mnc\":260}}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/card/wireless/penalty": {
+      "get": {
+        "operationId": "card_wireless_penalty_query",
+        "summary": "View the current state of a [Notecard Penalty Box](/support/understanding-notecard-penalty-boxes/), manually remove the Notecard from a penalty box, or override penalty box defaults.",
+        "x-safety": "readonly",
+        "x-notecard-request": "card.wireless.penalty",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.wireless.penalty Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "add",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 15
+            },
+            "description": "The number of minutes to add to successive retries. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults."
+          },
+          {
+            "name": "max",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 4320
+            },
+            "description": "The maximum number of minutes that a device can be in a Network Registration Failure Penalty Box. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults."
+          },
+          {
+            "name": "min",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 15
+            },
+            "description": "The number of minutes of the first retry interval of a Network Registration Failure Penalty Box. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults."
+          },
+          {
+            "name": "rate",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "default": 1.25
+            },
+            "description": "The rate at which the penalty box time multiplier is increased over successive retries. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults."
+          },
+          {
+            "name": "reset",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Set to `true` to remove the Notecard from certain types of penalty boxes."
+          },
+          {
+            "name": "set",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Set to `true` to override the default settings of the [Network Registration Failure Penalty Box](/support/understanding-notecard-penalty-boxes/#network-registration-failure)."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Check Penalty Box State",
+            "description": "Request current penalty box status and information.",
+            "json": "{\"req\":\"card.wireless.penalty\"}"
+          },
+          {
+            "title": "Remove from Penalty Box",
+            "description": "Reset and remove the Notecard from penalty box conditions.",
+            "json": "{\"req\":\"card.wireless.penalty\",\"reset\":true}"
+          },
+          {
+            "title": "Override Default Penalty Box Settings",
+            "description": "Configure custom penalty box parameters with modified defaults.",
+            "json": "{\"req\":\"card.wireless.penalty\",\"set\":true,\"rate\":2.0,\"add\":10,\"max\":720,\"min\":5}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing penalty box status information, including failure counts, duration, and current penalty conditions from the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "description": "The number of consecutive network registration failures.",
+                      "type": "integer"
+                    },
+                    "minutes": {
+                      "description": "The time since the first network registration failure.",
+                      "type": "integer"
+                    },
+                    "seconds": {
+                      "description": "If the Notecard is in a [Penalty Box](/support/understanding-notecard-penalty-boxes/), the number of seconds until the penalty condition ends.",
+                      "type": "integer",
+                      "x-min-api-version": "4.1.1"
+                    },
+                    "status": {
+                      "description": "If the Notecard is in a [Penalty Box](/support/understanding-notecard-penalty-boxes/), this field provides the associated [Error and Status Codes](/support/notecard-error-and-status-codes/).",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.wireless.penalty Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Active Penalty Box Status",
+                "description": "Example response showing Notecard in penalty box with active network registration failure.",
+                "json": "{\"seconds\":3324,\"minutes\":69,\"status\":\"network: can't connect (55.4 min remaining) {registration-failure}{network}{extended-network-failure}\",\"count\":6}"
+              },
+              {
+                "title": "No Active Penalty",
+                "description": "Example response when Notecard is not in a penalty box.",
+                "json": "{\"minutes\":0,\"count\":0}"
+              },
+              {
+                "title": "Partial Penalty Information",
+                "description": "Example response with basic penalty metrics without active penalty.",
+                "json": "{\"count\":3,\"minutes\":15}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "put": {
+        "operationId": "card_wireless_penalty_set",
+        "summary": "View the current state of a [Notecard Penalty Box](/support/understanding-notecard-penalty-boxes/), manually remove the Notecard from a penalty box, or override penalty box defaults.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "card.wireless.penalty",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "set"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.wireless.penalty Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "add": {
+                    "description": "The number of minutes to add to successive retries. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults.",
+                    "type": "integer",
+                    "default": 15
+                  },
+                  "max": {
+                    "description": "The maximum number of minutes that a device can be in a Network Registration Failure Penalty Box. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults.",
+                    "type": "integer",
+                    "default": 4320
+                  },
+                  "min": {
+                    "description": "The number of minutes of the first retry interval of a Network Registration Failure Penalty Box. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults.",
+                    "type": "integer",
+                    "default": 15
+                  },
+                  "rate": {
+                    "description": "The rate at which the penalty box time multiplier is increased over successive retries. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults.",
+                    "type": "number",
+                    "default": 1.25
+                  },
+                  "reset": {
+                    "description": "Set to `true` to remove the Notecard from certain types of penalty boxes.",
+                    "type": "boolean"
+                  },
+                  "set": {
+                    "description": "Set to `true` to override the default settings of the [Network Registration Failure Penalty Box](/support/understanding-notecard-penalty-boxes/#network-registration-failure).",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Check Penalty Box State",
+            "description": "Request current penalty box status and information.",
+            "json": "{\"req\":\"card.wireless.penalty\"}"
+          },
+          {
+            "title": "Remove from Penalty Box",
+            "description": "Reset and remove the Notecard from penalty box conditions.",
+            "json": "{\"req\":\"card.wireless.penalty\",\"reset\":true}"
+          },
+          {
+            "title": "Override Default Penalty Box Settings",
+            "description": "Configure custom penalty box parameters with modified defaults.",
+            "json": "{\"req\":\"card.wireless.penalty\",\"set\":true,\"rate\":2.0,\"add\":10,\"max\":720,\"min\":5}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing penalty box status information, including failure counts, duration, and current penalty conditions from the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "description": "The number of consecutive network registration failures.",
+                      "type": "integer"
+                    },
+                    "minutes": {
+                      "description": "The time since the first network registration failure.",
+                      "type": "integer"
+                    },
+                    "seconds": {
+                      "description": "If the Notecard is in a [Penalty Box](/support/understanding-notecard-penalty-boxes/), the number of seconds until the penalty condition ends.",
+                      "type": "integer",
+                      "x-min-api-version": "4.1.1"
+                    },
+                    "status": {
+                      "description": "If the Notecard is in a [Penalty Box](/support/understanding-notecard-penalty-boxes/), this field provides the associated [Error and Status Codes](/support/notecard-error-and-status-codes/).",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.wireless.penalty Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Active Penalty Box Status",
+                "description": "Example response showing Notecard in penalty box with active network registration failure.",
+                "json": "{\"seconds\":3324,\"minutes\":69,\"status\":\"network: can't connect (55.4 min remaining) {registration-failure}{network}{extended-network-failure}\",\"count\":6}"
+              },
+              {
+                "title": "No Active Penalty",
+                "description": "Example response when Notecard is not in a penalty box.",
+                "json": "{\"minutes\":0,\"count\":0}"
+              },
+              {
+                "title": "Partial Penalty Information",
+                "description": "Example response with basic penalty metrics without active penalty.",
+                "json": "{\"count\":3,\"minutes\":15}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "card_wireless_penalty_delete",
+        "summary": "View the current state of a [Notecard Penalty Box](/support/understanding-notecard-penalty-boxes/), manually remove the Notecard from a penalty box, or override penalty box defaults.",
+        "x-safety": "destructive",
+        "x-notecard-request": "card.wireless.penalty",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "reset"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "card.wireless.penalty Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "add": {
+                    "description": "The number of minutes to add to successive retries. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults.",
+                    "type": "integer",
+                    "default": 15
+                  },
+                  "max": {
+                    "description": "The maximum number of minutes that a device can be in a Network Registration Failure Penalty Box. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults.",
+                    "type": "integer",
+                    "default": 4320
+                  },
+                  "min": {
+                    "description": "The number of minutes of the first retry interval of a Network Registration Failure Penalty Box. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults.",
+                    "type": "integer",
+                    "default": 15
+                  },
+                  "rate": {
+                    "description": "The rate at which the penalty box time multiplier is increased over successive retries. Used with the `set` argument to override the Network Registration Failure Penalty Box defaults.",
+                    "type": "number",
+                    "default": 1.25
+                  },
+                  "reset": {
+                    "description": "Set to `true` to remove the Notecard from certain types of penalty boxes.",
+                    "type": "boolean"
+                  },
+                  "set": {
+                    "description": "Set to `true` to override the default settings of the [Network Registration Failure Penalty Box](/support/understanding-notecard-penalty-boxes/#network-registration-failure).",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Check Penalty Box State",
+            "description": "Request current penalty box status and information.",
+            "json": "{\"req\":\"card.wireless.penalty\"}"
+          },
+          {
+            "title": "Remove from Penalty Box",
+            "description": "Reset and remove the Notecard from penalty box conditions.",
+            "json": "{\"req\":\"card.wireless.penalty\",\"reset\":true}"
+          },
+          {
+            "title": "Override Default Penalty Box Settings",
+            "description": "Configure custom penalty box parameters with modified defaults.",
+            "json": "{\"req\":\"card.wireless.penalty\",\"set\":true,\"rate\":2.0,\"add\":10,\"max\":720,\"min\":5}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing penalty box status information, including failure counts, duration, and current penalty conditions from the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "description": "The number of consecutive network registration failures.",
+                      "type": "integer"
+                    },
+                    "minutes": {
+                      "description": "The time since the first network registration failure.",
+                      "type": "integer"
+                    },
+                    "seconds": {
+                      "description": "If the Notecard is in a [Penalty Box](/support/understanding-notecard-penalty-boxes/), the number of seconds until the penalty condition ends.",
+                      "type": "integer",
+                      "x-min-api-version": "4.1.1"
+                    },
+                    "status": {
+                      "description": "If the Notecard is in a [Penalty Box](/support/understanding-notecard-penalty-boxes/), this field provides the associated [Error and Status Codes](/support/notecard-error-and-status-codes/).",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "card.wireless.penalty Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Active Penalty Box Status",
+                "description": "Example response showing Notecard in penalty box with active network registration failure.",
+                "json": "{\"seconds\":3324,\"minutes\":69,\"status\":\"network: can't connect (55.4 min remaining) {registration-failure}{network}{extended-network-failure}\",\"count\":6}"
+              },
+              {
+                "title": "No Active Penalty",
+                "description": "Example response when Notecard is not in a penalty box.",
+                "json": "{\"minutes\":0,\"count\":0}"
+              },
+              {
+                "title": "Partial Penalty Information",
+                "description": "Example response with basic penalty metrics without active penalty.",
+                "json": "{\"count\":3,\"minutes\":15}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/dfu/get": {
+      "get": {
+        "operationId": "dfu_get",
+        "summary": "Retrieves downloaded firmware data from the Notecard for use with [IAP host MCU firmware updates](https://dev.blues.io/notehub/host-firmware-updates/iap-firmware-update/).",
+        "x-safety": "readonly",
+        "x-notecard-request": "dfu.get",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "dfu.get Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "binary",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If `true`, the Notecard will return firmware data in the binary I/O buffer instead of the response `payload` field. This allows for larger data transfers and more efficient processing. When `true`, the response will include `cobs`, `length`, and `status` (MD5 hash) fields instead of `payload`.\n\nLearn more in this guide on [Sending and Receiving Large Binary Objects](https://dev.blues.io/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects/)."
+          },
+          {
+            "name": "length",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "The number of bytes of firmware data to read and return to the host. Set to `0` to verify that the Notecard is in DFU mode without attempting to retrieve data."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "The offset to use before performing a read of firmware data."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Retrieve Firmware Data",
+            "description": "Retrieve 32 bytes of firmware data from the Notecard with an offset of 32 bytes.",
+            "json": "{\"req\": \"dfu.get\", \"length\": 32, \"offset\": 32}"
+          },
+          {
+            "title": "Verify DFU Mode",
+            "description": "Verify that the Notecard is in DFU mode without retrieving data.",
+            "json": "{\"req\": \"dfu.get\", \"length\": 0}"
+          },
+          {
+            "title": "Read First Block",
+            "description": "Read the first 1024 bytes of firmware data from the beginning.",
+            "json": "{\"req\": \"dfu.get\", \"length\": 1024, \"offset\": 0}"
+          },
+          {
+            "title": "Retrieve Large Firmware Data with Binary Buffer",
+            "description": "Retrieve 8192 bytes of firmware data using the binary I/O buffer for efficient large data transfers.",
+            "json": "{\"req\": \"dfu.get\", \"length\": 8192, \"offset\": 0, \"binary\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing base64-encoded firmware data retrieved from the Notecard for use with host MCU firmware updates.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "cobs": {
+                      "description": "When `binary` is `true` in the request, this field contains the COBS encoded length of the firmware data in the binary I/O buffer.",
+                      "type": "integer"
+                    },
+                    "length": {
+                      "description": "When `binary` is `true` in the request, this field contains the actual length of the firmware data in bytes in the binary I/O buffer.",
+                      "type": "integer"
+                    },
+                    "payload": {
+                      "description": "A base64 string containing firmware data of the provided `length`. This field is only present when `binary` is not used or is `false` in the request.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "When `binary` is `true` in the request, this field contains a 32-character hex-encoded MD5 hash of the firmware data. Useful for the host to verify data integrity.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "dfu.get Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Firmware Data Response",
+                "description": "Example response with base64-encoded firmware data.",
+                "json": "{\"payload\": \"AAAAAAAAAAAAAAAAcy8ACIEvAAgAAAAAjy8ACJ0vAAg=\"}"
+              },
+              {
+                "title": "Empty Response",
+                "description": "Example response when verifying DFU mode with length 0.",
+                "json": "{\"payload\": \"\"}"
+              },
+              {
+                "title": "Small Data Block",
+                "description": "Example response with a small firmware data block.",
+                "json": "{\"payload\": \"dGVzdGZpcm13YXJlZGF0YQ==\"}"
+              },
+              {
+                "title": "Binary Mode Response",
+                "description": "Example response when using binary mode with firmware data in the I/O buffer.",
+                "json": "{\"cobs\": 10240, \"length\": 8192, \"status\": \"5d41402abc4b2a76b9719d911017c592\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/dfu/status": {
+      "put": {
+        "operationId": "dfu_status",
+        "summary": "Gets and sets the background download status of MCU host or Notecard firmware updates.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "dfu.status",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "dfu.status Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "description": "If `err` text is provided along with `\"stop\":true`, this sets the host DFU to an error state with the specified string.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Determines which type of firmware update status to view. The value can be `\"user\"` (default), which gets the status of MCU host firmware updates, or `\"card\"`, which gets the status of Notecard firmware updates.",
+                    "type": "string",
+                    "enum": [
+                      "user",
+                      "card"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "user",
+                        "description": "Gets the status of MCU host firmware updates (default)."
+                      },
+                      {
+                        "const": "card",
+                        "description": "Gets the status of Notecard firmware updates."
+                      }
+                    ]
+                  },
+                  "off": {
+                    "description": "`true` to disable firmware downloads from Notehub.",
+                    "type": "boolean"
+                  },
+                  "on": {
+                    "description": "`true` to allow firmware downloads from Notehub.",
+                    "type": "boolean"
+                  },
+                  "status": {
+                    "description": "When setting `stop` to `true`, an optional string synchronized to Notehub, which can be used for informational or diagnostic purposes.",
+                    "type": "string"
+                  },
+                  "stop": {
+                    "description": "`true` to clear DFU state and delete the local firmware image from the Notecard.",
+                    "type": "boolean"
+                  },
+                  "x-schema-version": {
+                    "description": "Version information on the host firmware to pass to Notehub. You may pass a simple version number string (e.g. `\"1.0.0.0\"`), or an object with detailed information about the firmware image (recommended).\n\nIf you provide an object it must take the following form.\n\n`{\"org\":\"my-organization\",\"product\":\"My Product\",\"description\":\"A description of the image\",\"version\":\"1.2.4\",\"built\":\"Jan 01 2025 01:02:03\",\"ver_major\":1,\"ver_minor\":2,\"ver_patch\":4,\"ver_build\": 5,\"builder\":\"The Builder\"}`\n\nCode to help you generate a version with the correct formatting is available in [Enabling Notecard Outboard Firmware Update](/notehub/host-firmware-updates/notecard-outboard-firmware-update/#enabling-notecard-outboard-firmware-update).",
+                    "type": [
+                      "string",
+                      "object"
+                    ]
+                  },
+                  "vvalue": {
+                    "description": "A voltage-variable string that controls, by Notecard voltage, whether or not DFU is enabled. Use a boolean `1` (on) or `0` (off) for each source/voltage level: `usb:<1/0>;high:<1/0>;normal:<1/0>;low:<1/0>;dead:0`.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Enable DFU Downloads",
+            "description": "Enable firmware downloads from Notehub.",
+            "json": "{\"req\": \"dfu.status\", \"on\": true}"
+          },
+          {
+            "title": "Disable DFU Downloads",
+            "description": "Disable firmware downloads from Notehub.",
+            "json": "{\"req\": \"dfu.status\", \"off\": true}"
+          },
+          {
+            "title": "Voltage-Variable Enable",
+            "description": "Enable DFU downloads only when USB-powered or high voltage.",
+            "json": "{\"req\": \"dfu.status\", \"vvalue\": \"usb:1;high:1;normal:0;low:0;dead:0\"}"
+          },
+          {
+            "title": "Check Notecard DFU Status",
+            "description": "Get the status of Notecard firmware updates.",
+            "json": "{\"req\": \"dfu.status\", \"name\": \"card\"}"
+          },
+          {
+            "title": "Stop DFU with Status",
+            "description": "Clear DFU state and provide status information.",
+            "json": "{\"req\": \"dfu.status\", \"stop\": true, \"status\": \"Update cancelled by user\"}"
+          },
+          {
+            "title": "Set Version Information",
+            "description": "Provide version information for host firmware.",
+            "json": "{\"req\": \"dfu.status\", \"version\": \"1.2.4\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the current DFU mode and status information for firmware downloads.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "Object that includes essential details about the firmware binary, including its length, md5 hash, notes from the Notehub admin, created and updated dates, and more.",
+                      "type": "object"
+                    },
+                    "mode": {
+                      "description": "The current DFU mode. Will be one of:",
+                      "type": "string",
+                      "enum": [
+                        "idle",
+                        "error",
+                        "downloading",
+                        "ready",
+                        "completed"
+                      ],
+                      "x-sub-descriptions": [
+                        {
+                          "const": "idle",
+                          "description": "There is no firmware download in progress, and no data previously downloaded."
+                        },
+                        {
+                          "const": "error",
+                          "description": "The download or verification has failed. In this mode, the `status` field will contain the reason."
+                        },
+                        {
+                          "const": "downloading",
+                          "description": "The download is in progress. In this mode, the `status` field will contain info about progress."
+                        },
+                        {
+                          "const": "ready",
+                          "description": "The firmware data is fully downloaded."
+                        },
+                        {
+                          "const": "completed",
+                          "description": "The firmware has been installed."
+                        }
+                      ]
+                    },
+                    "off": {
+                      "description": "`true` when firmware downloads are disabled.",
+                      "type": "boolean"
+                    },
+                    "on": {
+                      "description": "`true` when firmware downloads are enabled.",
+                      "type": "boolean"
+                    },
+                    "pending": {
+                      "description": "`true` when Notecard DFU is currently in-progress.",
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "description": "The current status of the firmware download.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "dfu.status Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "DFU Ready Status",
+                "description": "Example response showing firmware is ready for installation.",
+                "json": "{\"mode\": \"ready\", \"status\": \"successfully downloaded\", \"on\": true, \"body\": {\"crc32\": 2525287425, \"created\": 1599163431, \"info\": {}, \"length\": 42892, \"md5\": \"5a3f73a7f1b4bc8917b12b36c2532969\", \"modified\": 1599163431, \"name\": \"stm32-new-firmware$20200903200351.bin\", \"notes\": \"Latest prod firmware\", \"source\": \"stm32-new-firmware.bin\", \"type\": \"firmware\"}}"
+              },
+              {
+                "title": "DFU Idle Status",
+                "description": "Example response showing no firmware download in progress.",
+                "json": "{\"mode\": \"idle\", \"status\": \"no download in progress\", \"on\": true}"
+              },
+              {
+                "title": "DFU Downloading Status",
+                "description": "Example response showing firmware download in progress.",
+                "json": "{\"mode\": \"downloading\", \"status\": \"downloading: 45% complete\", \"on\": true, \"pending\": true}"
+              },
+              {
+                "title": "DFU Error Status",
+                "description": "Example response showing download error.",
+                "json": "{\"mode\": \"error\", \"status\": \"download failed: checksum mismatch\", \"on\": true}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/env/default": {
+      "put": {
+        "operationId": "env_default_set",
+        "summary": "Used by the Notecard host to specify a default value for an environment variable until that variable is overridden by a device, project or fleet-wide setting at Notehub.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "env.default",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "name",
+            "text"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "env.default Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The name of the environment variable (case-insensitive).",
+                    "type": "string"
+                  },
+                  "sync": {
+                    "description": "Set to `true` to trigger an immediate sync.",
+                    "type": "boolean"
+                  },
+                  "text": {
+                    "description": "The value of the variable. Pass `\"\"` or omit from the request to delete it.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Set Default Environment Variable",
+            "description": "Set a default value for an environment variable.",
+            "json": "{\"req\": \"env.default\", \"name\": \"monitor-pump\", \"text\": \"on\"}"
+          },
+          {
+            "title": "Clear Default Environment Variable",
+            "description": "Clear the default value for an environment variable by omitting text.",
+            "json": "{\"req\": \"env.default\", \"name\": \"monitor-pump\"}"
+          },
+          {
+            "title": "Set Empty String Default",
+            "description": "Set an environment variable default to an empty string.",
+            "json": "{\"req\": \"env.default\", \"name\": \"debug-mode\", \"text\": \"\"}"
+          },
+          {
+            "title": "Set Numeric Default",
+            "description": "Set a default value for a numeric environment variable.",
+            "json": "{\"req\": \"env.default\", \"name\": \"sample-rate\", \"text\": \"60\"}"
+          },
+          {
+            "title": "Set Default and Sync",
+            "description": "Set a default environment variable and trigger an immediate sync.",
+            "json": "{\"req\": \"env.default\", \"name\": \"monitor-pump\", \"text\": \"on\", \"sync\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty response confirming successful execution of the environment variable default setting or deletion.",
+            "x-title": "env.default Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "env_default_delete",
+        "summary": "Used by the Notecard host to specify a default value for an environment variable until that variable is overridden by a device, project or fleet-wide setting at Notehub.",
+        "x-safety": "destructive",
+        "x-notecard-request": "env.default",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "name"
+          ],
+          "excludes": [
+            "text"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "env.default Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The name of the environment variable (case-insensitive).",
+                    "type": "string"
+                  },
+                  "sync": {
+                    "description": "Set to `true` to trigger an immediate sync.",
+                    "type": "boolean"
+                  },
+                  "text": {
+                    "description": "The value of the variable. Pass `\"\"` or omit from the request to delete it.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Set Default Environment Variable",
+            "description": "Set a default value for an environment variable.",
+            "json": "{\"req\": \"env.default\", \"name\": \"monitor-pump\", \"text\": \"on\"}"
+          },
+          {
+            "title": "Clear Default Environment Variable",
+            "description": "Clear the default value for an environment variable by omitting text.",
+            "json": "{\"req\": \"env.default\", \"name\": \"monitor-pump\"}"
+          },
+          {
+            "title": "Set Empty String Default",
+            "description": "Set an environment variable default to an empty string.",
+            "json": "{\"req\": \"env.default\", \"name\": \"debug-mode\", \"text\": \"\"}"
+          },
+          {
+            "title": "Set Numeric Default",
+            "description": "Set a default value for a numeric environment variable.",
+            "json": "{\"req\": \"env.default\", \"name\": \"sample-rate\", \"text\": \"60\"}"
+          },
+          {
+            "title": "Set Default and Sync",
+            "description": "Set a default environment variable and trigger an immediate sync.",
+            "json": "{\"req\": \"env.default\", \"name\": \"monitor-pump\", \"text\": \"on\", \"sync\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty response confirming successful execution of the environment variable default setting or deletion.",
+            "x-title": "env.default Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/env/get": {
+      "get": {
+        "operationId": "env_get",
+        "summary": "Returns a single environment variable, or all variables according to precedence rules.",
+        "x-safety": "readonly",
+        "x-notecard-request": "env.get",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "env.get Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the environment variable (case-insensitive). Omit to return all environment variables known to the Notecard."
+          },
+          {
+            "name": "names",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "x-min-api-version": "3.4.1"
+            },
+            "description": "A list of one or more variables to retrieve, by name (case-insensitive)."
+          },
+          {
+            "name": "time",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "x-min-api-version": "3.4.1"
+            },
+            "description": "Request a modified environment variable or variables from the Notecard, but only if modified after the time provided."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Get Single Variable",
+            "description": "Retrieve a specific environment variable by name.",
+            "json": "{\"req\": \"env.get\", \"name\": \"monitor-pump-one\"}"
+          },
+          {
+            "title": "Get Single Variable With Modified Time",
+            "description": "Retrieve a variable only if modified after the specified time.",
+            "json": "{\"req\": \"env.get\", \"name\": \"monitor-pump-one\", \"time\": 1656315835}"
+          },
+          {
+            "title": "Get Multiple Variables",
+            "description": "Retrieve multiple environment variables by name.",
+            "json": "{\"req\": \"env.get\", \"names\": [\"monitor-pump-one\", \"monitor-pump-two\"]}"
+          },
+          {
+            "title": "Get All Variables",
+            "description": "Retrieve all environment variables known to the Notecard.",
+            "json": "{\"req\": \"env.get\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing environment variable values and metadata based on the request parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "If a `name` was not specified, an object with `name` and `value` pairs for all environment variables.",
+                      "type": "object"
+                    },
+                    "text": {
+                      "description": "If a `name` was specified, the value of the environment variable.",
+                      "type": "string"
+                    },
+                    "time": {
+                      "description": "The time of the Notecard variable or variables change.",
+                      "type": "integer",
+                      "x-min-api-version": "3.4.1"
+                    }
+                  },
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "x-title": "env.get Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Single Variable Response",
+                "description": "Response for a single environment variable request.",
+                "json": "{\"monitor-pump-one\": \"on\", \"time\": 1656315835}"
+              },
+              {
+                "title": "Multiple Variables Response",
+                "description": "Response for multiple environment variables request.",
+                "json": "{\"body\": {\"monitor-pump-one\": \"on\", \"monitor-pump-two\": \"off\"}, \"time\": 1656315835}"
+              },
+              {
+                "title": "All Variables Response",
+                "description": "Response for all environment variables request.",
+                "json": "{\"body\": {\"monitor-pump-one\": \"on\", \"monitor-pump-two\": \"off\", \"monitor-pump-three\": \"on\"}, \"time\": 1656315835}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/env/modified": {
+      "get": {
+        "operationId": "env_modified",
+        "summary": "Get the time of the update to any environment variable managed by the Notecard.",
+        "x-safety": "readonly",
+        "x-notecard-request": "env.modified",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "env.modified Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "time",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "x-min-api-version": "3.4.1"
+            },
+            "description": "Request whether the Notecard has detected an environment variable change since a known epoch time."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Get Environment Modified Time",
+            "description": "Get the timestamp of the last environment variable change.",
+            "json": "{\"req\": \"env.modified\"}"
+          },
+          {
+            "title": "Check Changes Since Time",
+            "description": "Check if environment variables have been modified since a specific time.",
+            "json": "{\"req\": \"env.modified\", \"time\": 1605814400}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the timestamp of the last environment variable change.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "description": "Timestamp indicating the last time any environment variable was changed on the device.",
+                      "type": "integer",
+                      "x-min-api-version": "3.4.1"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "env.modified Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Environment Modified Time Response",
+                "description": "Response containing the last modification timestamp.",
+                "json": "{\"time\": 1605814493}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/env/set": {
+      "put": {
+        "operationId": "env_set",
+        "summary": "Sets a local environment variable on the Notecard. Local environment variables cannot be overridden by a Notehub variable of any scope.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "env.set",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "env.set Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The name of the environment variable (case-insensitive).",
+                    "type": "string"
+                  },
+                  "text": {
+                    "description": "The value of the variable. Pass `\"\"` or omit from the request to delete it.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Set Environment Variable",
+            "description": "Set a local environment variable on the Notecard.",
+            "json": "{\"req\": \"env.set\", \"name\": \"monitor-pump\", \"text\": \"on\"}"
+          },
+          {
+            "title": "Clear Environment Variable",
+            "description": "Clear a local environment variable by omitting text.",
+            "json": "{\"req\": \"env.set\", \"name\": \"monitor-pump\"}"
+          },
+          {
+            "title": "Set Empty String",
+            "description": "Set an environment variable to an empty string.",
+            "json": "{\"req\": \"env.set\", \"name\": \"debug-mode\", \"text\": \"\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the timestamp of the environment variable change.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "description": "The logged time of the variable change.",
+                      "type": "integer",
+                      "x-min-api-version": "3.4.1"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "env.set Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Environment Variable Set Response",
+                "description": "Response containing the timestamp of when the variable was set.",
+                "json": "{\"time\": 1605814493}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/env/template": {
+      "put": {
+        "operationId": "env_template",
+        "summary": "The `env.template` request allows developers to provide a schema for the environment variables the Notecard uses. The provided template allows the Notecard to store environment variables as fixed-length binary records rather than as flexible JSON objects that require much more memory.\n\nUsing templated environment variables also allows the Notecard to optimize the network traffic related to sending and receiving environment variable updates.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "env.template",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "env.template Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "description": "A sample JSON body that specifies environment variables names and values as \"hints\" for the data type. Possible data types are: boolean, integer, float, and string. See [Understanding Template Data Types](/notecard/notecard-walkthrough/low-bandwidth-design#understanding-template-data-types) for a full explanation of type hints.",
+                    "type": "object"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Define Environment Variable Template",
+            "description": "Provide a schema with data type hints for environment variables.",
+            "json": "{\"req\": \"env.template\", \"body\": {\"env_var_int\": 11, \"env_var_string\": \"10\"}}"
+          },
+          {
+            "title": "Complex Template Example",
+            "description": "Template with multiple data types including boolean and float.",
+            "json": "{\"req\": \"env.template\", \"body\": {\"enabled\": true, \"temperature\": 23.5, \"count\": 42, \"name\": \"sensor\"}}"
+          },
+          {
+            "title": "Clear Template",
+            "description": "Clear the environment variable template by omitting the body.",
+            "json": "{\"req\": \"env.template\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the maximum number of bytes for the environment variable template.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bytes": {
+                      "description": "The maximum number of bytes that will be used when environment variables are communicated or stored, so long as the variables do not include variable-length strings.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "env.template Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Template Size Response",
+                "description": "Response showing the maximum bytes used by the environment variable template.",
+                "json": "{\"bytes\": 22}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/file/changes": {
+      "get": {
+        "operationId": "file_changes",
+        "summary": "Used to perform queries on a single or multiple files to determine if new Notes are available to read, or if there are unsynced Notes in local Notefiles.\n\n*Note: This request is a Notefile API request, only. `.qo` Notes in Notehub are automatically ingested and stored, or sent to applicable Routes.*",
+        "x-safety": "readonly",
+        "x-notecard-request": "file.changes",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "file.changes Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "files",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "One or more files to obtain change information from. Omit to return changes for all Notefiles."
+          },
+          {
+            "name": "tracker",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-skus": [
+                "CELL",
+                "CELL+WIFI",
+                "WIFI"
+              ]
+            },
+            "description": "ID of a [change tracker](/notecard/notecard-walkthrough/inbound-requests-and-shared-data/#using-change-trackers-with-inbound-data) to use to determine changes to Notefiles."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Check All Files",
+            "description": "Check all Notefiles for changes without specifying files or tracker.",
+            "json": "{\"req\": \"file.changes\"}"
+          },
+          {
+            "title": "Check Specific Files",
+            "description": "Check specific Notefiles for changes.",
+            "json": "{\"req\": \"file.changes\", \"files\": [\"sensors.qo\", \"data.qo\"]}"
+          },
+          {
+            "title": "Use Change Tracker",
+            "description": "Use a change tracker to monitor file changes over time.",
+            "json": "{\"req\": \"file.changes\", \"tracker\": \"my-tracker\"}"
+          },
+          {
+            "title": "Tracker with Specific Files",
+            "description": "Combine change tracker with specific file monitoring.",
+            "json": "{\"req\": \"file.changes\", \"files\": [\"sensors.qo\"], \"tracker\": \"sensor-tracker\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing information about file changes and their status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "changes": {
+                      "description": "If a change tracker is used, the number of changes across all files.",
+                      "type": "integer"
+                    },
+                    "info": {
+                      "description": "An object with a key for each Notefile that matched the request parameters, and value object with the `changes` and `total` for each file.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "changes": {
+                            "description": "The number of changes in this file.",
+                            "type": "integer"
+                          },
+                          "total": {
+                            "description": "The total number of Notes in this file.",
+                            "type": "integer"
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "pending": {
+                      "description": "Set to `true` if this was a pending changes request and there are changes",
+                      "type": "boolean"
+                    },
+                    "total": {
+                      "description": "The total of local Notes across all Notefiles. This includes Inbound Notes that have not been deleted, as well as outbound Notes that have yet to sync.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "file.changes Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Example Change Response",
+                "description": "Response showing changes detected in monitored files.",
+                "json": "{\"changes\": 5, \"total\": 5, \"info\": {\"my-settings.db\": {\"changes\": 3, \"total\": 3}, \"other-settings.db\": {\"changes\": 2, \"total\": 2}}}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/file/changes/pending": {
+      "get": {
+        "operationId": "file_changes_pending",
+        "summary": "Returns info about file changes that are pending upload to Notehub.",
+        "x-safety": "readonly",
+        "x-notecard-request": "file.changes.pending",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "file.changes.pending Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Check Pending Changes",
+            "description": "Query for pending file changes awaiting upload to Notehub.",
+            "json": "{\"req\": \"file.changes.pending\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing information about file changes pending upload to Notehub.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "changes": {
+                      "description": "The number of changes across all files.",
+                      "type": "integer"
+                    },
+                    "info": {
+                      "description": "An object with a key for each Notefile and value object with the `changes` and `total` for each file.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "changes": {
+                            "description": "Number of changes in this specific file",
+                            "type": "integer"
+                          },
+                          "total": {
+                            "description": "Total number of notes in this specific file",
+                            "type": "integer"
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "pending": {
+                      "description": "`true` if there are pending changes.",
+                      "type": "boolean"
+                    },
+                    "total": {
+                      "description": "The total of unsynced notes across all Notefiles.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "file.changes.pending Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Pending Changes Response",
+                "description": "Response showing pending changes across multiple files.",
+                "json": "{\"total\": 3, \"changes\": 3, \"pending\": true, \"info\": {\"sensors.qo\": {\"changes\": 3, \"total\": 3}}}"
+              },
+              {
+                "title": "No Pending Changes",
+                "description": "Response when no changes are pending upload.",
+                "json": "{\"total\": 0, \"changes\": 0, \"pending\": false}"
+              },
+              {
+                "title": "Multiple Files with Changes",
+                "description": "Response with pending changes across multiple Notefiles.",
+                "json": "{\"total\": 5, \"changes\": 5, \"pending\": true, \"info\": {\"sensors.qo\": {\"changes\": 3, \"total\": 3}, \"data.qo\": {\"changes\": 2, \"total\": 2}}}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/file/clear": {
+      "delete": {
+        "operationId": "file_clear",
+        "summary": "Used to clear the contents of a specified outbound (`.qo`/`.qos`) Notefile, deleting all pending Notes.",
+        "x-safety": "destructive",
+        "x-notecard-request": "file.clear",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "8.2.1",
+        "x-title": "file.clear Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "description": "The name of the Notefile whose Notes you wish to delete.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Clear Outbound Notefile",
+            "description": "Clear all pending Notes from an outbound Notefile.",
+            "json": "{\"req\": \"file.clear\", \"file\": \"data.qo\"}"
+          },
+          {
+            "title": "Clear Encrypted Outbound Notefile",
+            "description": "Clear all pending Notes from an encrypted outbound Notefile.",
+            "json": "{\"req\": \"file.clear\", \"file\": \"sensors.qos\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response confirming the clearing of the specified Notefile.",
+            "x-title": "file.clear Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "8.2.1"
+          }
+        }
+      }
+    },
+    "/file/delete": {
+      "delete": {
+        "operationId": "file_delete",
+        "summary": "Deletes Notefiles and the Notes they contain.",
+        "x-safety": "destructive",
+        "x-notecard-request": "file.delete",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "file.delete Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "files": {
+                    "description": "One or more files to delete.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Delete Multiple Files",
+            "description": "Delete multiple Notefiles and their contents.",
+            "json": "{\"req\": \"file.delete\", \"files\": [\"my-settings.db\", \"other-settings.db\"]}"
+          },
+          {
+            "title": "Delete Single File",
+            "description": "Delete a single Notefile and its contents.",
+            "json": "{\"req\": \"file.delete\", \"files\": [\"data.qo\"]}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response confirming the deletion of the specified Notefiles.",
+            "x-title": "file.delete Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/file/stats": {
+      "get": {
+        "operationId": "file_stats",
+        "summary": "Gets resource statistics about local Notefiles.",
+        "x-safety": "readonly",
+        "x-notecard-request": "file.stats",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "file.stats Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Returns the stats for the specified Notefile only."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Get All File Stats",
+            "description": "Get resource statistics for all Notefiles.",
+            "json": "{\"req\": \"file.stats\"}"
+          },
+          {
+            "title": "Get Specific File Stats",
+            "description": "Get resource statistics for a specific Notefile.",
+            "json": "{\"req\": \"file.stats\", \"file\": \"sensors.qo\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing resource statistics about local Notefiles.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "changes": {
+                      "description": "The number of Notes across all Notefiles pending sync.",
+                      "type": "integer"
+                    },
+                    "sync": {
+                      "description": "`true` if a sync is recommended based on the number of pending notes.",
+                      "type": "boolean"
+                    },
+                    "total": {
+                      "description": "The total number of Notes across all Notefiles.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "file.stats Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "File Statistics Response",
+                "description": "Response with resource statistics showing pending sync recommendation.",
+                "json": "{\"total\": 83, \"changes\": 78, \"sync\": true}"
+              },
+              {
+                "title": "No Pending Changes",
+                "description": "Response when no changes are pending sync.",
+                "json": "{\"total\": 25, \"changes\": 0, \"sync\": false}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/hub/get": {
+      "get": {
+        "operationId": "hub_get",
+        "summary": "Retrieves the current Notehub configuration for the Notecard.",
+        "x-safety": "readonly",
+        "x-notecard-request": "hub.get",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "hub.get Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Get Notehub Configuration",
+            "description": "Retrieve the current Notehub configuration for the Notecard.",
+            "json": "{\"req\": \"hub.get\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the current Notehub configuration for the Notecard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "device": {
+                      "description": "The [DeviceUID](/api-reference/glossary#deviceuid) for the Notecard.",
+                      "type": "string"
+                    },
+                    "host": {
+                      "description": "The URL of the Notehub host.",
+                      "type": "string"
+                    },
+                    "inbound": {
+                      "description": "The max wait time, in minutes, to sync inbound data from Notehub.",
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "description": "The current operating `mode` of the Notecard, as defined in `hub.set`.",
+                      "type": "string",
+                      "enum": [
+                        "periodic",
+                        "continuous",
+                        "minimum",
+                        "off",
+                        "dfu"
+                      ],
+                      "x-sub-descriptions": [
+                        {
+                          "const": "periodic",
+                          "description": "Periodically connect to the Notehub. This is the default value set on each Notecard after a factory reset."
+                        },
+                        {
+                          "const": "continuous",
+                          "description": "Enables an always-on network connection, for high power devices. Outbound data still syncs periodically, unless specified in a Note or File request."
+                        },
+                        {
+                          "const": "minimum",
+                          "description": "Disables periodic connection. The Notecard will not sync until it receives an explicit `hub.sync` request. OTA DFU updates are not available when using this mode."
+                        },
+                        {
+                          "const": "off",
+                          "description": "Disables automatic and manual syncs. `hub.sync` requests will be ignored in this mode. OTA DFU updates are not available when using this mode."
+                        },
+                        {
+                          "const": "dfu",
+                          "description": "Puts the Notecard in DFU mode for IAP host MCU firmware updates. This mode is effectively the same as `off` in terms of the Notecard's network and Notehub connections."
+                        }
+                      ]
+                    },
+                    "outbound": {
+                      "description": "The max wait time, in minutes, to sync outbound data from the Notecard.",
+                      "type": "integer"
+                    },
+                    "product": {
+                      "description": "The ProductUID to which the Notecard is registered.",
+                      "type": "string"
+                    },
+                    "sn": {
+                      "description": "The serial number of the device, if set.",
+                      "type": "string"
+                    },
+                    "sync": {
+                      "description": "`true` if the device is in `continuous` mode and set to sync every time a change is detected.",
+                      "type": "boolean"
+                    },
+                    "vinbound": {
+                      "description": "If `inbound` has been overridden with a voltage-variable value.",
+                      "type": "string"
+                    },
+                    "voutbound": {
+                      "description": "If `outbound` is overridden with a voltage-variable value.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "hub.get Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Notehub Configuration Response",
+                "description": "Response with current Notehub configuration settings.",
+                "json": "{\"device\": \"dev:000000000000000\", \"product\": \"com.your-company.your-name:your_product\", \"mode\": \"periodic\", \"outbound\": 60, \"inbound\": 240, \"host\": \"a.notefile.net\", \"sn\": \"your-serial-number\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/hub/log": {
+      "post": {
+        "operationId": "hub_log",
+        "summary": "Add a \"device health\" log message to send to Notehub on the next sync via the [_health_host.qo Notefile](/api-reference/system-notefiles/#healthhost-qo).",
+        "x-safety": "non-idempotent",
+        "x-notecard-request": "hub.log",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "hub.log Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "alert": {
+                    "description": "`true` if the message is urgent. This doesn't change any functionality, but rather `alert` is provided as a convenient flag to use in your program logic.",
+                    "type": "boolean"
+                  },
+                  "sync": {
+                    "description": "`true` if a sync should be initiated immediately. Setting `true` will also remove the Notecard from certain types of penalty boxes.",
+                    "type": "boolean"
+                  },
+                  "text": {
+                    "description": "Text to log.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Log Health Alert with Immediate Sync",
+            "description": "Log an urgent health alert and sync immediately.",
+            "json": "{\"req\": \"hub.log\", \"text\": \"something is wrong!\", \"alert\": true, \"sync\": true}"
+          },
+          {
+            "title": "Log Simple Message",
+            "description": "Log a simple text message.",
+            "json": "{\"req\": \"hub.log\", \"text\": \"System status: normal\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response from logging a device health message to Notehub.",
+            "x-title": "hub.log Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/hub/set": {
+      "put": {
+        "operationId": "hub_set",
+        "summary": "The hub.set request is the primary method for controlling the Notecard's Notehub connection and sync behavior.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "hub.set",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "hub.set Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "align": {
+                    "description": "Use `true` to align syncs on a regular time-periodic cycle.",
+                    "type": "boolean"
+                  },
+                  "details": {
+                    "description": "When using Notecard LoRa you can use this argument to provide information about an alternative LoRaWAN server or service you would like the Notecard to use. The argument you provide must be a JSON object with three keys, \"deveui\", \"appeui\", and \"appkey\", all of which are hexadecimal strings with no leading 0x. For example:\n\n`{\"deveui\":\"0080E11500088B37\",\"appeui\":\"6E6F746563617264\",\"appkey\":\"00088B37\"}`\n\nThe LoRaWAN details you send to a Notecard become part of its permanent configuration, and survive factory resets. You can reset a Notecard's LoRaWAN details to its default values by providing a `\"-\"` for the details argument.",
+                    "x-skus": [
+                      "LORA"
+                    ],
+                    "x-min-api-version": "6.2.3",
+                    "type": [
+                      "string",
+                      "object"
+                    ],
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "const": "-"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "deveui": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]+$"
+                          },
+                          "appeui": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]+$"
+                          },
+                          "appkey": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]+$"
+                          }
+                        },
+                        "required": [
+                          "deveui",
+                          "appeui",
+                          "appkey"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "duration": {
+                    "description": "When in `continuous` mode, the amount of time, in minutes, of each session (the minimum allowed value is `15`). When this time elapses, the Notecard gracefully ends the current session and starts a new one in order to sync session-specific data to Notehub.",
+                    "type": "integer",
+                    "anyOf": [
+                      {
+                        "const": -1
+                      },
+                      {
+                        "minimum": 15
+                      }
+                    ]
+                  },
+                  "host": {
+                    "description": "The URL of the Notehub service. Use `\"-\"` to reset to the default value.",
+                    "type": "string"
+                  },
+                  "inbound": {
+                    "description": "The max wait time, in minutes, to sync inbound data from Notehub. Explicit syncs (e.g. using `hub.sync`) do not affect this cadence.\n\nWhen in `periodic` or `continuous` mode this argument is required, otherwise the Notecard will function as if it is in `minimum` mode as it pertains to syncing behavior.\n\nUse `-1` to reset the value back to its default of `0`.\n\nA value of `0` means that the Notecard will never sync inbound data unless explicitly told to do so (e.g. using `hub.sync`).",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "mode": {
+                    "description": "The Notecard's synchronization mode.\n\n**NOTE:** The Notecard must be in `periodic` or `continuous` mode to use the onboard GPS module.",
+                    "type": "string",
+                    "enum": [
+                      "periodic",
+                      "continuous",
+                      "minimum",
+                      "off",
+                      "dfu"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "periodic",
+                        "description": "Periodically connect to the Notehub. This is the default value set on each Notecard after a factory reset."
+                      },
+                      {
+                        "const": "continuous",
+                        "description": "Enables an always-on network connection, for high power devices. Outbound data still syncs periodically, unless specified in a Note or File request."
+                      },
+                      {
+                        "const": "minimum",
+                        "description": "Disables periodic connection. The Notecard will not sync until it receives an explicit `hub.sync` request. OTA DFU updates are not available when using this mode."
+                      },
+                      {
+                        "const": "off",
+                        "description": "Disables automatic and manual syncs. `hub.sync` requests will be ignored in this mode. OTA DFU updates are not available when using this mode."
+                      },
+                      {
+                        "const": "dfu",
+                        "description": "Puts the Notecard in DFU mode for IAP host MCU firmware updates. This mode is effectively the same as `off` in terms of the Notecard's network and Notehub connections."
+                      }
+                    ]
+                  },
+                  "off": {
+                    "description": "Set to `true` to manually instruct the Notecard to resume periodic mode after a web transaction has completed.",
+                    "type": "boolean",
+                    "x-min-api-version": "3.4.1"
+                  },
+                  "on": {
+                    "description": "If in `periodic` mode, used to temporarily switch the Notecard to `continuous` mode to perform a web transaction.\\n\\nIgnored if the Notecard is already in `continuous` mode or if the Notecard is NOT performing a web transaction.",
+                    "type": "boolean",
+                    "x-min-api-version": "3.4.1"
+                  },
+                  "outbound": {
+                    "description": "The max wait time, in minutes, to sync outbound data from the Notecard. Explicit syncs (e.g. using `hub.sync`) do not affect this cadence.\n\nWhen in `periodic` or `continuous` mode this argument is required, otherwise the Notecard will function as if it is in `minimum` mode as it pertains to syncing behavior.\n\nUse `-1` to reset the value back to its default of `0`.\n\nA value of `0` means that the Notecard will never sync outbound data unless explicitly told to do so (e.g. using `hub.sync`).",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "product": {
+                    "description": "A Notehub-managed unique identifier that is used to match Devices with Projects. This string is used during a device's auto-provisioning to find the Notehub Project that, once provisioned, will securely manage the device and its data.",
+                    "type": "string"
+                  },
+                  "seconds": {
+                    "description": "If in `periodic` mode and using `on` above, the number of seconds to run in continuous mode before switching back to periodic mode. If not set, a default of 300 seconds is used. Ignored if the Notecard is already in continuous mode.",
+                    "type": "integer",
+                    "x-min-api-version": "3.4.1",
+                    "minimum": -1
+                  },
+                  "sn": {
+                    "description": "The end product's serial number.",
+                    "type": "string"
+                  },
+                  "sync": {
+                    "description": "If in `continuous` mode, automatically and immediately sync each time an inbound Notefile change is detected on Notehub.\n\n**NOTE:** The `sync` argument is not supported when a Notecard is in NTN mode.",
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ],
+                    "type": "boolean"
+                  },
+                  "umin": {
+                    "description": "Set to `true` to use USB/line power variable sync behavior, enabling the Notecard to stay in `continuous` mode when connected to USB/line power and fallback to `minimum` mode when disconnected.",
+                    "type": "boolean",
+                    "x-min-api-version": "4.1.1"
+                  },
+                  "uoff": {
+                    "description": "Set to `true` to use USB/line power variable sync behavior, enabling the Notecard to stay in `continuous` mode when connected to USB/line power and fallback to `off` mode when disconnected.",
+                    "type": "boolean",
+                    "x-min-api-version": "4.1.1"
+                  },
+                  "uperiodic": {
+                    "description": "Set to `true` to use USB/line power variable sync behavior, enabling the Notecard to stay in `continuous` mode when connected to USB/line power and fallback to `periodic` mode when disconnected.",
+                    "type": "boolean",
+                    "x-min-api-version": "4.1.1"
+                  },
+                  "x-schema-version": {
+                    "description": "The version of your host firmware. The value provided will appear on your device in Notehub under the \"Host Firmware\" tab.\n\nYou may pass a simple version number string (e.g. \"1.0.0.0\"), or an object with detailed information about the firmware image. If you provide an object it must take the following form.\n\n`{\"org\":\"my-organization\",\"product\":\"My Product\",\"description\":\"A description of the image\",\"version\":\"1.2.4\",\"built\":\"Jan 01 2025 01:02:03\",\"ver_major\":1,\"ver_minor\":2,\"ver_patch\":4,\"ver_build\": 5,\"builder\":\"The Builder\"}`\n\nIf your project uses [Notecard Outboard Firmware Update](/notehub/host-firmware-updates/notecard-outboard-firmware-update), you can alternatively use the [`dfu.status` request](/api-reference/notecard-api/dfu-requests/latest/#dfu-status) to set your host firmware version.",
+                    "type": [
+                      "string",
+                      "object"
+                    ],
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "org": {
+                            "type": "string"
+                          },
+                          "product": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "x-schema-version": {
+                            "type": "string"
+                          },
+                          "built": {
+                            "type": "string"
+                          },
+                          "ver_major": {
+                            "type": "integer"
+                          },
+                          "ver_minor": {
+                            "type": "integer"
+                          },
+                          "ver_patch": {
+                            "type": "integer"
+                          },
+                          "ver_build": {
+                            "type": "integer"
+                          },
+                          "builder": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ],
+                    "x-min-api-version": "7.3.1"
+                  },
+                  "vinbound": {
+                    "description": "Overrides `inbound` with a voltage-variable value. Use `\"-\"` to clear this value.\n\n**NOTE:** Setting voltage-variable values is not supported on Notecard XP.",
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ],
+                    "type": "string"
+                  },
+                  "voutbound": {
+                    "description": "Overrides `outbound` with a voltage-variable value. Use `\"-\"` to clear this value.\n\n**NOTE:** Setting voltage-variable values is not supported on Notecard XP.",
+                    "x-skus": [
+                      "CELL",
+                      "CELL+WIFI",
+                      "WIFI"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Set ProductUID",
+            "description": "Change device ProductUID and serial number.",
+            "json": "{\"req\": \"hub.set\", \"product\": \"com.your-company.your-name:your_product\", \"sn\": \"my-device\"}"
+          },
+          {
+            "title": "Periodic Mode",
+            "description": "Configure periodic mode with outbound and inbound sync timing.",
+            "json": "{\"req\": \"hub.set\", \"mode\": \"periodic\", \"product\": \"com.your-company.your-name:your_product\", \"outbound\": 90, \"inbound\": 240}"
+          },
+          {
+            "title": "Continuous Mode",
+            "description": "Configure continuous mode with session duration and automatic sync.",
+            "json": "{\"req\": \"hub.set\", \"mode\": \"continuous\", \"product\": \"com.your-company.your-name:your_product\", \"outbound\": 30, \"inbound\": 60, \"duration\": 240, \"sync\": true}"
+          },
+          {
+            "title": "Voltage-Variable Sync",
+            "description": "Configure voltage-dependent synchronization periods.",
+            "json": "{\"req\": \"hub.set\", \"mode\": \"periodic\", \"voutbound\": \"usb:30;high:60;normal:90;low:120;dead:0\", \"vinbound\": \"usb:60;high:120;normal:240;low:480;dead:0\"}"
+          },
+          {
+            "title": "Set Host Firmware Version String",
+            "description": "Set host firmware version using a simple string.",
+            "json": "{\"req\": \"hub.set\", \"version\": \"1.2.3\"}"
+          },
+          {
+            "title": "Set Host Firmware Version Object",
+            "description": "Set host firmware version using detailed object information.",
+            "json": "{\"req\": \"hub.set\", \"version\": {\"org\": \"my-organization\", \"product\": \"My Product\", \"description\": \"A description of the image\", \"version\": \"1.2.4\", \"built\": \"Jan 01 2025 01:02:03\", \"ver_major\": 1, \"ver_minor\": 2, \"ver_patch\": 4, \"ver_build\": 5, \"builder\": \"The Builder\"}}"
+          },
+          {
+            "title": "Configure LoRaWAN Details",
+            "description": "Set alternative LoRaWAN server details for Notecard LoRa.",
+            "json": "{\"req\": \"hub.set\", \"details\": {\"deveui\": \"0080E11500088B37\", \"appeui\": \"6E6F746563617264\", \"appkey\": \"00088B3700112233445566778899AABB\"}}"
+          },
+          {
+            "title": "Reset LoRaWAN Details",
+            "description": "Reset LoRaWAN details to default values using dash.",
+            "json": "{\"req\": \"hub.set\", \"details\": \"-\"}"
+          },
+          {
+            "title": "USB Power Variable Sync",
+            "description": "Configure USB/line power variable sync to minimum mode.",
+            "json": "{\"req\": \"hub.set\", \"umin\": true}"
+          },
+          {
+            "title": "Web Transaction Control",
+            "description": "Temporarily switch to continuous mode for web transactions.",
+            "json": "{\"req\": \"hub.set\", \"on\": true, \"seconds\": 300}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response from configuring the Notecard's Notehub connection and sync behavior.",
+            "x-title": "hub.set Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/hub/signal": {
+      "post": {
+        "operationId": "hub_signal",
+        "summary": "Receive a [Signal](/api-reference/glossary/#signal) (a near-real-time Note) from Notehub.\n\nThis request checks for an inbound signal from Notehub. If it finds a signal, this request returns the signal's body and deletes the signal. If there are multiple signals to receive, this request reads and deletes signals in FIFO (first in first out) order.",
+        "x-safety": "non-idempotent",
+        "x-notecard-request": "hub.signal",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "hub.signal Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "seconds": {
+                    "description": "The number of seconds to wait before timing out the request.",
+                    "type": "integer",
+                    "x-min-api-version": "5.1.1"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Receive a Signal",
+            "description": "Check for an inbound signal from Notehub.",
+            "json": "{\"req\": \"hub.signal\"}"
+          },
+          {
+            "title": "Receive Signal with Timeout",
+            "description": "Check for an inbound signal with custom timeout.",
+            "json": "{\"req\": \"hub.signal\", \"seconds\": 30}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing a received signal from Notehub.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "The JSON body of a received signal.",
+                      "type": "object"
+                    },
+                    "connected": {
+                      "description": "`true` if the Notecard is connected to Notehub.",
+                      "type": "boolean"
+                    },
+                    "signals": {
+                      "description": "The number of queued signals remaining.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "hub.signal Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Signal Received",
+                "description": "Response when a signal is received from Notehub.",
+                "json": "{\"body\": {\"example-key\": \"example-value\"}, \"connected\": true}"
+              },
+              {
+                "title": "No Signals Available",
+                "description": "Response when no signals are available.",
+                "json": "{\"connected\": true, \"signals\": 0}"
+              },
+              {
+                "title": "Multiple Signals Queued",
+                "description": "Response with remaining queued signals.",
+                "json": "{\"body\": {\"data\": \"signal-data\"}, \"connected\": true, \"signals\": 3}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/hub/status": {
+      "get": {
+        "operationId": "hub_status",
+        "summary": "Displays the current status of the Notecard's connection to Notehub.",
+        "x-safety": "readonly",
+        "x-notecard-request": "hub.status",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "hub.status Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Get Hub Connection Status",
+            "description": "Check the current status of the Notecard's connection to Notehub.",
+            "json": "{\"req\": \"hub.status\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the current status of the Notecard's connection to Notehub.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "connected": {
+                      "description": "`true` if the Notecard is connected to Notehub.",
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "description": "Details about the Notecard's transport (e.g. cellular, WiFi, LoRa) connection status.\n\nUse `connected` to check if the Notecard is connected to Notehub.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "hub.status Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Connected Status",
+                "description": "Response when Notecard is connected to Notehub.",
+                "json": "{\"status\": \"connected (session open) {connected}\", \"connected\": true}"
+              },
+              {
+                "title": "Disconnected Status",
+                "description": "Response when Notecard is not connected to Notehub.",
+                "json": "{\"status\": \"disconnected\", \"connected\": false}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/hub/sync": {
+      "post": {
+        "operationId": "hub_sync",
+        "summary": "Manually initiates a sync with Notehub.",
+        "x-safety": "non-idempotent",
+        "x-notecard-request": "hub.sync",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "hub.sync Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "allow": {
+                    "description": "Set to `true` to remove the Notecard from certain types of [penalty boxes](/support/understanding-notecard-penalty-boxes/) (the default is `false`).",
+                    "type": "boolean"
+                  },
+                  "in": {
+                    "description": "Set to `true` to only sync pending inbound Notefiles. **Required** when using NTN mode with Starnote to check for inbound Notefiles.",
+                    "type": "boolean"
+                  },
+                  "out": {
+                    "description": "Set to `true` to only sync pending outbound Notefiles.",
+                    "type": "boolean",
+                    "x-min-api-version": "7.2.1"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Manual Sync",
+            "description": "Initiate a manual sync with Notehub.",
+            "json": "{\"req\": \"hub.sync\"}"
+          },
+          {
+            "title": "Sync with Penalty Box Removal",
+            "description": "Sync and remove Notecard from penalty boxes.",
+            "json": "{\"req\": \"hub.sync\", \"allow\": true}"
+          },
+          {
+            "title": "Outbound Only Sync",
+            "description": "Sync only pending outbound Notefiles.",
+            "json": "{\"req\": \"hub.sync\", \"out\": true}"
+          },
+          {
+            "title": "Inbound Only Sync",
+            "description": "Sync only pending inbound Notefiles (required for NTN mode).",
+            "json": "{\"req\": \"hub.sync\", \"in\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response from manually initiating a sync with Notehub.",
+            "x-title": "hub.sync Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/hub/sync/status": {
+      "get": {
+        "operationId": "hub_sync_status",
+        "summary": "Check on the status of a recently triggered or previous sync.",
+        "x-safety": "readonly",
+        "x-notecard-request": "hub.sync.status",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "hub.sync.status Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "sync",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "`true` if this request should auto-initiate a sync pending outbound data."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Check Sync Status",
+            "description": "Check the status of a recent or previous sync.",
+            "json": "{\"req\": \"hub.sync.status\"}"
+          },
+          {
+            "title": "Check Status and Auto-Initiate Sync",
+            "description": "Check sync status and auto-initiate sync if there is pending outbound data.",
+            "json": "{\"req\": \"hub.sync.status\", \"sync\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the status of a recently triggered or previous sync.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "alert": {
+                      "description": "`true` if an error occurred during the most recent sync.",
+                      "type": "boolean"
+                    },
+                    "completed": {
+                      "description": "Number of seconds since the last sync completion.",
+                      "type": "integer"
+                    },
+                    "mode": {
+                      "description": "The current state of the wireless connectivity module in use.",
+                      "type": "string"
+                    },
+                    "requested": {
+                      "description": "Number of seconds since the last explicit sync request.",
+                      "type": "integer"
+                    },
+                    "scan": {
+                      "description": "Returns `true` if triangulation data was sent to Notehub in the most recent sync.",
+                      "type": "boolean",
+                      "x-min-api-version": "6.1.1"
+                    },
+                    "seconds": {
+                      "description": "If the Notecard is in a [Penalty Box](/support/understanding-notecard-penalty-boxes/), the number of seconds until the penalty condition ends.",
+                      "type": "integer",
+                      "x-min-api-version": "4.1.1"
+                    },
+                    "status": {
+                      "description": "The status of the current or previous sync. Refer to [this listing](/support/notecard-error-and-status-codes/) for the meaning of the various status codes returned (e.g. `{sync-end}`).",
+                      "type": "string"
+                    },
+                    "sync": {
+                      "description": "`true` if the notecard has unsynchronized notes, or requires a sync to set its internal clock.",
+                      "type": "boolean"
+                    },
+                    "time": {
+                      "description": "Time of the last sync completion. Will only populate if the Notecard has completed a sync to Notehub to obtain the time.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "hub.sync.status Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Sync Status with Completion Info",
+                "description": "Response showing sync status with completion time and alert.",
+                "json": "{\"status\": \"completed {sync-end}\", \"mode\": \"{modem-off}\", \"time\": 1598367163, \"alert\": true, \"sync\": true, \"completed\": 1648}"
+              },
+              {
+                "title": "Sync Status with Penalty Box",
+                "description": "Response when Notecard is in penalty box.",
+                "json": "{\"status\": \"waiting {network-down}\", \"mode\": \"{modem-off}\", \"sync\": false, \"seconds\": 300}"
+              },
+              {
+                "title": "Recent Sync with Triangulation",
+                "description": "Response showing recent sync with scan data.",
+                "json": "{\"status\": \"completed {sync-end}\", \"mode\": \"{modem-off}\", \"time\": 1598367163, \"sync\": false, \"completed\": 45, \"scan\": true}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/note/add": {
+      "post": {
+        "operationId": "note_add",
+        "summary": "Adds a Note to a Notefile, creating the Notefile if it doesn't yet exist.",
+        "x-safety": "non-idempotent",
+        "x-notecard-request": "note.add",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "note.add Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "binary": {
+                    "description": "If `true`, the Notecard will send all the data in the binary buffer to Notehub.\n\nLearn more in this guide on [Sending and Receiving Large Binary Objects](/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects).",
+                    "type": "boolean",
+                    "x-min-api-version": "5.3.1"
+                  },
+                  "body": {
+                    "description": "A JSON object to be enqueued. A Note must have either a `body` or a `payload`, and can have both.",
+                    "type": "object"
+                  },
+                  "file": {
+                    "description": "The name of the Notefile.\n\nOn Notecard LoRa this argument is required. On all other Notecards this field is optional and defaults to `data.qo` if not provided.\n\nWhen using this request on the Notecard the Notefile name must end in one of:\n\n`.qo` for a queue outgoing (Notecard to Notehub) with plaintext transport\n\n`.qos` for a queue outgoing with encrypted transport\n\n`.db` for a bidirectionally synchronized database with plaintext transport\n\n`.dbs` for a bidirectionally synchronized database with encrypted transport\n\n`.dbx` for a local-only database",
+                    "type": "string",
+                    "default": "data.qo",
+                    "pattern": "\\.(qo|qos|db|dbs|dbx)$",
+                    "x-sub-descriptions": [
+                      {
+                        "pattern": "\\.qo$",
+                        "description": "queue outgoing (Notecard to Notehub) with plaintext transport"
+                      },
+                      {
+                        "pattern": "\\.qos$",
+                        "description": "queue outgoing with encrypted transport"
+                      },
+                      {
+                        "pattern": "\\.db$",
+                        "description": "bidirectionally synchronized database with plaintext transport"
+                      },
+                      {
+                        "pattern": "\\.dbs$",
+                        "description": "bidirectionally synchronized database with encrypted transport"
+                      },
+                      {
+                        "pattern": "\\.dbx$",
+                        "description": "local-only database"
+                      }
+                    ]
+                  },
+                  "full": {
+                    "description": "If set to `true`, and the Note is using a [Notefile Template](/notecard/notecard-walkthrough/low-bandwidth-design/#working-with-note-templates), the Note will bypass usage of [omitempty](/notecard/notecard-walkthrough/low-bandwidth-design/#use-of-in-templates) and retain `null`, `0`, `false`, and empty string `\"\"` values.",
+                    "type": "boolean",
+                    "x-min-api-version": "5.1.1"
+                  },
+                  "key": {
+                    "description": "The name of an environment variable in your Notehub.io project that contains the contents of a public key. Used when [encrypting the Note body for transport](/guides-and-tutorials/notecard-guides/encrypting-and-decrypting-data-with-the-notecard).",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "If set to `true`, the Note will not be created if Notecard is in a [penalty box](/support/understanding-notecard-penalty-boxes/).",
+                    "type": "boolean",
+                    "x-min-api-version": "9.1.1"
+                  },
+                  "live": {
+                    "description": "If `true`, bypasses saving the Note to flash on the Notecard. Required to be set to `true` if also using `\"binary\":true`.",
+                    "type": "boolean",
+                    "x-min-api-version": "5.3.1"
+                  },
+                  "max": {
+                    "description": "Defines the maximum number of queued Notes permitted in the specified Notefile (`\"file\"`). Any Notes added after this value will be rejected. When used with `\"sync\":true`, a sync will be triggered when the number of pending Notes matches the `max` value.",
+                    "type": "integer",
+                    "minimum": -1,
+                    "x-min-api-version": "8.2.1"
+                  },
+                  "note": {
+                    "description": "If the Notefile has a `.db/.dbs/.dbx` extension, specifies a unique Note ID.\n\nIf `note` string is `\"?\"`, then a random unique Note ID is generated and returned as `{\"note\":\"xxx\"}`.\n\n_If this argument is provided for a `.qo` Notefile, an error is returned._",
+                    "type": "string"
+                  },
+                  "payload": {
+                    "description": "A base64-encoded binary payload. A Note must have either a `body` or a `payload`, and can have both. Payloads are limited to 256 bytes.",
+                    "type": "string"
+                  },
+                  "sync": {
+                    "description": "Set to `true` to sync immediately. Only applies to **outgoing** Notecard requests, and only guarantees syncing the specified Notefile. Auto-syncing **incoming** Notes from Notehub is set on the Notecard with `{\"req\": \"hub.set\", \"mode\":\"continuous\", \"sync\": true}`.",
+                    "type": "boolean"
+                  },
+                  "verify": {
+                    "description": "If set to `true` and using a templated Notefile, the Notefile will be written to flash immediately, rather than being cached in RAM and written to flash later.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Basic Note Add",
+            "description": "Add a Note with JSON body data and trigger immediate sync.",
+            "json": "{\"req\": \"note.add\", \"file\": \"sensors.qo\", \"body\": {\"temp\": 72.22}, \"sync\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing information about the added Note.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "note": {
+                      "description": "The generated unique Note ID when `note` parameter was set to \"?\".",
+                      "type": "string"
+                    },
+                    "template": {
+                      "description": "`true` when a template is active on the Notefile.",
+                      "type": "boolean"
+                    },
+                    "total": {
+                      "description": "The total number of Notes in the Notefile.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "note.add Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Basic Add Response",
+                "description": "Response showing total notes after adding to a Notefile.",
+                "json": "{\"total\": 12}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/note/changes": {
+      "get": {
+        "operationId": "note_changes_query",
+        "summary": "Used to incrementally retrieve changes within a specific Notefile.",
+        "x-safety": "readonly",
+        "x-notecard-request": "note.changes",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "excludes": [
+            "delete"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "note.changes Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "delete",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "`true` to delete the Notes returned by the request."
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "`true` to return deleted Notes with this request. Deleted Notes are only persisted in a database notefile (`.db/.dbs`) between the time of Note deletion on the Notecard and the time that a sync with Notehub takes place. As such, this boolean will have no effect after a sync or on queue notefiles (`.q*`)."
+          },
+          {
+            "name": "file",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The Notefile ID."
+          },
+          {
+            "name": "max",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "anyOf": [
+                {
+                  "const": -1
+                },
+                {
+                  "minimum": 1
+                }
+              ]
+            },
+            "description": "The maximum number of Notes to return in the request."
+          },
+          {
+            "name": "reset",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "`true` to reset a change tracker."
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "`true` to reset the tracker to the beginning."
+          },
+          {
+            "name": "stop",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "`true` to delete the tracker."
+          },
+          {
+            "name": "tracker",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The change tracker ID. This value is developer-defined and can be used across both the `note.changes` and `file.changes` requests."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Peek at Changes",
+            "description": "Check changes in a Notefile with a tracker starting from the beginning.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"my-settings.db\", \"tracker\": \"inbound-tracker\", \"start\": true}"
+          },
+          {
+            "title": "Pop Changes with Limit",
+            "description": "Retrieve and delete up to 2 changes from a Notefile.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"my-settings.db\", \"tracker\": \"inbound-tracker\", \"start\": true, \"delete\": true, \"max\": 2}"
+          },
+          {
+            "title": "Basic File Changes",
+            "description": "Get changes from a Notefile without a tracker.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"data.db\"}"
+          },
+          {
+            "title": "Reset Tracker",
+            "description": "Reset a change tracker to start from the beginning.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"events.db\", \"tracker\": \"event-tracker\", \"reset\": true}"
+          },
+          {
+            "title": "Include Deleted Notes",
+            "description": "Retrieve changes including deleted notes from database.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"config.db\", \"tracker\": \"config-tracker\", \"deleted\": true}"
+          },
+          {
+            "title": "Stop Tracker",
+            "description": "Delete a change tracker when finished.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"logs.db\", \"tracker\": \"log-tracker\", \"stop\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing incremental changes from a specific Notefile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "changes": {
+                      "description": "The number of pending changes in the Notefile.",
+                      "type": "integer"
+                    },
+                    "notes": {
+                      "description": "An object with a key for each Note (the Note ID in a DB Notefile or an internally-generated ID for `.qo` and `.qi` Notes) and value object with the `body` of each Note and the `time` the Note was added.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "body": {
+                            "description": "The body content of the Note.",
+                            "type": "object"
+                          },
+                          "time": {
+                            "description": "The time the Note was added (Unix timestamp).",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "body",
+                          "time"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "description": "The total number of Notes in the Notefile.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "note.changes Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Changes Response with Notes",
+                "description": "Response showing changes with Note details and timestamps.",
+                "json": "{\"changes\": 4, \"total\": 4, \"notes\": {\"setting-one\": {\"body\": {\"foo\": \"bar\"}, \"time\": 1598918235}, \"setting-two\": {\"body\": {\"foo\": \"bat\"}, \"time\": 1598918245}, \"setting-three\": {\"body\": {\"foo\": \"baz\"}, \"time\": 1598918225}, \"setting-four\": {\"body\": {\"foo\": \"foo\"}, \"time\": 1598910532}}}"
+              },
+              {
+                "title": "No Changes Response",
+                "description": "Response when no changes are available.",
+                "json": "{\"changes\": 0, \"total\": 10, \"notes\": {}}"
+              },
+              {
+                "title": "Single Change Response",
+                "description": "Response with a single Note change.",
+                "json": "{\"changes\": 1, \"total\": 5, \"notes\": {\"config-update\": {\"body\": {\"brightness\": 75, \"volume\": 50}, \"time\": 1609459200}}}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "note_changes_delete",
+        "summary": "Used to incrementally retrieve changes within a specific Notefile.",
+        "x-safety": "destructive",
+        "x-notecard-request": "note.changes",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "delete"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "note.changes Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "delete": {
+                    "description": "`true` to delete the Notes returned by the request.",
+                    "type": "boolean"
+                  },
+                  "deleted": {
+                    "description": "`true` to return deleted Notes with this request. Deleted Notes are only persisted in a database notefile (`.db/.dbs`) between the time of Note deletion on the Notecard and the time that a sync with Notehub takes place. As such, this boolean will have no effect after a sync or on queue notefiles (`.q*`).",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "The Notefile ID.",
+                    "type": "string"
+                  },
+                  "max": {
+                    "description": "The maximum number of Notes to return in the request.",
+                    "type": "integer",
+                    "anyOf": [
+                      {
+                        "const": -1
+                      },
+                      {
+                        "minimum": 1
+                      }
+                    ]
+                  },
+                  "reset": {
+                    "description": "`true` to reset a change tracker.",
+                    "type": "boolean"
+                  },
+                  "start": {
+                    "description": "`true` to reset the tracker to the beginning.",
+                    "type": "boolean"
+                  },
+                  "stop": {
+                    "description": "`true` to delete the tracker.",
+                    "type": "boolean"
+                  },
+                  "tracker": {
+                    "description": "The change tracker ID. This value is developer-defined and can be used across both the `note.changes` and `file.changes` requests.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Peek at Changes",
+            "description": "Check changes in a Notefile with a tracker starting from the beginning.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"my-settings.db\", \"tracker\": \"inbound-tracker\", \"start\": true}"
+          },
+          {
+            "title": "Pop Changes with Limit",
+            "description": "Retrieve and delete up to 2 changes from a Notefile.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"my-settings.db\", \"tracker\": \"inbound-tracker\", \"start\": true, \"delete\": true, \"max\": 2}"
+          },
+          {
+            "title": "Basic File Changes",
+            "description": "Get changes from a Notefile without a tracker.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"data.db\"}"
+          },
+          {
+            "title": "Reset Tracker",
+            "description": "Reset a change tracker to start from the beginning.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"events.db\", \"tracker\": \"event-tracker\", \"reset\": true}"
+          },
+          {
+            "title": "Include Deleted Notes",
+            "description": "Retrieve changes including deleted notes from database.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"config.db\", \"tracker\": \"config-tracker\", \"deleted\": true}"
+          },
+          {
+            "title": "Stop Tracker",
+            "description": "Delete a change tracker when finished.",
+            "json": "{\"req\": \"note.changes\", \"file\": \"logs.db\", \"tracker\": \"log-tracker\", \"stop\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing incremental changes from a specific Notefile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "changes": {
+                      "description": "The number of pending changes in the Notefile.",
+                      "type": "integer"
+                    },
+                    "notes": {
+                      "description": "An object with a key for each Note (the Note ID in a DB Notefile or an internally-generated ID for `.qo` and `.qi` Notes) and value object with the `body` of each Note and the `time` the Note was added.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "body": {
+                            "description": "The body content of the Note.",
+                            "type": "object"
+                          },
+                          "time": {
+                            "description": "The time the Note was added (Unix timestamp).",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "body",
+                          "time"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "description": "The total number of Notes in the Notefile.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "note.changes Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Changes Response with Notes",
+                "description": "Response showing changes with Note details and timestamps.",
+                "json": "{\"changes\": 4, \"total\": 4, \"notes\": {\"setting-one\": {\"body\": {\"foo\": \"bar\"}, \"time\": 1598918235}, \"setting-two\": {\"body\": {\"foo\": \"bat\"}, \"time\": 1598918245}, \"setting-three\": {\"body\": {\"foo\": \"baz\"}, \"time\": 1598918225}, \"setting-four\": {\"body\": {\"foo\": \"foo\"}, \"time\": 1598910532}}}"
+              },
+              {
+                "title": "No Changes Response",
+                "description": "Response when no changes are available.",
+                "json": "{\"changes\": 0, \"total\": 10, \"notes\": {}}"
+              },
+              {
+                "title": "Single Change Response",
+                "description": "Response with a single Note change.",
+                "json": "{\"changes\": 1, \"total\": 5, \"notes\": {\"config-update\": {\"body\": {\"brightness\": 75, \"volume\": 50}, \"time\": 1609459200}}}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/note/delete": {
+      "delete": {
+        "operationId": "note_delete",
+        "summary": "Deletes a Note from a **DB Notefile** by its Note ID. To delete Notes from a `.qi` Notefile, use `note.get` or `note.changes` with `delete:true`.",
+        "x-safety": "destructive",
+        "x-notecard-request": "note.delete",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "note.delete Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "description": "The Notefile from which to delete a Note. Must be a Notefile with a `.db` or `.dbx` extension.",
+                    "type": "string"
+                  },
+                  "note": {
+                    "description": "The Note ID of the Note to delete.",
+                    "type": "string"
+                  },
+                  "verify": {
+                    "description": "If set to `true` and using a templated Notefile, the Notefile will be written to flash immediately, rather than being cached in RAM and written to flash later.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "file",
+                  "note"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Delete Note from DB Notefile",
+            "description": "Delete a specific Note by ID from a database Notefile.",
+            "json": "{\"req\": \"note.delete\", \"file\": \"my-settings.db\", \"note\": \"measurements\"}"
+          },
+          {
+            "title": "Delete Note with Verification",
+            "description": "Delete a Note and write to flash immediately for a templated Notefile.",
+            "json": "{\"req\": \"note.delete\", \"file\": \"config.db\", \"note\": \"display-settings\", \"verify\": true}"
+          },
+          {
+            "title": "Delete Note with Command",
+            "description": "Delete a Note using command syntax (no response expected).",
+            "json": "{\"cmd\": \"note.delete\", \"file\": \"temp-data.db\", \"note\": \"sensor-reading\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response confirming Note deletion from a DB Notefile.",
+            "x-title": "note.delete Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/note/get": {
+      "get": {
+        "operationId": "note_get_query",
+        "summary": "Retrieves a Note from a Notefile. The file must either be a DB Notefile or inbound queue file (see `file` argument below).\n\n`.qo`/`.qos` Notes must be read from the Notehub event table using the [Notehub Event API](/api-reference/notehub-api/event-api/).",
+        "x-safety": "readonly",
+        "x-notecard-request": "note.get",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "excludes": [
+            "delete"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "note.get Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "decrypt",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "`true` to decrypt [encrypted inbound Notefiles](/guides-and-tutorials/notecard-guides/encrypting-and-decrypting-data-with-the-notecard)."
+          },
+          {
+            "name": "delete",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "`true` to delete the Note after retrieving it."
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "`true` to allow retrieval of a deleted Note."
+          },
+          {
+            "name": "file",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "data.qi"
+            },
+            "description": "The Notefile name must end in `.qi` (for plaintext transport), `.qis` (for encrypted transport), `.db` or `.dbx` (for local-only DB Notefiles)."
+          },
+          {
+            "name": "note",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "If the Notefile has a `.db` or `.dbx` extension, specifies a unique Note ID. Not applicable to `.qi` Notefiles."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Pop from `.qi` Notefile",
+            "description": "Retrieve and delete a Note from an inbound queue file.",
+            "json": "{\"req\": \"note.get\", \"file\": \"requests.qi\", \"delete\": true}"
+          },
+          {
+            "title": "Read from `.db` Notefile",
+            "description": "Read a specific Note from a database Notefile.",
+            "json": "{\"req\": \"note.get\", \"file\": \"my-settings.db\", \"note\": \"measurements\"}"
+          },
+          {
+            "title": "Get with Default File",
+            "description": "Retrieve from the default `data.qi` Notefile.",
+            "json": "{\"req\": \"note.get\"}"
+          },
+          {
+            "title": "Get Deleted Note",
+            "description": "Retrieve a deleted Note from a `.db` Notefile.",
+            "json": "{\"req\": \"note.get\", \"file\": \"config.db\", \"note\": \"old-setting\", \"deleted\": true}"
+          },
+          {
+            "title": "Decrypt Encrypted Note",
+            "description": "Retrieve and decrypt an encrypted inbound Note.",
+            "json": "{\"req\": \"note.get\", \"file\": \"secure.qis\", \"decrypt\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing a Note retrieved from a Notefile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "The JSON body, if contained in the Note.",
+                      "type": "object"
+                    },
+                    "payload": {
+                      "description": "The payload, if contained in the Note.",
+                      "type": "string"
+                    },
+                    "time": {
+                      "description": "The time the Note was added to the Notecard or Notehub.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "note.get Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Note with Body and Time",
+                "description": "Response showing note with JSON body and timestamp.",
+                "json": "{\"body\": {\"api-key1\": \"api-val1\"}, \"time\": 1598909219}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "note_get_delete",
+        "summary": "Retrieves a Note from a Notefile. The file must either be a DB Notefile or inbound queue file (see `file` argument below).\n\n`.qo`/`.qos` Notes must be read from the Notehub event table using the [Notehub Event API](/api-reference/notehub-api/event-api/).",
+        "x-safety": "destructive",
+        "x-notecard-request": "note.get",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "delete"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "note.get Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "decrypt": {
+                    "description": "`true` to decrypt [encrypted inbound Notefiles](/guides-and-tutorials/notecard-guides/encrypting-and-decrypting-data-with-the-notecard).",
+                    "type": "boolean"
+                  },
+                  "delete": {
+                    "description": "`true` to delete the Note after retrieving it.",
+                    "type": "boolean"
+                  },
+                  "deleted": {
+                    "description": "`true` to allow retrieval of a deleted Note.",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "The Notefile name must end in `.qi` (for plaintext transport), `.qis` (for encrypted transport), `.db` or `.dbx` (for local-only DB Notefiles).",
+                    "type": "string",
+                    "default": "data.qi"
+                  },
+                  "note": {
+                    "description": "If the Notefile has a `.db` or `.dbx` extension, specifies a unique Note ID. Not applicable to `.qi` Notefiles.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Pop from `.qi` Notefile",
+            "description": "Retrieve and delete a Note from an inbound queue file.",
+            "json": "{\"req\": \"note.get\", \"file\": \"requests.qi\", \"delete\": true}"
+          },
+          {
+            "title": "Read from `.db` Notefile",
+            "description": "Read a specific Note from a database Notefile.",
+            "json": "{\"req\": \"note.get\", \"file\": \"my-settings.db\", \"note\": \"measurements\"}"
+          },
+          {
+            "title": "Get with Default File",
+            "description": "Retrieve from the default `data.qi` Notefile.",
+            "json": "{\"req\": \"note.get\"}"
+          },
+          {
+            "title": "Get Deleted Note",
+            "description": "Retrieve a deleted Note from a `.db` Notefile.",
+            "json": "{\"req\": \"note.get\", \"file\": \"config.db\", \"note\": \"old-setting\", \"deleted\": true}"
+          },
+          {
+            "title": "Decrypt Encrypted Note",
+            "description": "Retrieve and decrypt an encrypted inbound Note.",
+            "json": "{\"req\": \"note.get\", \"file\": \"secure.qis\", \"decrypt\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing a Note retrieved from a Notefile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "The JSON body, if contained in the Note.",
+                      "type": "object"
+                    },
+                    "payload": {
+                      "description": "The payload, if contained in the Note.",
+                      "type": "string"
+                    },
+                    "time": {
+                      "description": "The time the Note was added to the Notecard or Notehub.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "note.get Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Note with Body and Time",
+                "description": "Response showing note with JSON body and timestamp.",
+                "json": "{\"body\": {\"api-key1\": \"api-val1\"}, \"time\": 1598909219}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/note/template": {
+      "put": {
+        "operationId": "note_template_set",
+        "summary": "By using the `note.template` request with any `.qo`/`.qos` Notefile, developers can provide the Notecard with a schema of sorts to apply to future Notes added to the Notefile. This template acts as a hint to the Notecard that allows it to internally store data as fixed-length binary records rather than as flexible JSON objects which require much more memory. Using templated Notes in place of regular Notes increases the storage and sync capability of the Notecard by an order of magnitude.\n\nRead about [Working with Note Templates](/notecard/notecard-walkthrough/low-bandwidth-design/#working-with-note-templates) for additional information.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "note.template",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "body"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "note.template Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "description": "A sample JSON body that specifies field names and values as \"hints\" for the data type. Possible data types are: boolean, integer, float, and string. See [Understanding Template Data Types](https://dev.blues.io/notecard/notecard-walkthrough/low-bandwidth-design/#understanding-template-data-types) for an explanation of type hints and explanations.",
+                    "type": "object"
+                  },
+                  "delete": {
+                    "description": "Set to `true` to delete all pending Notes using the template if one of the following scenarios is also true:\n\nConnecting via non-NTN (e.g. cellular or WiFi) communications, but attempting to sync NTN-compatible Notefiles.\n\nor\n\nConnecting via NTN (e.g. satellite) communications, but attempting to sync non-NTN-compatible Notefiles.\n\nRead more about this feature in [Starnote Best Practices](https://dev.blues.io/starnote/starnote-best-practices/#define-ntn-vs-non-ntn-templates).",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "The name of the Notefile to which the template will be applied.",
+                    "type": "string"
+                  },
+                  "format": {
+                    "description": "By default all Note templates automatically include metadata, including a timestamp for when the Note was created, various fields about a device's location, as well as a timestamp for when the device's location was determined.\n\nBy providing a `format` of `\"compact\"` you tell the Notecard to omit this additional metadata to save on storage and bandwidth. The use of `format: \"compact\"` is required for Notecard LoRa and a Notecard paired with Starnote.\n\nWhen using `\"compact\"` templates, you may include the following keywords in your template to add in fields that would otherwise be omitted: `_lat`, `_lon`, `_ltime`, `_time`. See [Creating Compact Templates](https://dev.blues.io/notecard/notecard-walkthrough/low-bandwidth-design/#creating-compact-templates) to learn more.",
+                    "type": "string",
+                    "x-min-api-version": "6.2.3"
+                  },
+                  "length": {
+                    "description": "The maximum length of a `payload` (in bytes) that can be sent in Notes for the template Notefile. As of v3.2.1 `length` is not required, and payloads can be added to any template-based Note without specifying the payload length.",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "port": {
+                    "description": "This argument is required on Notecard LoRa and a Notecard paired with Starnote, but ignored on all other Notecards.\n\nA port is a unique integer in the range 1\u2013100, where each unique number represents one Notefile. This argument allows the Notecard to send a numerical reference to the Notefile over the air, rather than the full Notefile name.\n\nThe port you provide is also used in the \"frame port\" field on LoRaWAN gateways.",
+                    "type": "integer",
+                    "anyOf": [
+                      {
+                        "const": -1
+                      },
+                      {
+                        "minimum": 1,
+                        "maximum": 100
+                      }
+                    ]
+                  },
+                  "verify": {
+                    "description": "If `true`, returns the current template set on a given Notefile.",
+                    "type": "boolean",
+                    "x-min-api-version": "3.2.1"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Provide Schema",
+            "description": "Provide a template schema for the readings.qo Notefile with sample data.",
+            "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\",\"body\":{\"new_vals\":true,\"temperature\":14.1,\"humidity\":11,\"pump_state\":\"4\"}}"
+          },
+          {
+            "title": "Compact Schema for LoRa",
+            "description": "Set up a compact template for LoRa transmission on port 50 to reduce bandwidth usage.",
+            "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\",\"body\":{\"new_vals\":true,\"temperature\":14.1,\"humidity\":11,\"pump_state\":\"4\"},\"format\":\"compact\",\"port\":50}"
+          },
+          {
+            "title": "Compact Schema with Additional Fields",
+            "description": "Set up a compact template including location and timestamp fields for comprehensive sensor data.",
+            "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\",\"body\":{\"temperature\":14.1,\"_lat\":14.1,\"_lon\":14.1,\"_ltime\":14,\"_time\":14},\"format\":\"compact\",\"port\":50}"
+          },
+          {
+            "title": "Request Current Template",
+            "description": "Retrieve the current template configuration for the readings.qo Notefile.",
+            "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\",\"verify\":true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "If the `verify` argument is provided and the Notefile has an active template, the template `body`.",
+                      "type": "object"
+                    },
+                    "bytes": {
+                      "description": "The number of bytes that will be transmitted to Notehub, per Note, before compression.",
+                      "type": "integer"
+                    },
+                    "format": {
+                      "description": "If the `format` argument is provided, this represents the format applied to the template.",
+                      "type": "string",
+                      "x-min-api-version": "6.2.3"
+                    },
+                    "length": {
+                      "description": "If the `verify` argument is provided and the Notefile has an active template with a payload, the payload length.",
+                      "type": "integer"
+                    },
+                    "template": {
+                      "description": "`true` if an active template exists on the Notefile.",
+                      "type": "boolean",
+                      "x-min-api-version": "3.2.1"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "note.template Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Template Set Response",
+                "description": "Response when template is successfully set, showing bytes per note.",
+                "json": "{\"bytes\": 40}"
+              },
+              {
+                "title": "Template Verify Response",
+                "description": "Response when verifying existing template with all fields.",
+                "json": "{\"template\": true, \"body\": {\"temperature\": 14.1, \"humidity\": 11}, \"bytes\": 40}"
+              },
+              {
+                "title": "Template with Format Response",
+                "description": "Response showing compact format template.",
+                "json": "{\"template\": true, \"format\": \"compact\", \"bytes\": 25}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "note_template_delete",
+        "summary": "By using the `note.template` request with any `.qo`/`.qos` Notefile, developers can provide the Notecard with a schema of sorts to apply to future Notes added to the Notefile. This template acts as a hint to the Notecard that allows it to internally store data as fixed-length binary records rather than as flexible JSON objects which require much more memory. Using templated Notes in place of regular Notes increases the storage and sync capability of the Notecard by an order of magnitude.\n\nRead about [Working with Note Templates](/notecard/notecard-walkthrough/low-bandwidth-design/#working-with-note-templates) for additional information.",
+        "x-safety": "destructive",
+        "x-notecard-request": "note.template",
+        "x-supports-cmd": true,
+        "x-dispatch": {
+          "requires": [
+            "delete"
+          ]
+        },
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "note.template Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "description": "A sample JSON body that specifies field names and values as \"hints\" for the data type. Possible data types are: boolean, integer, float, and string. See [Understanding Template Data Types](https://dev.blues.io/notecard/notecard-walkthrough/low-bandwidth-design/#understanding-template-data-types) for an explanation of type hints and explanations.",
+                    "type": "object"
+                  },
+                  "delete": {
+                    "description": "Set to `true` to delete all pending Notes using the template if one of the following scenarios is also true:\n\nConnecting via non-NTN (e.g. cellular or WiFi) communications, but attempting to sync NTN-compatible Notefiles.\n\nor\n\nConnecting via NTN (e.g. satellite) communications, but attempting to sync non-NTN-compatible Notefiles.\n\nRead more about this feature in [Starnote Best Practices](https://dev.blues.io/starnote/starnote-best-practices/#define-ntn-vs-non-ntn-templates).",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "The name of the Notefile to which the template will be applied.",
+                    "type": "string"
+                  },
+                  "format": {
+                    "description": "By default all Note templates automatically include metadata, including a timestamp for when the Note was created, various fields about a device's location, as well as a timestamp for when the device's location was determined.\n\nBy providing a `format` of `\"compact\"` you tell the Notecard to omit this additional metadata to save on storage and bandwidth. The use of `format: \"compact\"` is required for Notecard LoRa and a Notecard paired with Starnote.\n\nWhen using `\"compact\"` templates, you may include the following keywords in your template to add in fields that would otherwise be omitted: `_lat`, `_lon`, `_ltime`, `_time`. See [Creating Compact Templates](https://dev.blues.io/notecard/notecard-walkthrough/low-bandwidth-design/#creating-compact-templates) to learn more.",
+                    "type": "string",
+                    "x-min-api-version": "6.2.3"
+                  },
+                  "length": {
+                    "description": "The maximum length of a `payload` (in bytes) that can be sent in Notes for the template Notefile. As of v3.2.1 `length` is not required, and payloads can be added to any template-based Note without specifying the payload length.",
+                    "type": "integer",
+                    "minimum": -1
+                  },
+                  "port": {
+                    "description": "This argument is required on Notecard LoRa and a Notecard paired with Starnote, but ignored on all other Notecards.\n\nA port is a unique integer in the range 1\u2013100, where each unique number represents one Notefile. This argument allows the Notecard to send a numerical reference to the Notefile over the air, rather than the full Notefile name.\n\nThe port you provide is also used in the \"frame port\" field on LoRaWAN gateways.",
+                    "type": "integer",
+                    "anyOf": [
+                      {
+                        "const": -1
+                      },
+                      {
+                        "minimum": 1,
+                        "maximum": 100
+                      }
+                    ]
+                  },
+                  "verify": {
+                    "description": "If `true`, returns the current template set on a given Notefile.",
+                    "type": "boolean",
+                    "x-min-api-version": "3.2.1"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Provide Schema",
+            "description": "Provide a template schema for the readings.qo Notefile with sample data.",
+            "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\",\"body\":{\"new_vals\":true,\"temperature\":14.1,\"humidity\":11,\"pump_state\":\"4\"}}"
+          },
+          {
+            "title": "Compact Schema for LoRa",
+            "description": "Set up a compact template for LoRa transmission on port 50 to reduce bandwidth usage.",
+            "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\",\"body\":{\"new_vals\":true,\"temperature\":14.1,\"humidity\":11,\"pump_state\":\"4\"},\"format\":\"compact\",\"port\":50}"
+          },
+          {
+            "title": "Compact Schema with Additional Fields",
+            "description": "Set up a compact template including location and timestamp fields for comprehensive sensor data.",
+            "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\",\"body\":{\"temperature\":14.1,\"_lat\":14.1,\"_lon\":14.1,\"_ltime\":14,\"_time\":14},\"format\":\"compact\",\"port\":50}"
+          },
+          {
+            "title": "Request Current Template",
+            "description": "Retrieve the current template configuration for the readings.qo Notefile.",
+            "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\",\"verify\":true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "If the `verify` argument is provided and the Notefile has an active template, the template `body`.",
+                      "type": "object"
+                    },
+                    "bytes": {
+                      "description": "The number of bytes that will be transmitted to Notehub, per Note, before compression.",
+                      "type": "integer"
+                    },
+                    "format": {
+                      "description": "If the `format` argument is provided, this represents the format applied to the template.",
+                      "type": "string",
+                      "x-min-api-version": "6.2.3"
+                    },
+                    "length": {
+                      "description": "If the `verify` argument is provided and the Notefile has an active template with a payload, the payload length.",
+                      "type": "integer"
+                    },
+                    "template": {
+                      "description": "`true` if an active template exists on the Notefile.",
+                      "type": "boolean",
+                      "x-min-api-version": "3.2.1"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "note.template Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Template Set Response",
+                "description": "Response when template is successfully set, showing bytes per note.",
+                "json": "{\"bytes\": 40}"
+              },
+              {
+                "title": "Template Verify Response",
+                "description": "Response when verifying existing template with all fields.",
+                "json": "{\"template\": true, \"body\": {\"temperature\": 14.1, \"humidity\": 11}, \"bytes\": 40}"
+              },
+              {
+                "title": "Template with Format Response",
+                "description": "Response showing compact format template.",
+                "json": "{\"template\": true, \"format\": \"compact\", \"bytes\": 25}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/note/update": {
+      "put": {
+        "operationId": "note_update",
+        "summary": "Updates a Note in a **DB Notefile** by its ID, replacing the existing `body` and/or `payload`.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "note.update",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "note.update Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "description": "A JSON object to add to the Note. A Note must have either a `body` or `payload`, and can have both.",
+                    "type": "object"
+                  },
+                  "file": {
+                    "description": "The name of the DB Notefile that contains the Note to update.",
+                    "type": "string"
+                  },
+                  "note": {
+                    "description": "The unique Note ID.",
+                    "type": "string"
+                  },
+                  "payload": {
+                    "description": "A base64-encoded binary payload. A Note must have either a `body` or `payload`, and can have both.",
+                    "type": "string"
+                  },
+                  "verify": {
+                    "description": "If set to `true` and using a templated Notefile, the Notefile will be written to flash immediately, rather than being cached in RAM and written to flash later.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "file",
+                  "note"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Update Note Body",
+            "description": "Update a Note with new JSON body content.",
+            "json": "{\"req\": \"note.update\", \"file\": \"my-settings.db\", \"note\": \"measurements\", \"body\": {\"interval\": 60}}"
+          },
+          {
+            "title": "Update Note Payload",
+            "description": "Update a Note with new base64 payload data.",
+            "json": "{\"req\": \"note.update\", \"file\": \"data.db\", \"note\": \"sensor-1\", \"payload\": \"SGVsbG8gV29ybGQ=\"}"
+          },
+          {
+            "title": "Update with Body and Payload",
+            "description": "Update a Note with both body and payload.",
+            "json": "{\"req\": \"note.update\", \"file\": \"config.db\", \"note\": \"device-config\", \"body\": {\"enabled\": true}, \"payload\": \"YWRkaXRpb25hbERhdGE=\"}"
+          },
+          {
+            "title": "Update with Verification",
+            "description": "Update a Note in a templated Notefile with immediate flash write.",
+            "json": "{\"req\": \"note.update\", \"file\": \"template.db\", \"note\": \"user-setting\", \"body\": {\"theme\": \"dark\"}, \"verify\": true}"
+          },
+          {
+            "title": "Update with Command",
+            "description": "Update a Note using command syntax (no response expected).",
+            "json": "{\"cmd\": \"note.update\", \"file\": \"cache.db\", \"note\": \"temp-data\", \"body\": {\"status\": \"updated\"}}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response confirming Note update in a DB Notefile.",
+            "x-title": "note.update Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/ntn/gps": {
+      "put": {
+        "operationId": "ntn_gps",
+        "summary": "Determines whether a Notecard should override a paired Starnote's GPS/GNSS location with its own GPS/GNSS location. The paired Starnote uses its own GPS/GNSS location by default.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "ntn.gps",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "6.2.3",
+        "x-title": "ntn.gps Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "off": {
+                    "description": "When `true`, a paired Starnote will use its own GPS/GNSS location. This is the default configuration.",
+                    "type": "boolean"
+                  },
+                  "on": {
+                    "description": "When `true`, a Starnote will use the GPS/GNSS location from its paired Notecard, instead of its own GPS/GNSS location.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Enable Notecard GPS Override",
+            "description": "Configure Starnote to use the paired Notecard's GPS/GNSS location.",
+            "json": "{\"req\": \"ntn.gps\", \"on\": true}"
+          },
+          {
+            "title": "Use Starnote's Own GPS",
+            "description": "Configure Starnote to use its own GPS/GNSS location (default).",
+            "json": "{\"req\": \"ntn.gps\", \"off\": true}"
+          },
+          {
+            "title": "Query Current GPS Configuration",
+            "description": "Request current GPS/GNSS location configuration.",
+            "json": "{\"req\": \"ntn.gps\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response indicating current Starnote GPS/GNSS location configuration.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "off": {
+                      "description": "Returned and `true` if a paired Starnote will use its own GPS/GNSS location.",
+                      "type": "boolean"
+                    },
+                    "on": {
+                      "description": "Returned and `true` if a Starnote will use the GPS/GNSS location from its paired Notecard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "ntn.gps Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Starnote Using Own GPS",
+                "description": "Response indicating Starnote is using its own GPS/GNSS location (default).",
+                "json": "{\"off\": true}"
+              },
+              {
+                "title": "Starnote Using Notecard GPS",
+                "description": "Response indicating Starnote is using paired Notecard's GPS/GNSS location.",
+                "json": "{\"on\": true}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "6.2.3"
+          }
+        }
+      }
+    },
+    "/ntn/reset": {
+      "delete": {
+        "operationId": "ntn_reset",
+        "summary": "Once a Notecard is connected to a Starnote device, the presence of a physical Starnote is stored in a permanent configuration that is not affected by a `card.restore` request. This request clears the existing NTN configuration, allowing you to return to testing NTN mode over cellular or WiFi, and [enables the Starnote to be paired with a different Notecard device](/starnote/starnote-best-practices#pairing-starnote-with-a-different-notecard).",
+        "x-safety": "destructive",
+        "x-notecard-request": "ntn.reset",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "6.2.3",
+        "x-title": "ntn.reset Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Reset Starnote Configuration",
+            "description": "Clear Starnote configuration to return to testing NTN mode over cellular or WiFi.",
+            "json": "{\"req\": \"ntn.reset\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty response confirming Starnote configuration reset.",
+            "x-title": "ntn.reset Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "6.2.3"
+          }
+        }
+      }
+    },
+    "/ntn/status": {
+      "get": {
+        "operationId": "ntn_status",
+        "summary": "Displays the current status of a Notecard's connection to a paired Starnote.",
+        "x-safety": "readonly",
+        "x-notecard-request": "ntn.status",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "6.2.3",
+        "x-title": "ntn.status Request Application Programming Interface (API) Schema",
+        "x-samples": [
+          {
+            "title": "Get Starnote Connection Status",
+            "description": "Request current status of Notecard's connection to paired Starnote.",
+            "json": "{\"req\": \"ntn.status\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response showing current status of Notecard's connection to paired Starnote.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "err": {
+                      "description": "This member is present if any errors have occurred while connecting to a paired Starnote, for example: `{\"err\":\"no NTN module is connected {no-ntn-module}\"}`",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "Details about a Notecard's connection to a paired Starnote, for example: `{\"status\":\"{ntn-idle}{ntn-unknown-location}\"}`",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "ntn.status Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Starnote Idle Status",
+                "description": "Response showing Starnote connection in idle state.",
+                "json": "{\"status\": \"{ntn-idle}\"}"
+              },
+              {
+                "title": "Starnote Connection Error",
+                "description": "Response showing error when no NTN module is connected.",
+                "json": "{\"err\": \"no NTN module is connected {no-ntn-module}\"}"
+              },
+              {
+                "title": "Starnote Status with Location Info",
+                "description": "Response showing detailed status including location information.",
+                "json": "{\"status\": \"{ntn-idle}{ntn-unknown-location}\"}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "6.2.3"
+          }
+        }
+      }
+    },
+    "/var/delete": {
+      "delete": {
+        "operationId": "var_delete",
+        "summary": "Delete a Note from a **DB Notefile** by its `name`. Provides a simpler interface to the [note.delete](/api-reference/notecard-api/note-requests/latest/#note-delete) API.",
+        "x-safety": "destructive",
+        "x-notecard-request": "var.delete",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "7.3.1",
+        "x-title": "var.delete Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "description": "The name of the DB Notefile that contains the Note to delete. Default value is `vars.db`.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "The unique Note ID.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Delete Variable with Default File",
+            "description": "Delete a variable named `\"status\"` from the default `vars.db` DB Notefile.",
+            "json": "{\"req\": \"var.delete\", \"name\": \"status\"}"
+          },
+          {
+            "title": "Delete Variable with Specific File",
+            "description": "Delete a variable named `\"temperature\"` from the `\"sensors.db\"` DB Notefile.",
+            "json": "{\"req\": \"var.delete\", \"name\": \"temperature\", \"file\": \"sensors.db\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response confirming deletion of a variable from a DB Notefile.",
+            "x-title": "var.delete Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/var/get": {
+      "get": {
+        "operationId": "var_get",
+        "summary": "Retrieves a Note from a **DB Notefile**. Provides a simpler interface to the [note.get](/api-reference/notecard-api/note-requests/latest/#note-get) API.",
+        "x-safety": "readonly",
+        "x-notecard-request": "var.get",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-min-api-version": "7.3.1",
+        "x-title": "var.get Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the DB Notefile that contains the Note to retrieve. Default value is `vars.db`."
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The unique Note ID."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Retrieve Variable with Default File",
+            "description": "Retrieve a variable named `\"status\"` from the default `vars.db` DB Notefile.",
+            "json": "{\"req\": \"var.get\", \"name\": \"status\"}"
+          },
+          {
+            "title": "Retrieve Variable with Specific File",
+            "description": "Retrieve a variable named `\"temperature\"` from the `sensors.db` DB Notefile.",
+            "json": "{\"req\": \"var.get\", \"name\": \"temperature\", \"file\": \"sensors.db\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing a Note value from a DB Notefile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "flag": {
+                      "description": "The boolean value stored in the DB Notefile.",
+                      "type": "boolean"
+                    },
+                    "text": {
+                      "description": "The string-based value stored in the DB Notefile.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The numeric value stored in the DB Notefile.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "var.get Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "title": "Text Value Response",
+                "description": "Response containing a string value from the DB Notefile.",
+                "json": "{\"text\": \"open\"}"
+              },
+              {
+                "title": "Numeric Value Response",
+                "description": "Response containing a numeric value from the DB Notefile.",
+                "json": "{\"value\": 42}"
+              },
+              {
+                "title": "Boolean Flag Response",
+                "description": "Response containing a boolean value from the DB Notefile.",
+                "json": "{\"flag\": true}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1",
+            "x-min-api-version": "7.3.1"
+          }
+        }
+      }
+    },
+    "/var/set": {
+      "put": {
+        "operationId": "var_set",
+        "summary": "Adds or updates a Note in a **DB Notefile**, replacing the existing body with the specified key-value pair where text, value, or flag is the key. Provides a simpler interface to the [note.update](/api-reference/notecard-api/note-requests/latest/#note-update) API.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "var.set",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "LORA",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "var.set Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "description": "The name of the DB Notefile that contains the Note to add or update. Default value is `vars.db`.",
+                    "type": "string",
+                    "x-min-api-version": "7.3.1"
+                  },
+                  "flag": {
+                    "description": "The boolean value to be stored in the DB Notefile.",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "The unique Note ID.",
+                    "type": "string"
+                  },
+                  "sync": {
+                    "description": "Set to `true` to immediately sync any changes.",
+                    "type": "boolean"
+                  },
+                  "text": {
+                    "description": "The string-based value to be stored in the DB Notefile.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "The numeric value to be stored in the DB Notefile.",
+                    "type": "number"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Set Text Variable",
+            "description": "Set a text variable named `\"status\"` to `\"open\"` in the default `vars.db` DB Notefile.",
+            "json": "{\"req\": \"var.set\", \"name\": \"status\", \"text\": \"open\"}"
+          },
+          {
+            "title": "Set Numeric Variable",
+            "description": "Set a numeric variable named `\"temperature\"` to `23` in a specific DB Notefile.",
+            "json": "{\"req\": \"var.set\", \"name\": \"temperature\", \"value\": 23.5, \"file\": \"sensors.db\"}"
+          },
+          {
+            "title": "Set Boolean Variable with Sync",
+            "description": "Set a boolean variable named `\"active\"` to `true` and immediately sync changes.",
+            "json": "{\"req\": \"var.set\", \"name\": \"active\", \"flag\": true, \"sync\": true}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response confirming successful addition or update of a Note in a DB Notefile.",
+            "x-title": "var.set Response Application Programming Interface (API) Schema",
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "LORA",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/web": {
+      "post": {
+        "operationId": "web",
+        "summary": "Performs an HTTP or HTTPS request against an external endpoint, with the ability to specify any valid HTTP method.",
+        "x-safety": "non-idempotent",
+        "x-notecard-request": "web",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "web Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "description": "The MIME type of the body or payload of the response. Default is `application/json`.",
+                    "type": "string"
+                  },
+                  "method": {
+                    "description": "The HTTP method of the request. Must be one of GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS, TRACE, or CONNECT.",
+                    "type": "string",
+                    "enum": [
+                      "CONNECT",
+                      "DELETE",
+                      "GET",
+                      "HEAD",
+                      "OPTIONS",
+                      "PATCH",
+                      "POST",
+                      "PUT",
+                      "TRACE"
+                    ],
+                    "x-sub-descriptions": [
+                      {
+                        "const": "CONNECT",
+                        "description": "Establishes a tunnel to the server identified by the target resource."
+                      },
+                      {
+                        "const": "DELETE",
+                        "description": "Performs a simple HTTP or HTTPS `DELETE` request against an external endpoint, and returns the response to the Notecard."
+                      },
+                      {
+                        "const": "GET",
+                        "description": "Performs a simple HTTP or HTTPS `GET` request against an external endpoint, and returns the response to the Notecard."
+                      },
+                      {
+                        "const": "HEAD",
+                        "description": "Requests the headers that would be returned if the URL was requested with a `GET` method."
+                      },
+                      {
+                        "const": "OPTIONS",
+                        "description": "Requests the communication options available for the target resource."
+                      },
+                      {
+                        "const": "PATCH",
+                        "description": "Applies partial modifications to a resource at the target endpoint."
+                      },
+                      {
+                        "const": "POST",
+                        "description": "Performs a simple HTTP or HTTPS `POST` request against an external endpoint, and returns the response to the Notecard."
+                      },
+                      {
+                        "const": "PUT",
+                        "description": "Performs a simple HTTP or HTTPS `PUT` request against an external endpoint, and returns the response to the Notecard."
+                      },
+                      {
+                        "const": "TRACE",
+                        "description": "Performs a message loop-back test along the path to the target resource."
+                      }
+                    ]
+                  },
+                  "name": {
+                    "description": "A web URL endpoint relative to the host configured in the Proxy Route. URL parameters may be added to this argument as well (e.g. `/getLatest?id=1`).",
+                    "type": "string"
+                  },
+                  "route": {
+                    "description": "Alias for a Proxy Route in Notehub.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Web Transaction",
+            "description": "Performs a simple HTTP or HTTPS request and returns the response.",
+            "json": "{\"req\": \"web\", \"method\": \"GET\", \"route\": \"weatherInfo\", \"name\": \"/getLatest\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the result of an HTTP or HTTPS request to an external endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "The JSON response body from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "object"
+                    },
+                    "cobs": {
+                      "description": "The size of the COBS-encoded data (in bytes).",
+                      "type": "integer"
+                    },
+                    "length": {
+                      "description": "The length of the returned binary payload (in bytes).",
+                      "type": "integer"
+                    },
+                    "payload": {
+                      "description": "A base64-encoded binary payload from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "string",
+                      "contentEncoding": "base64"
+                    },
+                    "result": {
+                      "description": "The HTTP Status Code",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "web Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "description": "Response from a web request",
+                "json": "{\"result\": 200, \"body\": { \"temp\": 75, \"humidity\": 49 } }"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/web/delete": {
+      "delete": {
+        "operationId": "web_delete",
+        "summary": "Performs a simple HTTP or HTTPS `DELETE` request against an external endpoint, and returns the response to the Notecard.",
+        "x-safety": "destructive",
+        "x-notecard-request": "web.delete",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "web.delete Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "async": {
+                    "description": "If `true`, the Notecard performs the web request asynchronously, and returns control to the host without waiting for a response from Notehub.",
+                    "type": "boolean",
+                    "x-min-api-version": "5.1.1"
+                  },
+                  "content": {
+                    "description": "The MIME type of the body or payload of the response. Default is `application/json`.",
+                    "default": "application/json",
+                    "type": "string"
+                  },
+                  "file": {
+                    "description": "The name of the [local-only Database Notefile](https://dev.blues.io/notecard/notecard-walkthrough/inbound-requests-and-shared-data/#using-database-notefiles-for-local-only-state) (`.dbx`) to be used if the web request is issued [asynchronously](https://dev.blues.io/notecard/notecard-walkthrough/web-transactions/#using-web-transactions-asynchronously) and you wish to store the response.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "A web URL endpoint relative to the host configured in the Proxy Route. URL parameters may be added to this argument as well (e.g. `/deleteReading?id=1`).",
+                    "type": "string"
+                  },
+                  "note": {
+                    "description": "The unique Note ID for the local-only Database Notefile (`.dbx`). Only used with asynchronous web requests (see `file` argument above).",
+                    "type": "string"
+                  },
+                  "route": {
+                    "description": "Alias for a Proxy Route in Notehub.",
+                    "type": "string"
+                  },
+                  "seconds": {
+                    "description": "If specified, overrides the default 90 second timeout.",
+                    "default": 90,
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Web DELETE Transaction",
+            "description": "Performs a simple HTTP or HTTPS DELETE request and returns the response.",
+            "json": "{\"req\": \"web.delete\", \"route\": \"SensorService\", \"name\": \"/deleteReading?id=1\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the result of an HTTP or HTTPS DELETE request to an external endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "The JSON response body from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "object"
+                    },
+                    "payload": {
+                      "description": "A base64-encoded binary payload from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "string",
+                      "contentEncoding": "base64"
+                    },
+                    "result": {
+                      "description": "The HTTP Status Code",
+                      "type": "integer"
+                    },
+                    "status": {
+                      "description": "If a `payload` is returned in the response, this is a 32-character hex-encoded MD5 sum of the payload or payload fragment. Useful for the host to check for any I2C/UART corruption.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "web.delete Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "description": "Example Response",
+                "json": "{\"result\": 204}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/web/get": {
+      "get": {
+        "operationId": "web_get",
+        "summary": "Performs a simple HTTP or HTTPS `GET` request against an external endpoint, and returns the response to the Notecard.",
+        "x-safety": "readonly",
+        "x-notecard-request": "web.get",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "web.get Request Application Programming Interface (API) Schema",
+        "parameters": [
+          {
+            "name": "async",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "x-min-api-version": "5.1.1"
+            },
+            "description": "If `true`, the Notecard performs the web request asynchronously, and returns control to the host without waiting for a response from Notehub."
+          },
+          {
+            "name": "binary",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "x-min-api-version": "5.3.1"
+            },
+            "description": "If `true`, the Notecard will return the response stored in its binary buffer.\n\nLearn more in this guide on [Sending and Receiving Large Binary Objects](/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects)."
+          },
+          {
+            "name": "body",
+            "in": "query",
+            "schema": {
+              "type": "object"
+            },
+            "description": "The JSON body to send with the request."
+          },
+          {
+            "name": "content",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The MIME type of the body or payload of the response. Default is `application/json`."
+          },
+          {
+            "name": "file",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the local-only Database Notefile (`.dbx`) to be used if the web request is issued asynchronously and you wish to store the response."
+          },
+          {
+            "name": "max",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Used along with `binary:true` and `offset`, sent as a URL parameter to the remote endpoint. Represents the number of bytes to retrieve from the binary payload segment."
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "A web URL endpoint relative to the host configured in the Proxy Route. URL parameters may be added to this argument as well (e.g. `/getLatest?id=1`)."
+          },
+          {
+            "name": "note",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The unique Note ID for the local-only Database Notefile (`.dbx`). Only used with asynchronous web requests (see `file` argument above)."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Used along with `binary:true` and `max`, sent as a URL parameter to the remote endpoint. Represents the number of bytes to offset the binary payload from 0 when retrieving binary data from the remote endpoint."
+          },
+          {
+            "name": "route",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Alias for a Proxy Route in Notehub."
+          },
+          {
+            "name": "seconds",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "If specified, overrides the default 90 second timeout."
+          }
+        ],
+        "x-samples": [
+          {
+            "title": "Web GET Transaction",
+            "description": "Performs a simple HTTP or HTTPS GET request and returns the response.",
+            "json": "{\"req\": \"web.get\", \"route\": \"weatherInfo\", \"name\": \"/getLatest\"}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the result of an HTTP or HTTPS GET request to an external endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "The JSON response body from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "object"
+                    },
+                    "cobs": {
+                      "description": "The size of the COBS-encoded data (in bytes).",
+                      "type": "integer"
+                    },
+                    "length": {
+                      "description": "The length of the returned binary payload (in bytes).",
+                      "type": "integer"
+                    },
+                    "payload": {
+                      "description": "A base64-encoded binary payload from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "string"
+                    },
+                    "result": {
+                      "description": "The HTTP Status Code.",
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "web.get Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "description": "Response body from HTTP GET request to the external service.",
+                "json": "{\"result\": 200, \"body\": { \"temp\": 75, \"humidity\": 49 } }"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/web/post": {
+      "post": {
+        "operationId": "web_post",
+        "summary": "Performs a simple HTTP or HTTPS `POST` request against an external endpoint, and returns the response to the Notecard.",
+        "x-safety": "non-idempotent",
+        "x-notecard-request": "web.post",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "web.post Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "async": {
+                    "description": "If `true`, the Notecard performs the web request asynchronously, and returns control to the host without waiting for a response from Notehub.",
+                    "type": "boolean",
+                    "x-min-api-version": "5.1.1"
+                  },
+                  "binary": {
+                    "description": "If `true`, the Notecard will send all the data in the binary buffer to the specified proxy route in Notehub.\n\nLearn more in this guide on [Sending and Receiving Large Binary Objects](https://dev.blues.io/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects/).",
+                    "type": "boolean",
+                    "x-min-api-version": "5.3.1"
+                  },
+                  "body": {
+                    "description": "The JSON body to send with the request.",
+                    "type": "object"
+                  },
+                  "content": {
+                    "description": "The MIME type of the body or payload of the response. Default is `application/json`.",
+                    "default": "application/json",
+                    "type": "string"
+                  },
+                  "file": {
+                    "description": "The name of the [local-only Database Notefile](https://dev.blues.io/notecard/notecard-walkthrough/inbound-requests-and-shared-data/#using-database-notefiles-for-local-only-state) (`.dbx`) to be used if the web request is issued [asynchronously](https://dev.blues.io/notecard/notecard-walkthrough/web-transactions/#using-web-transactions-asynchronously) and you wish to store the response.",
+                    "type": "string"
+                  },
+                  "max": {
+                    "description": "The maximum size of the response from the remote server, in bytes. Useful if a memory-constrained host wants to limit the response size.",
+                    "type": "integer"
+                  },
+                  "name": {
+                    "description": "A web URL endpoint relative to the host configured in the Proxy Route. URL parameters may be added to this argument as well (e.g. `/addReading?id=1`).",
+                    "type": "string"
+                  },
+                  "note": {
+                    "description": "The unique Note ID for the local-only Database Notefile (`.dbx`). Only used with asynchronous web requests (see `file` argument above).",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "description": "When sending payload fragments, the number of bytes of the binary payload to offset from 0 when reassembling on the Notehub once all fragments have been received.",
+                    "type": "integer"
+                  },
+                  "payload": {
+                    "description": "A base64-encoded binary payload. A `web.post` may have either a `body` or a `payload`, but may NOT have both. Be aware that Notehub will decode the payload as it is delivered to the endpoint.\n\nLearn more about [sending large binary objects](https://dev.blues.io/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects/#binary-uploads-with-web-apis) with the Notecard.",
+                    "type": "string",
+                    "contentEncoding": "base64"
+                  },
+                  "route": {
+                    "description": "Alias for a Proxy Route in Notehub.",
+                    "type": "string"
+                  },
+                  "seconds": {
+                    "description": "If specified, overrides the default 90 second timeout.",
+                    "default": 90,
+                    "type": "integer"
+                  },
+                  "status": {
+                    "description": "A 32-character hex-encoded MD5 sum of the payload or payload fragment. Used by Notehub to perform verification upon receipt.",
+                    "type": "string"
+                  },
+                  "total": {
+                    "description": "When using the `application/octet-stream` content type, you may send large payloads to Notehub in fragments spanning several `web.post` requests by using `offset` (see above) and `total`. The `total` field indicates the total size, in bytes (10MB max), of the payload across all fragments.",
+                    "type": "integer",
+                    "x-min-api-version": "3.2.1"
+                  },
+                  "verify": {
+                    "description": "`true` to request verification from Notehub once the payload or payload fragment is received. Automatically set to `true` when `status` is supplied.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "description": "Performs a simple HTTP or HTTPS POST request and returns the response.",
+            "json": "{\"req\": \"web.post\", \"route\": \"SensorService\", \"name\": \"/addReading\", \"body\": {\"temp\": 72.32, \"humidity\": 32.2 }}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the result of an HTTP or HTTPS POST request to an external endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "The JSON response body from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "object"
+                    },
+                    "cobs": {
+                      "description": "If the web transaction returns a binary payload, `cobs` is the size of the COBS-encoded payload (in bytes).",
+                      "type": "integer",
+                      "x-min-api-version": "5.3.1"
+                    },
+                    "length": {
+                      "description": "If the web transaction returns a binary payload, `length` is the size of the unencoded payload (in bytes).",
+                      "type": "integer"
+                    },
+                    "payload": {
+                      "description": "A base64-encoded binary payload from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "string",
+                      "contentEncoding": "base64"
+                    },
+                    "result": {
+                      "description": "The HTTP Status Code.",
+                      "type": "integer"
+                    },
+                    "status": {
+                      "description": "If a `payload` is returned in the response, this is a 32-character hex-encoded MD5 sum of the payload or payload fragment. Useful for the host to check for any I2C/UART corruption.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "web.post Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "description": "Example Response",
+                "json": "{\"result\": 201}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    },
+    "/web/put": {
+      "put": {
+        "operationId": "web_put",
+        "summary": "Performs a simple HTTP or HTTPS `PUT` request against an external endpoint, and returns the response to the Notecard.",
+        "x-safety": "idempotent",
+        "x-notecard-request": "web.put",
+        "x-supports-cmd": true,
+        "x-skus": [
+          "CELL",
+          "CELL+WIFI",
+          "WIFI"
+        ],
+        "x-api-version": "9.1.1",
+        "x-schema-version": "1.1.2",
+        "x-title": "web.put Request Application Programming Interface (API) Schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "async": {
+                    "description": "If `true`, the Notecard performs the web request asynchronously, and returns control to the host without waiting for a response from Notehub.",
+                    "type": "boolean",
+                    "x-min-api-version": "5.1.1"
+                  },
+                  "binary": {
+                    "description": "If `true`, the Notecard will send all the data in the binary buffer to the specified proxy route in Notehub.\n\nLearn more in this guide on [Sending and Receiving Large Binary Objects](https://dev.blues.io/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects/).",
+                    "type": "boolean",
+                    "x-min-api-version": "5.3.1"
+                  },
+                  "body": {
+                    "description": "The JSON body to send with the request.",
+                    "type": "object"
+                  },
+                  "content": {
+                    "description": "The MIME type of the body or payload of the response. Default is `application/json`.",
+                    "default": "application/json",
+                    "type": "string"
+                  },
+                  "file": {
+                    "description": "The name of the [local-only Database Notefile](https://dev.blues.io/notecard/notecard-walkthrough/inbound-requests-and-shared-data/#using-database-notefiles-for-local-only-state) (`.dbx`) to be used if the web request is issued [asynchronously](https://dev.blues.io/notecard/notecard-walkthrough/web-transactions/#using-web-transactions-asynchronously) and you wish to store the response.",
+                    "type": "string"
+                  },
+                  "max": {
+                    "description": "The maximum size of the response from the remote server, in bytes. Useful if a memory-constrained host wants to limit the response size. Default (and maximum value) is 8192.",
+                    "default": 8192,
+                    "type": "integer"
+                  },
+                  "name": {
+                    "description": "A web URL endpoint relative to the host configured in the Proxy Route. URL parameters may be added to this argument as well (e.g. `/updateReading?id=1`).",
+                    "type": "string"
+                  },
+                  "note": {
+                    "description": "The unique Note ID for the local-only Database Notefile (`.dbx`). Only used with asynchronous web requests (see `file` argument above).",
+                    "type": "string"
+                  },
+                  "offset": {
+                    "description": "When sending payload fragments, the number of bytes of the binary payload to offset from 0 when reassembling on the Notehub once all fragments have been received.",
+                    "type": "integer"
+                  },
+                  "payload": {
+                    "description": "A base64-encoded binary payload. A `web.put` may have either a `body` or a `payload`, but may NOT have both. Be aware that Notehub will decode the payload as it is delivered to the endpoint.\n\nLearn more about [sending large binary objects](https://dev.blues.io/guides-and-tutorials/notecard-guides/sending-and-receiving-large-binary-objects/#binary-uploads-with-web-apis) with the Notecard.",
+                    "type": "string",
+                    "contentEncoding": "base64"
+                  },
+                  "route": {
+                    "description": "Alias for a Proxy Route in Notehub.",
+                    "type": "string"
+                  },
+                  "seconds": {
+                    "description": "If specified, overrides the default 90 second timeout.",
+                    "default": 90,
+                    "type": "integer"
+                  },
+                  "status": {
+                    "description": "A 32-character hex-encoded MD5 sum of the payload or payload fragment. Used by Notehub to perform verification upon receipt.",
+                    "type": "string"
+                  },
+                  "total": {
+                    "description": "When using the `application/octet-stream` content type, you may send large payloads to Notehub in fragments spanning several `web.put` requests by using `offset` (see above) and `total`. The `total` field indicates the total size, in bytes (10MB max), of the payload across all fragments.",
+                    "type": "integer",
+                    "x-min-api-version": "3.2.1"
+                  },
+                  "verify": {
+                    "description": "`true` to request verification from Notehub once the payload or payload fragment is received. Automatically set to `true` when `status` is supplied.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-samples": [
+          {
+            "title": "Web PUT Transaction",
+            "description": "Performs a simple HTTP or HTTPS PUT request and returns the response.",
+            "json": "{\"req\": \"web.put\", \"route\": \"SensorService\", \"name\": \"/updateReading\", \"body\": {\"id\": 1234, \"temp\": 72.32, \"humidity\": 32.2 }}"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the result of an HTTP or HTTPS PUT request to an external endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "The JSON response body from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "object"
+                    },
+                    "payload": {
+                      "description": "A base64-encoded binary payload from the external service, if any. The maximum response size from the service is 8192 bytes.",
+                      "type": "string",
+                      "contentEncoding": "base64"
+                    },
+                    "result": {
+                      "description": "The HTTP Status Code.",
+                      "type": "integer"
+                    },
+                    "status": {
+                      "description": "If a `payload` is returned in the response, this is a 32-character hex-encoded MD5 sum of the payload or payload fragment. Useful for the host to check for any I2C/UART corruption.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "x-title": "web.put Response Application Programming Interface (API) Schema",
+            "x-samples": [
+              {
+                "description": "Example Response",
+                "json": "{\"result\": 204}"
+              }
+            ],
+            "x-skus": [
+              "CELL",
+              "CELL+WIFI",
+              "WIFI"
+            ],
+            "x-schema-version": "1.1.2",
+            "x-api-version": "9.1.1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/notecard-api.openapi.json
+++ b/notecard-api.openapi.json
@@ -1595,6 +1595,11 @@
             "x-api-version": "9.1.1",
             "x-min-api-version": "5.3.1"
           }
+        },
+        "x-binary-transfer": {
+          "direction": "receive",
+          "encoding": "cobs",
+          "follows": "response"
         }
       }
     },
@@ -1673,6 +1678,11 @@
             "x-api-version": "9.1.1",
             "x-min-api-version": "5.3.1"
           }
+        },
+        "x-binary-transfer": {
+          "direction": "send",
+          "encoding": "cobs",
+          "follows": "response"
         }
       }
     },
@@ -7500,6 +7510,14 @@
             ],
             "x-schema-version": "1.1.2",
             "x-api-version": "9.1.1"
+          }
+        },
+        "x-binary-transfer": {
+          "direction": "receive",
+          "encoding": "cobs",
+          "follows": "response",
+          "when": {
+            "binary": true
           }
         }
       }

--- a/tools/binary_transfer.json
+++ b/tools/binary_transfer.json
@@ -1,0 +1,20 @@
+{
+  "$comment": "Endpoints that transfer binary data over the serial link using COBS encoding, separate from the JSON request/response. 'direction' is relative to the host: 'send' = host->notecard, 'receive' = notecard->host. 'when' specifies the condition under which the transfer occurs (omit for unconditional).",
+
+  "card.binary.put": {
+    "direction": "send",
+    "encoding": "cobs",
+    "follows": "response"
+  },
+  "card.binary.get": {
+    "direction": "receive",
+    "encoding": "cobs",
+    "follows": "response"
+  },
+  "dfu.get": {
+    "direction": "receive",
+    "encoding": "cobs",
+    "follows": "response",
+    "when": { "binary": true }
+  }
+}

--- a/tools/openapi_to_schema.py
+++ b/tools/openapi_to_schema.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Convert an OpenAPI 3.1 Notecard spec back to individual JSON Schema files.
+
+This is the reverse of schema_to_openapi.py, used to verify round-trip fidelity.
+
+Usage:
+    python3 openapi_to_schema.py notecard-api.openapi.json -o output_dir/
+"""
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+# Same mapping as the forward transform
+CUSTOM_KEYS = {
+    "sub-descriptions": "x-sub-descriptions",
+    "skus": "x-skus",
+    "samples": "x-samples",
+    "minApiVersion": "x-min-api-version",
+    "annotations": "x-annotations",
+    "version": "x-schema-version",
+    "apiVersion": "x-api-version",
+}
+
+REVERSE_CUSTOM_KEYS = {v: k for k, v in CUSTOM_KEYS.items()}
+
+SCHEMA_BASE_URL = "https://raw.githubusercontent.com/blues/notecard-schema/master"
+
+
+def unprefix_custom_keys(schema):
+    """Recursively reverse x- prefix on custom keys."""
+    if isinstance(schema, list):
+        return [unprefix_custom_keys(item) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    result = {}
+    for key, value in schema.items():
+        new_key = REVERSE_CUSTOM_KEYS.get(key, key)
+        result[new_key] = unprefix_custom_keys(value)
+    return result
+
+
+def path_to_endpoint(path: str) -> str:
+    """Convert '/hub/set' to 'hub.set'."""
+    return path.lstrip("/").replace("/", ".")
+
+
+def extract_properties_from_operation(operation: dict, method: str) -> dict:
+    """Extract the request properties from an OpenAPI operation."""
+    method_upper = method.upper()
+
+    if method_upper == "GET":
+        # Properties stored as query parameters
+        props = {}
+        for param in operation.get("parameters", []):
+            if param.get("in") == "query":
+                schema = copy.deepcopy(param["schema"])
+                if "description" in param:
+                    schema["description"] = param["description"]
+                props[param["name"]] = schema
+        return props
+    else:
+        # Properties in requestBody
+        rb = operation.get("requestBody", {})
+        content = rb.get("content", {})
+        json_content = content.get("application/json", {})
+        body_schema = json_content.get("schema", {})
+        return copy.deepcopy(body_schema.get("properties", {}))
+
+
+def extract_allof_from_operation(operation: dict, method: str) -> list | None:
+    """Extract allOf (conditional schemas) from the request body."""
+    if method.upper() == "GET":
+        return None
+    rb = operation.get("requestBody", {})
+    content = rb.get("content", {})
+    json_content = content.get("application/json", {})
+    body_schema = json_content.get("schema", {})
+    allof = body_schema.get("allOf")
+    return copy.deepcopy(allof) if allof else None
+
+
+def extract_response_schema(operation: dict) -> dict | None:
+    """Extract response properties from an operation's 200 response."""
+    resp = operation.get("responses", {}).get("200", {})
+    content = resp.get("content", {})
+    json_content = content.get("application/json", {})
+    schema = json_content.get("schema")
+    return copy.deepcopy(schema) if schema else None
+
+
+def rebuild_request_schema(endpoint: str, operations: dict) -> dict:
+    """Rebuild the original request JSON Schema from OpenAPI operation(s).
+
+    For polymorphic endpoints, merges properties from all method variants.
+    """
+    # Pick any operation for shared metadata (they all came from the same schema)
+    first_op = next(iter(operations.values()))
+
+    # Start with envelope
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": f"{SCHEMA_BASE_URL}/{endpoint}.req.notecard.api.json",
+    }
+
+    # Restore top-level metadata
+    if "x-title" in first_op:
+        schema["title"] = first_op["x-title"]
+    schema["description"] = first_op.get("summary", "")
+    schema["type"] = "object"
+
+    if "x-schema-version" in first_op:
+        schema["version"] = first_op["x-schema-version"]
+    if "x-api-version" in first_op:
+        schema["apiVersion"] = first_op["x-api-version"]
+    if "x-skus" in first_op:
+        schema["skus"] = first_op["x-skus"]
+    if first_op.get("x-min-api-version"):
+        schema["minApiVersion"] = first_op["x-min-api-version"]
+
+    # Merge properties from all operations (polymorphic endpoints)
+    all_props = {}
+    all_allof = None
+    for method, op in operations.items():
+        props = extract_properties_from_operation(op, method)
+        props = unprefix_custom_keys(props)
+        all_props.update(props)
+
+        allof = extract_allof_from_operation(op, method)
+        if allof:
+            all_allof = unprefix_custom_keys(allof)
+
+    # Add req/cmd properties
+    supports_cmd = first_op.get("x-supports-cmd", False)
+    all_props["req"] = {
+        "description": "Request for the Notecard (expects response)",
+        "const": endpoint,
+    }
+
+    if supports_cmd:
+        all_props["cmd"] = {
+            "description": "Command for the Notecard (no response)",
+            "const": endpoint,
+        }
+
+    schema["properties"] = all_props
+
+    # Add req/cmd oneOf
+    schema["oneOf"] = [
+        {"required": ["req"], "properties": {"req": {"const": endpoint}}},
+    ]
+    if supports_cmd:
+        schema["oneOf"].append(
+            {"required": ["cmd"], "properties": {"cmd": {"const": endpoint}}}
+        )
+
+    schema["additionalProperties"] = False
+
+    # Restore allOf (conditional schemas)
+    if all_allof:
+        schema["allOf"] = all_allof
+
+    # Restore samples
+    if "x-samples" in first_op:
+        schema["samples"] = first_op["x-samples"]
+
+    return schema
+
+
+def rebuild_response_schema(endpoint: str, operations: dict) -> dict | None:
+    """Rebuild the original response JSON Schema from OpenAPI operation(s)."""
+    # Use first operation's response (all ops share the same response schema)
+    first_op = next(iter(operations.values()))
+    resp_schema = extract_response_schema(first_op)
+    resp_200 = first_op.get("responses", {}).get("200", {})
+
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": f"{SCHEMA_BASE_URL}/{endpoint}.rsp.notecard.api.json",
+    }
+
+    # Response metadata from the 200 response object
+    if "x-title" in resp_200:
+        schema["title"] = resp_200["x-title"]
+    desc = resp_200.get("description")
+    if desc and desc != "Successful response":
+        schema["description"] = desc
+    schema["type"] = "object"
+
+    if "x-schema-version" in resp_200:
+        schema["version"] = resp_200["x-schema-version"]
+    if "x-api-version" in resp_200:
+        schema["apiVersion"] = resp_200["x-api-version"]
+    if "x-skus" in resp_200:
+        schema["skus"] = resp_200["x-skus"]
+    if resp_200.get("x-min-api-version"):
+        schema["minApiVersion"] = resp_200["x-min-api-version"]
+
+    if resp_schema:
+        resp_schema = unprefix_custom_keys(resp_schema)
+        schema["properties"] = resp_schema.get("properties", {})
+        if "required" in resp_schema:
+            schema["required"] = resp_schema["required"]
+    else:
+        schema["properties"] = {}
+
+    schema["additionalProperties"] = False
+
+    if "x-samples" in resp_200:
+        schema["samples"] = resp_200["x-samples"]
+
+    return schema
+
+
+def convert(openapi_path: Path) -> tuple[dict, dict]:
+    """Convert OpenAPI spec back to individual JSON Schemas.
+
+    Returns (requests, responses) dicts keyed by endpoint name.
+    """
+    with open(openapi_path) as f:
+        spec = json.load(f)
+
+    requests = {}
+    responses = {}
+
+    for path, path_item in spec.get("paths", {}).items():
+        endpoint = path_to_endpoint(path)
+
+        # Group operations by method
+        operations = {}
+        for method in ("get", "put", "post", "delete", "patch"):
+            if method in path_item:
+                operations[method] = path_item[method]
+
+        if not operations:
+            continue
+
+        requests[endpoint] = rebuild_request_schema(endpoint, operations)
+        rsp = rebuild_response_schema(endpoint, operations)
+        if rsp:
+            responses[endpoint] = rsp
+
+    return requests, responses
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("openapi", type=Path,
+                        help="Path to OpenAPI 3.1 JSON file")
+    parser.add_argument("-o", "--output-dir", type=Path, required=True,
+                        help="Output directory for JSON Schema files")
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    requests, responses = convert(args.openapi)
+
+    for endpoint, schema in requests.items():
+        out_path = args.output_dir / f"{endpoint}.req.notecard.api.json"
+        out_path.write_text(json.dumps(schema, indent=4) + "\n")
+
+    for endpoint, schema in responses.items():
+        out_path = args.output_dir / f"{endpoint}.rsp.notecard.api.json"
+        out_path.write_text(json.dumps(schema, indent=4) + "\n")
+
+    print(f"Wrote {len(requests)} request + {len(responses)} response schemas to {args.output_dir}",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/safety_semantics.json
+++ b/tools/safety_semantics.json
@@ -1,0 +1,124 @@
+{
+  "$comment": "Safety semantics for Notecard API endpoints. Maps each endpoint to HTTP method(s) encoding safety/idempotency. Polymorphic endpoints have multiple methods with 'requires'/'excludes' constraints on request properties.",
+
+  "card.attn": "PUT",
+  "card.aux": "PUT",
+  "card.aux.serial": "PUT",
+  "card.carrier": "PUT",
+  "card.dfu": "PUT",
+  "card.illumination": "GET",
+  "card.io": "PUT",
+  "card.led": "PUT",
+  "card.location": "GET",
+  "card.location.track": "PUT",
+  "card.monitor": "PUT",
+  "card.motion": "GET",
+  "card.motion.mode": "PUT",
+  "card.motion.sync": "PUT",
+  "card.motion.track": "PUT",
+  "card.random": "GET",
+  "card.restart": "POST",
+  "card.restore": "DELETE",
+  "card.sleep": "PUT",
+  "card.status": "GET",
+  "card.time": "GET",
+  "card.trace": "PUT",
+  "card.transport": "PUT",
+  "card.triangulate": "PUT",
+  "card.usage.get": "GET",
+  "card.usage.test": "GET",
+  "card.version": "GET",
+  "card.wifi": "PUT",
+  "card.wireless": "PUT",
+
+  "dfu.get": "GET",
+  "dfu.status": "PUT",
+
+  "env.get": "GET",
+  "env.modified": "GET",
+  "env.set": "PUT",
+  "env.template": "PUT",
+
+  "file.changes.pending": "GET",
+  "file.clear": "DELETE",
+  "file.delete": "DELETE",
+  "file.stats": "GET",
+
+  "hub.get": "GET",
+  "hub.log": "POST",
+  "hub.set": "PUT",
+  "hub.signal": "POST",
+  "hub.status": "GET",
+  "hub.sync": "POST",
+  "hub.sync.status": "GET",
+
+  "note.add": "POST",
+  "note.delete": "DELETE",
+  "note.update": "PUT",
+  "ntn.gps": "PUT",
+  "ntn.reset": "DELETE",
+  "ntn.status": "GET",
+
+  "var.delete": "DELETE",
+  "var.get": "GET",
+  "var.set": "PUT",
+
+  "web": "POST",
+  "web.delete": "DELETE",
+  "web.get": "GET",
+  "web.post": "POST",
+  "web.put": "PUT",
+
+  "card.binary.get": "POST",
+  "card.binary.put": "POST",
+
+  "card.binary": {
+    "GET": {},
+    "DELETE": { "requires": ["delete"] }
+  },
+  "card.contact": {
+    "GET": {},
+    "PUT": { "requires_any": ["name", "email", "org", "role"] }
+  },
+  "card.location.mode": {
+    "GET": {},
+    "PUT": { "requires_any": ["mode", "seconds", "lat", "lon"] },
+    "DELETE": { "requires": ["delete"] }
+  },
+  "card.power": {
+    "GET": {},
+    "PUT": { "requires": ["minutes"] },
+    "DELETE": { "requires": ["reset"] }
+  },
+  "card.temp": {
+    "GET": {},
+    "PUT": { "requires_any": ["minutes", "status", "sync"] },
+    "DELETE": { "requires": ["stop"] }
+  },
+  "card.voltage": {
+    "GET": {},
+    "PUT": { "requires_any": ["mode", "set", "usb", "alert", "sync", "on", "off", "calibration", "name"] }
+  },
+  "card.wireless.penalty": {
+    "GET": {},
+    "PUT": { "requires": ["set"] },
+    "DELETE": { "requires": ["reset"] }
+  },
+  "env.default": {
+    "PUT": { "requires": ["name", "text"] },
+    "DELETE": { "requires": ["name"], "excludes": ["text"] }
+  },
+  "file.changes": "GET",
+  "note.changes": {
+    "GET": { "excludes": ["delete"] },
+    "DELETE": { "requires": ["delete"] }
+  },
+  "note.get": {
+    "GET": { "excludes": ["delete"] },
+    "DELETE": { "requires": ["delete"] }
+  },
+  "note.template": {
+    "PUT": { "requires": ["body"] },
+    "DELETE": { "requires": ["delete"] }
+  }
+}

--- a/tools/schema_to_openapi.py
+++ b/tools/schema_to_openapi.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Convert Notecard JSON Schema files to an OpenAPI 3.1 spec.
+
+Reads all *.req.notecard.api.json and *.rsp.notecard.api.json files from the
+notecard-schema repo, combines them with safety_semantics.json, and emits a
+single notecard-api.openapi.json.
+
+Usage:
+    python3 schema_to_openapi.py <schema_dir> [--safety safety_semantics.json] [-o output.json]
+"""
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+# Top-level schema keys that are NOT standard JSON Schema and need x- prefix
+CUSTOM_KEYS = {
+    "sub-descriptions": "x-sub-descriptions",
+    "skus": "x-skus",
+    "samples": "x-samples",
+    "minApiVersion": "x-min-api-version",
+    "annotations": "x-annotations",
+    "version": "x-schema-version",
+    "apiVersion": "x-api-version",
+}
+
+REVERSE_CUSTOM_KEYS = {v: k for k, v in CUSTOM_KEYS.items()}
+
+SAFETY_TO_X = {
+    "GET": "readonly",
+    "PUT": "idempotent",
+    "POST": "non-idempotent",
+    "DELETE": "destructive",
+}
+
+
+def endpoint_to_path(endpoint: str) -> str:
+    """Convert 'hub.set' to '/hub/set'."""
+    return "/" + endpoint.replace(".", "/")
+
+
+def path_to_endpoint(path: str) -> str:
+    """Convert '/hub/set' to 'hub.set'."""
+    return path.lstrip("/").replace("/", ".")
+
+
+def prefix_custom_keys(schema):
+    """Recursively rename custom keys with x- prefix in a schema."""
+    if isinstance(schema, list):
+        return [prefix_custom_keys(item) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    result = {}
+    for key, value in schema.items():
+        new_key = CUSTOM_KEYS.get(key, key)
+        result[new_key] = prefix_custom_keys(value)
+    return result
+
+
+def unprefix_custom_keys(schema):
+    """Recursively reverse x- prefix on custom keys."""
+    if isinstance(schema, list):
+        return [unprefix_custom_keys(item) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    result = {}
+    for key, value in schema.items():
+        new_key = REVERSE_CUSTOM_KEYS.get(key, key)
+        result[new_key] = unprefix_custom_keys(value)
+    return result
+
+
+def strip_req_cmd(schema: dict) -> tuple[dict, bool]:
+    """Remove req/cmd properties and the oneOf requiring them.
+
+    Returns (cleaned_schema, supports_cmd).
+    """
+    schema = copy.deepcopy(schema)
+    supports_cmd = False
+
+    props = schema.get("properties", {})
+    if "cmd" in props:
+        supports_cmd = True
+
+    props.pop("req", None)
+    props.pop("cmd", None)
+
+    # Remove the top-level oneOf that just selects req vs cmd
+    if "oneOf" in schema:
+        oneof = schema["oneOf"]
+        is_req_cmd_oneof = (
+            len(oneof) == 2
+            and any("req" in item.get("required", []) for item in oneof)
+            and any("cmd" in item.get("required", []) for item in oneof)
+        )
+        if is_req_cmd_oneof:
+            del schema["oneOf"]
+
+    return schema, supports_cmd
+
+
+def restore_req_cmd(endpoint: str, schema: dict, supports_cmd: bool) -> dict:
+    """Re-add req/cmd properties and the oneOf selecting them."""
+    schema = copy.deepcopy(schema)
+    props = schema.setdefault("properties", {})
+
+    props["req"] = {
+        "description": "Request for the Notecard (expects response)",
+        "const": endpoint,
+    }
+    if supports_cmd:
+        props["cmd"] = {
+            "description": "Command for the Notecard (no response)",
+            "const": endpoint,
+        }
+
+    schema["oneOf"] = [
+        {"required": ["req"], "properties": {"req": {"const": endpoint}}},
+    ]
+    if supports_cmd:
+        schema["oneOf"].append(
+            {"required": ["cmd"], "properties": {"cmd": {"const": endpoint}}}
+        )
+
+    return schema
+
+
+def extract_body_schema(schema: dict) -> dict:
+    """Extract a request/response body schema from a cleaned schema."""
+    props = schema.get("properties", {})
+    if not props:
+        return {}
+
+    body_schema = {"type": "object", "properties": props}
+
+    if "required" in schema:
+        body_schema["required"] = schema["required"]
+    if schema.get("additionalProperties") is not None:
+        body_schema["additionalProperties"] = schema["additionalProperties"]
+    if "allOf" in schema:
+        body_schema["allOf"] = schema["allOf"]
+
+    return body_schema
+
+
+def build_operation(
+    endpoint: str,
+    method: str,
+    req_schema: dict,
+    rsp_schema: dict | None,
+    supports_cmd: bool,
+    constraints: dict | None,
+) -> dict:
+    """Build a single OpenAPI operation object."""
+    safety = SAFETY_TO_X[method]
+
+    operation = {
+        "operationId": endpoint.replace(".", "_"),
+        "summary": req_schema.get("description", ""),
+        "x-safety": safety,
+        "x-notecard-request": endpoint,
+    }
+
+    if supports_cmd:
+        operation["x-supports-cmd"] = True
+
+    if constraints:
+        operation["x-dispatch"] = constraints
+
+    # Preserve top-level metadata (use original key names, not yet prefixed)
+    if "skus" in req_schema:
+        operation["x-skus"] = req_schema["skus"]
+    if "apiVersion" in req_schema:
+        operation["x-api-version"] = req_schema["apiVersion"]
+    if "version" in req_schema:
+        operation["x-schema-version"] = req_schema["version"]
+    if req_schema.get("minApiVersion"):
+        operation["x-min-api-version"] = req_schema["minApiVersion"]
+    if "title" in req_schema:
+        operation["x-title"] = req_schema["title"]
+
+    # Request body / parameters
+    props = req_schema.get("properties", {})
+    if props:
+        body_schema = extract_body_schema(req_schema)
+        body_schema = prefix_custom_keys(body_schema)
+
+        if method == "GET":
+            parameters = []
+            for prop_name, prop_schema in props.items():
+                prop_schema = prefix_custom_keys(copy.deepcopy(prop_schema))
+                param = {
+                    "name": prop_name,
+                    "in": "query",
+                    "schema": prop_schema,
+                }
+                if "description" in prop_schema:
+                    param["description"] = prop_schema.pop("description")
+                parameters.append(param)
+            if parameters:
+                operation["parameters"] = parameters
+        else:
+            operation["requestBody"] = {
+                "content": {
+                    "application/json": {
+                        "schema": body_schema,
+                    }
+                },
+            }
+
+    # Samples
+    if "samples" in req_schema:
+        operation["x-samples"] = req_schema["samples"]
+
+    # Response
+    rsp_desc = "Successful response"
+    if rsp_schema:
+        rsp_desc = rsp_schema.get("description", rsp_desc)
+
+    responses = {"200": {"description": rsp_desc}}
+    if rsp_schema:
+        rsp_body = extract_body_schema(rsp_schema)
+        if rsp_body:
+            rsp_body = prefix_custom_keys(rsp_body)
+            responses["200"]["content"] = {
+                "application/json": {"schema": rsp_body}
+            }
+        # Preserve response-level metadata
+        rsp_meta = {}
+        if "title" in rsp_schema:
+            rsp_meta["x-title"] = rsp_schema["title"]
+        if "samples" in rsp_schema:
+            rsp_meta["x-samples"] = rsp_schema["samples"]
+        if "skus" in rsp_schema:
+            rsp_meta["x-skus"] = rsp_schema["skus"]
+        if "version" in rsp_schema:
+            rsp_meta["x-schema-version"] = rsp_schema["version"]
+        if "apiVersion" in rsp_schema:
+            rsp_meta["x-api-version"] = rsp_schema["apiVersion"]
+        if rsp_schema.get("minApiVersion"):
+            rsp_meta["x-min-api-version"] = rsp_schema["minApiVersion"]
+        if rsp_meta:
+            responses["200"].update(rsp_meta)
+
+    operation["responses"] = responses
+
+    return operation
+
+
+def load_schemas(schema_dir: Path) -> tuple[dict, dict]:
+    """Load all request and response schemas keyed by endpoint name."""
+    requests = {}
+    responses = {}
+
+    for path in sorted(schema_dir.glob("*.req.notecard.api.json")):
+        endpoint = path.name.replace(".req.notecard.api.json", "")
+        with open(path) as f:
+            requests[endpoint] = json.load(f)
+
+    for path in sorted(schema_dir.glob("*.rsp.notecard.api.json")):
+        endpoint = path.name.replace(".rsp.notecard.api.json", "")
+        with open(path) as f:
+            responses[endpoint] = json.load(f)
+
+    return requests, responses
+
+
+def load_safety(safety_path: Path) -> dict:
+    """Load safety semantics JSON."""
+    with open(safety_path) as f:
+        data = json.load(f)
+    data.pop("$comment", None)
+    return data
+
+
+def convert(schema_dir: Path, safety_path: Path) -> dict:
+    """Main conversion: JSON Schema files + safety semantics -> OpenAPI 3.1."""
+    requests, responses = load_schemas(schema_dir)
+    safety = load_safety(safety_path)
+
+    openapi = {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "Notecard API",
+            "description": (
+                "Machine-generated OpenAPI 3.1 specification for the Blues "
+                "Notecard API, derived from the notecard-schema JSON Schema "
+                "files with safety semantics annotations."
+            ),
+            "version": requests.get("card.version", {}).get("apiVersion", "0.0.0"),
+            "contact": {"name": "Blues Inc.", "url": "https://blues.com"},
+            "license": {
+                "name": "Apache-2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+            },
+        },
+        "paths": {},
+    }
+
+    missing = []
+
+    for endpoint in sorted(requests.keys()):
+        req_schema = requests[endpoint]
+        rsp_schema = responses.get(endpoint)
+
+        if endpoint not in safety:
+            missing.append(endpoint)
+            continue
+
+        req_cleaned, supports_cmd = strip_req_cmd(req_schema)
+        semantics = safety[endpoint]
+        path = endpoint_to_path(endpoint)
+        path_item = {}
+
+        if isinstance(semantics, str):
+            method = semantics.lower()
+            op = build_operation(
+                endpoint, semantics, req_cleaned, rsp_schema,
+                supports_cmd, None,
+            )
+            path_item[method] = op
+
+        elif isinstance(semantics, dict):
+            for http_method, constraints in semantics.items():
+                method = http_method.lower()
+                op = build_operation(
+                    endpoint, http_method, req_cleaned, rsp_schema,
+                    supports_cmd, constraints if constraints else None,
+                )
+                suffix = {"GET": "query", "PUT": "set", "POST": "create",
+                          "DELETE": "delete"}.get(http_method, method)
+                op["operationId"] = f"{endpoint.replace('.', '_')}_{suffix}"
+                path_item[method] = op
+
+        openapi["paths"][path] = path_item
+
+    if missing:
+        print(f"WARNING: {len(missing)} endpoints missing from safety_semantics.json:",
+              file=sys.stderr)
+        for ep in missing:
+            print(f"  - {ep}", file=sys.stderr)
+
+    return openapi
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("schema_dir", type=Path,
+                        help="Path to notecard-schema repo")
+    parser.add_argument("--safety", type=Path,
+                        default=Path(__file__).parent / "safety_semantics.json",
+                        help="Path to safety_semantics.json")
+    parser.add_argument("-o", "--output", type=Path,
+                        default=None,
+                        help="Output file (default: stdout)")
+    args = parser.parse_args()
+
+    openapi = convert(args.schema_dir, args.safety)
+
+    output = json.dumps(openapi, indent=2)
+    if args.output:
+        args.output.write_text(output + "\n")
+        print(f"Wrote {args.output} ({len(openapi['paths'])} paths)",
+              file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_roundtrip.py
+++ b/tools/verify_roundtrip.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Verify round-trip fidelity: original JSON Schema -> OpenAPI -> JSON Schema.
+
+Compares properties, types, descriptions, constraints, and metadata between
+the original notecard-schema files and schemas regenerated from the OpenAPI spec.
+
+Usage:
+    python3 verify_roundtrip.py <original_schema_dir> <openapi_spec>
+"""
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+# Keys that are structural envelope and won't survive round-trip exactly
+ENVELOPE_KEYS = {"$schema", "$id"}
+
+# Keys where exact match is expected
+SEMANTIC_KEYS_REQ = {
+    "title", "description", "type", "properties", "required",
+    "additionalProperties", "oneOf", "allOf", "anyOf",
+    "skus", "samples", "version", "apiVersion", "minApiVersion",
+}
+
+# Property-level keys
+PROPERTY_KEYS = {
+    "description", "type", "enum", "const", "pattern", "format",
+    "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum",
+    "minItems", "maxItems", "items", "default",
+    "oneOf", "anyOf", "allOf", "if", "then", "else", "not",
+    "properties", "required", "additionalProperties",
+    "contentEncoding",
+    "sub-descriptions", "skus", "minApiVersion",
+}
+
+
+def normalize_for_comparison(schema):
+    """Normalize a schema for comparison — sort keys, remove envelope."""
+    if isinstance(schema, list):
+        return [normalize_for_comparison(item) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    result = {}
+    for key in sorted(schema.keys()):
+        if key in ENVELOPE_KEYS:
+            continue
+        result[key] = normalize_for_comparison(schema[key])
+    return result
+
+
+def deep_diff(original, roundtripped, path=""):
+    """Recursively compare two structures, yielding (path, original, roundtripped) diffs."""
+    if type(original) != type(roundtripped):
+        yield (path, f"type mismatch: {type(original).__name__} vs {type(roundtripped).__name__}",
+               repr(original)[:80], repr(roundtripped)[:80])
+        return
+
+    if isinstance(original, dict):
+        all_keys = set(original.keys()) | set(roundtripped.keys())
+        for key in sorted(all_keys):
+            child_path = f"{path}.{key}" if path else key
+            if key not in roundtripped:
+                yield (child_path, "missing in round-tripped", repr(original[key])[:80], None)
+            elif key not in original:
+                yield (child_path, "extra in round-tripped", None, repr(roundtripped[key])[:80])
+            else:
+                yield from deep_diff(original[key], roundtripped[key], child_path)
+
+    elif isinstance(original, list):
+        if len(original) != len(roundtripped):
+            yield (path, f"list length: {len(original)} vs {len(roundtripped)}",
+                   None, None)
+        for i, (a, b) in enumerate(zip(original, roundtripped)):
+            yield from deep_diff(a, b, f"{path}[{i}]")
+
+    else:
+        if original != roundtripped:
+            yield (path, "value differs", repr(original)[:80], repr(roundtripped)[:80])
+
+
+def compare_properties(orig_props: dict, rt_props: dict, endpoint: str) -> list:
+    """Compare properties dicts, focusing on semantic content."""
+    diffs = []
+
+    orig_names = set(orig_props.keys())
+    rt_names = set(rt_props.keys())
+
+    for name in sorted(orig_names - rt_names):
+        diffs.append(f"  property '{name}': missing in round-tripped")
+    for name in sorted(rt_names - orig_names):
+        diffs.append(f"  property '{name}': extra in round-tripped")
+
+    for name in sorted(orig_names & rt_names):
+        orig_prop = copy.deepcopy(orig_props[name])
+        rt_prop = copy.deepcopy(rt_props[name])
+        # req/cmd properties are protocol envelope; minApiVersion on them
+        # is redundant with the top-level minApiVersion — skip this diff
+        if name in ("req", "cmd"):
+            orig_prop.pop("minApiVersion", None)
+            rt_prop.pop("minApiVersion", None)
+        for diff_path, diff_type, orig_val, rt_val in deep_diff(orig_prop, rt_prop):
+            detail = f"  property '{name}'.{diff_path}: {diff_type}"
+            if orig_val:
+                detail += f"\n    original:     {orig_val}"
+            if rt_val:
+                detail += f"\n    round-tripped: {rt_val}"
+            diffs.append(detail)
+
+    return diffs
+
+
+def verify_endpoint(endpoint: str, original: dict, roundtripped: dict) -> list:
+    """Compare an original schema with its round-tripped version."""
+    issues = []
+
+    # Compare properties (the core semantic content)
+    orig_props = original.get("properties", {})
+    rt_props = roundtripped.get("properties", {})
+    prop_diffs = compare_properties(orig_props, rt_props, endpoint)
+    issues.extend(prop_diffs)
+
+    # Compare allOf (conditional schemas)
+    orig_allof = original.get("allOf")
+    rt_allof = roundtripped.get("allOf")
+    if orig_allof and not rt_allof:
+        issues.append("  allOf: missing in round-tripped")
+    elif not orig_allof and rt_allof:
+        issues.append("  allOf: extra in round-tripped")
+    elif orig_allof and rt_allof:
+        orig_norm = normalize_for_comparison(orig_allof)
+        rt_norm = normalize_for_comparison(rt_allof)
+        if orig_norm != rt_norm:
+            for diff_path, diff_type, orig_val, rt_val in deep_diff(orig_norm, rt_norm):
+                detail = f"  allOf.{diff_path}: {diff_type}"
+                if orig_val:
+                    detail += f"\n    original:     {orig_val}"
+                if rt_val:
+                    detail += f"\n    round-tripped: {rt_val}"
+                issues.append(detail)
+
+    # Compare top-level metadata
+    for key in ["title", "description", "skus", "version", "apiVersion"]:
+        orig_val = original.get(key)
+        rt_val = roundtripped.get(key)
+        if orig_val != rt_val:
+            issues.append(f"  {key}: {repr(orig_val)[:60]} vs {repr(rt_val)[:60]}")
+
+    # Compare samples
+    orig_samples = original.get("samples")
+    rt_samples = roundtripped.get("samples")
+    if orig_samples and not rt_samples:
+        issues.append("  samples: missing in round-tripped")
+    elif orig_samples and rt_samples:
+        if len(orig_samples) != len(rt_samples):
+            issues.append(f"  samples: {len(orig_samples)} vs {len(rt_samples)}")
+
+    return issues
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("schema_dir", type=Path,
+                        help="Path to original notecard-schema repo")
+    parser.add_argument("openapi", type=Path,
+                        help="Path to OpenAPI 3.1 JSON file")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Show details for all endpoints, not just failures")
+    args = parser.parse_args()
+
+    # Load originals
+    originals_req = {}
+    originals_rsp = {}
+    for path in sorted(args.schema_dir.glob("*.req.notecard.api.json")):
+        endpoint = path.name.replace(".req.notecard.api.json", "")
+        with open(path) as f:
+            originals_req[endpoint] = json.load(f)
+    for path in sorted(args.schema_dir.glob("*.rsp.notecard.api.json")):
+        endpoint = path.name.replace(".rsp.notecard.api.json", "")
+        with open(path) as f:
+            originals_rsp[endpoint] = json.load(f)
+
+    # Reverse-transform from OpenAPI
+    # Import the reverse transform
+    sys.path.insert(0, str(Path(__file__).parent))
+    from openapi_to_schema import convert as reverse_convert
+    roundtripped_req, roundtripped_rsp = reverse_convert(args.openapi)
+
+    # Compare
+    total = 0
+    passed = 0
+    failed = 0
+    all_issues = {}
+
+    for endpoint in sorted(originals_req.keys()):
+        total += 1
+        if endpoint not in roundtripped_req:
+            print(f"MISS {endpoint}.req - not in round-tripped output")
+            failed += 1
+            continue
+
+        issues = verify_endpoint(
+            endpoint,
+            originals_req[endpoint],
+            roundtripped_req[endpoint],
+        )
+
+        # Also check response
+        if endpoint in originals_rsp and endpoint in roundtripped_rsp:
+            rsp_issues = verify_endpoint(
+                endpoint,
+                originals_rsp[endpoint],
+                roundtripped_rsp[endpoint],
+            )
+            if rsp_issues:
+                issues.extend([f"  [response] {i.strip()}" for i in rsp_issues])
+
+        if issues:
+            failed += 1
+            all_issues[endpoint] = issues
+            if args.verbose:
+                print(f"FAIL {endpoint}")
+                for issue in issues:
+                    print(f"  {issue}")
+        else:
+            passed += 1
+            if args.verbose:
+                print(f"PASS {endpoint}")
+
+    # Summary
+    print(f"\n{'='*60}")
+    print(f"Round-trip verification: {passed}/{total} passed, {failed} failed")
+    print(f"{'='*60}")
+
+    if all_issues and not args.verbose:
+        print(f"\nFailed endpoints ({failed}):")
+        for endpoint, issues in all_issues.items():
+            print(f"\n  {endpoint}:")
+            for issue in issues:
+                print(f"    {issue}")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add tooling to convert the Notecard JSON Schema files into a single OpenAPI 3.1 specification. The openAPI spec follows directly from what is in the existing json schema, with these additions:

- HTTP method mappings encoding safety and idempotency semantics per endpoint as well as the arguments that differ between the semantically different invocations. These were added to `tools/safety_semantics.json`

- APIs that expect to send or receive a binary payload have been added as an `x-binary-transfer` extension. The metadata for this is stored in `tools/binary_transfer.json`.  This covers the 3 endpoints, `card.binary.get`, `card.binary.put`, `dfu.get`.

The tool implements conversion to and from the OpenAPI spec, and verifies 100% round-trip fidelity.

Addresses issue #271