### PR TITLE
feat: new example for clearing a Notefile template

### DIFF
--- a/note.template.req.notecard.api.json
+++ b/note.template.req.notecard.api.json
@@ -109,6 +109,11 @@
             "title": "Request Current Template",
             "description": "Retrieve the current template configuration for the readings.qo Notefile.",
             "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\",\"verify\":true}"
+        },
+        {
+            "title": "Clear Template",
+            "description": "Clear the template from readings.qo. Omitting `body` and `payload` removes the template schema; subsequent Notes added to the Notefile will be stored as regular JSON objects.",
+            "json": "{\"req\":\"note.template\",\"file\":\"readings.qo\"}"
         }
     ]
 }


### PR DESCRIPTION
Another one from Claude.

Claude originally changed this in my local blues.dev repo. This is why I want those files to not be there—then I can tell Claude about notecard-schema :)