### PR TITLE
feat: update card.voltage mode to accept a string value

### DIFF
--- a/card.voltage.req.notecard.api.json
+++ b/card.voltage.req.notecard.api.json
@@ -32,16 +32,23 @@
             "maximum": 720
         },
         "mode": {
-            "description": "Used to set voltage thresholds based on how the Notecard will be powered, and which can be used to [configure voltage-variable Notecard behavior](/notecard/notecard-walkthrough/low-power-firmware-design). Each value is shorthand that assigns a battery voltage reading to a given device state like `high`, `normal`, `low`, and `dead`.\n\n**NOTE:** Setting voltage thresholds is not supported on the Notecard XP.",
+            "description": "Used to set voltage thresholds based on how the Notecard will be powered, and which can be used to [configure voltage-variable Notecard behavior](/notecard/notecard-walkthrough/low-power-firmware-design). Each value is shorthand that assigns a battery voltage reading to a given device state like `high`, `normal`, `low`, and `dead`.\n\nIn addition to the named presets below, a custom semicolon-separated shorthand string may be provided using any combination of the `usb`, `high`, `normal`, `low`, and `dead` states (e.g. `\"usb:4.6;high:4.2;normal:3.6;low:0\"`).\n\n**NOTE:** Setting voltage thresholds is not supported on the Notecard XP.",
             "type": "string",
-            "enum": [
-                "default",
-                "lipo",
-                "l91",
-                "alkaline",
-                "tad",
-                "lic",
-                "?"
+            "anyOf": [
+                {
+                    "enum": [
+                        "default",
+                        "lipo",
+                        "l91",
+                        "alkaline",
+                        "tad",
+                        "lic",
+                        "?"
+                    ]
+                },
+                {
+                    "pattern": "^(usb|high|normal|low|dead):\\d+(\\.\\d+)?(;(usb|high|normal|low|dead):\\d+(\\.\\d+)?)*$"
+                }
             ],
             "default": "default",
             "sub-descriptions": [
@@ -165,6 +172,11 @@
             "title": "Query Current Thresholds",
             "description": "Query the Notecard for its currently-set voltage thresholds.",
             "json": "{\"req\": \"card.voltage\", \"mode\": \"?\"}"
+        },
+        {
+            "title": "Set Custom Voltage Thresholds",
+            "description": "Configure voltage thresholds using a custom semicolon-separated shorthand string.",
+            "json": "{\"req\": \"card.voltage\", \"mode\": \"usb:4.6;high:4.2;normal:3.6;low:0\"}"
         },
         {
             "title": "Enable USB Power Monitoring",

--- a/tests/test_card_voltage_req.py
+++ b/tests/test_card_voltage_req.py
@@ -52,12 +52,11 @@ def test_valid_mode_enums(schema):
         instance = {"req": "card.voltage", "mode": mode}
         jsonschema.validate(instance=instance, schema=schema)
 
-def test_mode_invalid_enum(schema):
-    """Tests invalid mode enum value."""
+def test_mode_invalid_value(schema):
+    """Tests an arbitrary mode value that matches neither the enum nor the shorthand pattern."""
     instance = {"req": "card.voltage", "mode": "nimh"}
-    with pytest.raises(jsonschema.ValidationError) as excinfo:
+    with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=instance, schema=schema)
-    assert "'nimh' is not one of ['default'," in str(excinfo.value)
 
 def test_mode_invalid_type(schema):
     """Tests invalid type for mode."""
@@ -65,6 +64,41 @@ def test_mode_invalid_type(schema):
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
     assert "1 is not of type 'string'" in str(excinfo.value)
+
+def test_valid_mode_custom_shorthand(schema):
+    """Tests valid custom shorthand mode strings with various state combinations."""
+    valid_modes = [
+        "usb:4;low:0",
+        "usb:4.6;high:4.2;normal:3.6;low:0",
+        "usb:4.6;high:4.0;normal:3.5;low:3.2;dead:0",
+        "dead:0",
+        "high:5",
+        "normal:3.5",
+        "low:0;dead:0",
+        "high:4.2;dead:0"
+    ]
+    for mode in valid_modes:
+        instance = {"req": "card.voltage", "mode": mode}
+        jsonschema.validate(instance=instance, schema=schema)
+
+def test_mode_invalid_shorthand(schema):
+    """Tests invalid shorthand mode strings."""
+    invalid_modes = [
+        "usb:",                  # missing value
+        ":4.6",                  # missing key
+        "foo:4.6",               # unknown state
+        "usb:4.6;",              # trailing semicolon
+        ";usb:4.6",              # leading semicolon
+        "usb:4.6,high:4.2",      # comma instead of semicolon
+        "usb 4.6",               # space instead of colon
+        "usb:4.6;high",          # missing value in second pair
+        "usb:-4.6",              # negative value
+        "usb:4.6.2"              # malformed number
+    ]
+    for mode in invalid_modes:
+        instance = {"req": "card.voltage", "mode": mode}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=instance, schema=schema)
 
 def test_valid_vmax(schema):
     """Tests valid vmax field."""


### PR DESCRIPTION
I'm surprised we missed this one. The mode arg of card.voltage can also accept a list of values, so it's not a strict string enum.