### PR TITLE
fix: add outboard-ready to dfu.status mode enum

### DIFF
--- a/dfu.status.rsp.notecard.api.json
+++ b/dfu.status.rsp.notecard.api.json
@@ -24,6 +24,7 @@
                 "error",
                 "downloading",
                 "ready",
+                "outboard-ready",
                 "completed"
             ],
             "sub-descriptions": [
@@ -42,6 +43,10 @@
                 {
                     "const": "ready",
                     "description": "The firmware data is fully downloaded."
+                },
+                {
+                    "const": "outboard-ready",
+                    "description": "The firmware data is fully downloaded and ready for an outboard DFU operation, where the Notecard will flash the firmware to the host MCU via the AUX or ALT_DFU pins."
                 },
                 {
                     "const": "completed",
@@ -87,6 +92,11 @@
             "title": "DFU Error Status",
             "description": "Example response showing download error.",
             "json": "{\"mode\": \"error\", \"status\": \"download failed: checksum mismatch\", \"on\": true}"
+        },
+        {
+            "title": "DFU Outboard Ready Status",
+            "description": "Example response showing firmware is ready for an outboard DFU operation.",
+            "json": "{\"mode\": \"outboard-ready\", \"status\": \"successfully downloaded\", \"on\": true}"
         }
     ]
 }

--- a/tests/test_dfu_status_rsp.py
+++ b/tests/test_dfu_status_rsp.py
@@ -11,7 +11,7 @@ def test_minimal_valid_rsp(schema):
 
 def test_valid_mode_enums(schema):
     """Tests valid mode enum values."""
-    valid_modes = ["idle", "error", "downloading", "ready", "completed"]
+    valid_modes = ["idle", "error", "downloading", "ready", "outboard-ready", "completed"]
     for mode in valid_modes:
         instance = {"mode": mode}
         jsonschema.validate(instance=instance, schema=schema)
@@ -21,7 +21,7 @@ def test_mode_invalid_enum(schema):
     instance = {"mode": "invalid"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "'invalid' is not one of ['idle', 'error', 'downloading', 'ready', 'completed']" in str(excinfo.value)
+    assert "'invalid' is not one of" in str(excinfo.value)
 
 def test_mode_invalid_type(schema):
     """Tests invalid type for mode."""


### PR DESCRIPTION
## Summary

- Adds the missing `outboard-ready` enum value to the `mode` field in the `dfu.status` response schema
- Adds a sub-description explaining that this mode indicates firmware is fully downloaded and ready for an outboard DFU (ODFU) operation via the AUX or ALT_DFU pins
- Adds a corresponding sample response
- Updates tests to include `outboard-ready` as a valid mode

Closes #282.