### PR TITLE
chore: replace additionalProperties with unevaluatedProperties across all schemas

### DIFF
--- a/card.attn.req.notecard.api.json
+++ b/card.attn.req.notecard.api.json
@@ -260,7 +260,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "allOf": [
         {
             "if": {

--- a/card.attn.rsp.notecard.api.json
+++ b/card.attn.rsp.notecard.api.json
@@ -200,7 +200,7 @@
             ]
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "description": "Example Response",

--- a/card.aux.req.notecard.api.json
+++ b/card.aux.req.notecard.api.json
@@ -499,7 +499,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/card.aux.rsp.notecard.api.json
+++ b/card.aux.rsp.notecard.api.json
@@ -64,7 +64,7 @@
                         }
                     }
                 },
-                "additionalProperties": false
+                "unevaluatedProperties": false
             },
             "sub-descriptions": [
                 {

--- a/card.aux.serial.req.notecard.api.json
+++ b/card.aux.serial.req.notecard.api.json
@@ -107,7 +107,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/card.binary.get.req.notecard.api.json
+++ b/card.binary.get.req.notecard.api.json
@@ -60,7 +60,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get All Binary Data",

--- a/card.binary.put.req.notecard.api.json
+++ b/card.binary.put.req.notecard.api.json
@@ -59,7 +59,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Put Binary Data",

--- a/card.binary.req.notecard.api.json
+++ b/card.binary.req.notecard.api.json
@@ -49,7 +49,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "View Binary Status",

--- a/card.carrier.req.notecard.api.json
+++ b/card.carrier.req.notecard.api.json
@@ -67,7 +67,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Enable Charging Mode",

--- a/card.contact.req.notecard.api.json
+++ b/card.contact.req.notecard.api.json
@@ -61,7 +61,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Set Contact Information",

--- a/card.dfu.req.notecard.api.json
+++ b/card.dfu.req.notecard.api.json
@@ -115,7 +115,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Configure STM32 DFU",

--- a/card.illumination.req.notecard.api.json
+++ b/card.illumination.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Illumination",

--- a/card.io.req.notecard.api.json
+++ b/card.io.req.notecard.api.json
@@ -112,7 +112,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Change I2C Address",

--- a/card.led.req.notecard.api.json
+++ b/card.led.req.notecard.api.json
@@ -107,7 +107,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/card.led.rsp.notecard.api.json
+++ b/card.led.rsp.notecard.api.json
@@ -14,5 +14,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/card.location.mode.req.notecard.api.json
+++ b/card.location.mode.req.notecard.api.json
@@ -128,7 +128,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Continuous Mode",

--- a/card.location.req.notecard.api.json
+++ b/card.location.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Current Location",

--- a/card.location.rsp.notecard.api.json
+++ b/card.location.rsp.notecard.api.json
@@ -67,7 +67,7 @@
     "required": [
         "mode"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "GPS Location Response",

--- a/card.location.track.req.notecard.api.json
+++ b/card.location.track.req.notecard.api.json
@@ -75,7 +75,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Start",

--- a/card.monitor.req.notecard.api.json
+++ b/card.monitor.req.notecard.api.json
@@ -77,7 +77,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/card.motion.mode.req.notecard.api.json
+++ b/card.motion.mode.req.notecard.api.json
@@ -105,7 +105,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Start Motion Tracking",

--- a/card.motion.mode.rsp.notecard.api.json
+++ b/card.motion.mode.rsp.notecard.api.json
@@ -29,7 +29,7 @@
             "type": "boolean"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Motion Tracking Enabled Response",

--- a/card.motion.req.notecard.api.json
+++ b/card.motion.req.notecard.api.json
@@ -48,7 +48,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Motion with Minutes Sampling",

--- a/card.motion.sync.req.notecard.api.json
+++ b/card.motion.sync.req.notecard.api.json
@@ -64,7 +64,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Start Motion-Triggered Sync",

--- a/card.motion.sync.rsp.notecard.api.json
+++ b/card.motion.sync.rsp.notecard.api.json
@@ -12,5 +12,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/card.motion.track.req.notecard.api.json
+++ b/card.motion.track.req.notecard.api.json
@@ -73,7 +73,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Start Motion Tracking",

--- a/card.motion.track.rsp.notecard.api.json
+++ b/card.motion.track.rsp.notecard.api.json
@@ -12,5 +12,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/card.power.req.notecard.api.json
+++ b/card.power.req.notecard.api.json
@@ -54,7 +54,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Latest Power Consumption Reading",

--- a/card.power.rsp.notecard.api.json
+++ b/card.power.rsp.notecard.api.json
@@ -26,7 +26,7 @@
             "type": "number"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Power Consumption Response",

--- a/card.random.req.notecard.api.json
+++ b/card.random.req.notecard.api.json
@@ -53,7 +53,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get a Random Number",

--- a/card.random.rsp.notecard.api.json
+++ b/card.random.rsp.notecard.api.json
@@ -22,7 +22,7 @@
             "contentEncoding": "base64"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Random Number Response",

--- a/card.restart.req.notecard.api.json
+++ b/card.restart.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "warning",

--- a/card.restart.rsp.notecard.api.json
+++ b/card.restart.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/card.restore.req.notecard.api.json
+++ b/card.restore.req.notecard.api.json
@@ -53,7 +53,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Complete Factory Reset",

--- a/card.restore.rsp.notecard.api.json
+++ b/card.restore.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/card.sleep.req.notecard.api.json
+++ b/card.sleep.req.notecard.api.json
@@ -79,7 +79,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/card.sleep.rsp.notecard.api.json
+++ b/card.sleep.rsp.notecard.api.json
@@ -27,7 +27,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Sleep Mode Status",

--- a/card.status.req.notecard.api.json
+++ b/card.status.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Notecard Status",

--- a/card.status.rsp.notecard.api.json
+++ b/card.status.rsp.notecard.api.json
@@ -64,7 +64,7 @@
         "status",
         "usb"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Notecard Status Response",

--- a/card.temp.req.notecard.api.json
+++ b/card.temp.req.notecard.api.json
@@ -61,7 +61,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Card Temperature",

--- a/card.temp.rsp.notecard.api.json
+++ b/card.temp.rsp.notecard.api.json
@@ -42,7 +42,7 @@
             "type": "number"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Basic Temperature Response",

--- a/card.time.req.notecard.api.json
+++ b/card.time.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Current Time and Date",

--- a/card.time.rsp.notecard.api.json
+++ b/card.time.rsp.notecard.api.json
@@ -45,7 +45,7 @@
     "required": [
         "zone"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Complete Time Response",

--- a/card.trace.req.notecard.api.json
+++ b/card.trace.req.notecard.api.json
@@ -62,7 +62,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Enable Trace Mode",

--- a/card.trace.rsp.notecard.api.json
+++ b/card.trace.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/card.transport.req.notecard.api.json
+++ b/card.transport.req.notecard.api.json
@@ -161,7 +161,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Set WiFi-Cell Priority",

--- a/card.transport.rsp.notecard.api.json
+++ b/card.transport.rsp.notecard.api.json
@@ -121,7 +121,7 @@
     "required": [
         "method"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "WiFi-Cell Priority Response",

--- a/card.triangulate.req.notecard.api.json
+++ b/card.triangulate.req.notecard.api.json
@@ -92,7 +92,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/card.triangulate.rsp.notecard.api.json
+++ b/card.triangulate.rsp.notecard.api.json
@@ -40,7 +40,7 @@
             "type": "boolean"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Complete Triangulation Response",

--- a/card.usage.get.req.notecard.api.json
+++ b/card.usage.get.req.notecard.api.json
@@ -77,7 +77,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/card.usage.get.rsp.notecard.api.json
+++ b/card.usage.get.rsp.notecard.api.json
@@ -45,7 +45,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Complete Usage Statistics",

--- a/card.usage.test.req.notecard.api.json
+++ b/card.usage.test.req.notecard.api.json
@@ -57,7 +57,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/card.usage.test.rsp.notecard.api.json
+++ b/card.usage.test.rsp.notecard.api.json
@@ -57,7 +57,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Complete Usage Test Results",

--- a/card.version.req.notecard.api.json
+++ b/card.version.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Version Information",

--- a/card.version.rsp.notecard.api.json
+++ b/card.version.rsp.notecard.api.json
@@ -58,7 +58,7 @@
                     "type": "string"
                 }
             },
-            "additionalProperties": false
+            "unevaluatedProperties": false
         },
         "cell": {
             "description": "If `true`, indicates the Notecard supports cellular connectivity.",
@@ -93,7 +93,7 @@
     "required": [
         "version"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Complete Version Response",

--- a/card.voltage.req.notecard.api.json
+++ b/card.voltage.req.notecard.api.json
@@ -156,7 +156,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Voltage Trends",

--- a/card.voltage.rsp.notecard.api.json
+++ b/card.voltage.rsp.notecard.api.json
@@ -76,7 +76,7 @@
             "type": "number"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Bare Request (USB-Powered, History Disabled)",

--- a/card.wifi.req.notecard.api.json
+++ b/card.wifi.req.notecard.api.json
@@ -68,7 +68,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/card.wifi.rsp.notecard.api.json
+++ b/card.wifi.rsp.notecard.api.json
@@ -28,7 +28,7 @@
             "type": "string"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Complete WiFi Status Response",

--- a/card.wireless.penalty.req.notecard.api.json
+++ b/card.wireless.penalty.req.notecard.api.json
@@ -72,7 +72,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "warning",

--- a/card.wireless.penalty.rsp.notecard.api.json
+++ b/card.wireless.penalty.rsp.notecard.api.json
@@ -30,7 +30,7 @@
             "type": "string"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Active Penalty Box Status",

--- a/card.wireless.req.notecard.api.json
+++ b/card.wireless.req.notecard.api.json
@@ -119,7 +119,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Current Network State",

--- a/card.wireless.rsp.notecard.api.json
+++ b/card.wireless.rsp.notecard.api.json
@@ -89,14 +89,14 @@
                     "type": "integer"
                 }
             },
-            "additionalProperties": false
+            "unevaluatedProperties": false
         },
         "status": {
             "description": "The current status of the wireless connection and modem.",
             "type": "string"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Complete Wireless Status Response",

--- a/dfu.get.req.notecard.api.json
+++ b/dfu.get.req.notecard.api.json
@@ -56,7 +56,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/dfu.get.rsp.notecard.api.json
+++ b/dfu.get.rsp.notecard.api.json
@@ -29,7 +29,7 @@
             "type": "string"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Firmware Data Response",

--- a/dfu.status.req.notecard.api.json
+++ b/dfu.status.req.notecard.api.json
@@ -93,7 +93,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Enable DFU Downloads",

--- a/dfu.status.rsp.notecard.api.json
+++ b/dfu.status.rsp.notecard.api.json
@@ -75,7 +75,7 @@
         "mode",
         "on"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "DFU Ready Status",

--- a/env.default.req.notecard.api.json
+++ b/env.default.req.notecard.api.json
@@ -60,7 +60,7 @@
     "required": [
         "name"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/env.default.rsp.notecard.api.json
+++ b/env.default.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/env.get.req.notecard.api.json
+++ b/env.get.req.notecard.api.json
@@ -63,7 +63,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/env.modified.req.notecard.api.json
+++ b/env.modified.req.notecard.api.json
@@ -50,7 +50,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Environment Modified Time",

--- a/env.modified.rsp.notecard.api.json
+++ b/env.modified.rsp.notecard.api.json
@@ -22,7 +22,7 @@
     "required": [
         "time"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Environment Modified Time Response",

--- a/env.set.req.notecard.api.json
+++ b/env.set.req.notecard.api.json
@@ -56,7 +56,7 @@
     "required": [
         "name"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "deprecated",

--- a/env.set.rsp.notecard.api.json
+++ b/env.set.rsp.notecard.api.json
@@ -22,7 +22,7 @@
     "required": [
         "time"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Environment Variable Set Response",

--- a/env.template.req.notecard.api.json
+++ b/env.template.req.notecard.api.json
@@ -49,7 +49,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/env.template.rsp.notecard.api.json
+++ b/env.template.rsp.notecard.api.json
@@ -21,7 +21,7 @@
     "required": [
         "bytes"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Template Size Response",

--- a/file.changes.pending.req.notecard.api.json
+++ b/file.changes.pending.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Check Pending Changes",

--- a/file.changes.pending.rsp.notecard.api.json
+++ b/file.changes.pending.rsp.notecard.api.json
@@ -44,7 +44,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Pending Changes Response",

--- a/file.changes.req.notecard.api.json
+++ b/file.changes.req.notecard.api.json
@@ -62,7 +62,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Check All Files",

--- a/file.changes.rsp.notecard.api.json
+++ b/file.changes.rsp.notecard.api.json
@@ -44,7 +44,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Example Change Response",

--- a/file.clear.req.notecard.api.json
+++ b/file.clear.req.notecard.api.json
@@ -51,7 +51,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Clear Outbound Notefile",

--- a/file.clear.rsp.notecard.api.json
+++ b/file.clear.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/file.delete.req.notecard.api.json
+++ b/file.delete.req.notecard.api.json
@@ -54,7 +54,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Delete Multiple Files",

--- a/file.delete.rsp.notecard.api.json
+++ b/file.delete.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/file.stats.req.notecard.api.json
+++ b/file.stats.req.notecard.api.json
@@ -49,7 +49,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get All File Stats",

--- a/file.stats.rsp.notecard.api.json
+++ b/file.stats.rsp.notecard.api.json
@@ -26,7 +26,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "File Statistics Response",

--- a/hub.get.req.notecard.api.json
+++ b/hub.get.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Notehub Configuration",

--- a/hub.get.rsp.notecard.api.json
+++ b/hub.get.rsp.notecard.api.json
@@ -86,7 +86,7 @@
     "required": [
         "mode"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Notehub Configuration Response",

--- a/hub.log.req.notecard.api.json
+++ b/hub.log.req.notecard.api.json
@@ -56,7 +56,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Log Health Alert with Immediate Sync",

--- a/hub.log.rsp.notecard.api.json
+++ b/hub.log.rsp.notecard.api.json
@@ -12,5 +12,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/hub.set.req.notecard.api.json
+++ b/hub.set.req.notecard.api.json
@@ -54,7 +54,7 @@
                         "appeui",
                         "appkey"
                     ],
-                    "additionalProperties": false
+                    "unevaluatedProperties": false
                 }
             ]
         },
@@ -215,7 +215,7 @@
                             "type": "string"
                         }
                     },
-                    "additionalProperties": false
+                    "unevaluatedProperties": false
                 }
             ],
             "minApiVersion": "7.3.1"
@@ -271,7 +271,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Set ProductUID",

--- a/hub.set.rsp.notecard.api.json
+++ b/hub.set.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/hub.signal.req.notecard.api.json
+++ b/hub.signal.req.notecard.api.json
@@ -49,7 +49,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "warning",

--- a/hub.signal.rsp.notecard.api.json
+++ b/hub.signal.rsp.notecard.api.json
@@ -25,7 +25,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Signal Received",

--- a/hub.status.req.notecard.api.json
+++ b/hub.status.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Hub Connection Status",

--- a/hub.status.rsp.notecard.api.json
+++ b/hub.status.rsp.notecard.api.json
@@ -25,7 +25,7 @@
     "required": [
         "status"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Connected Status",

--- a/hub.sync.req.notecard.api.json
+++ b/hub.sync.req.notecard.api.json
@@ -58,7 +58,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Manual Sync",

--- a/hub.sync.rsp.notecard.api.json
+++ b/hub.sync.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/hub.sync.status.req.notecard.api.json
+++ b/hub.sync.status.req.notecard.api.json
@@ -49,7 +49,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Check Sync Status",

--- a/hub.sync.status.rsp.notecard.api.json
+++ b/hub.sync.status.rsp.notecard.api.json
@@ -55,7 +55,7 @@
     "required": [
         "status"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Sync Status with Completion Info",

--- a/note.add.req.notecard.api.json
+++ b/note.add.req.notecard.api.json
@@ -123,7 +123,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Basic Note Add",

--- a/note.add.rsp.notecard.api.json
+++ b/note.add.rsp.notecard.api.json
@@ -29,7 +29,7 @@
     "required": [
         "total"
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Basic Add Response",

--- a/note.changes.req.notecard.api.json
+++ b/note.changes.req.notecard.api.json
@@ -87,7 +87,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Peek at Changes",

--- a/note.changes.rsp.notecard.api.json
+++ b/note.changes.rsp.notecard.api.json
@@ -35,7 +35,7 @@
                     "body",
                     "time"
                 ],
-                "additionalProperties": false
+                "unevaluatedProperties": false
             }
         },
         "total": {
@@ -43,7 +43,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Changes Response with Notes",

--- a/note.delete.req.notecard.api.json
+++ b/note.delete.req.notecard.api.json
@@ -61,7 +61,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Delete Note from DB Notefile",

--- a/note.delete.rsp.notecard.api.json
+++ b/note.delete.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/note.get.req.notecard.api.json
+++ b/note.get.req.notecard.api.json
@@ -66,7 +66,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Pop from `.qi` Notefile",

--- a/note.get.rsp.notecard.api.json
+++ b/note.get.rsp.notecard.api.json
@@ -26,7 +26,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Note with Body and Time",

--- a/note.template.req.notecard.api.json
+++ b/note.template.req.notecard.api.json
@@ -88,7 +88,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Provide Schema",

--- a/note.template.rsp.notecard.api.json
+++ b/note.template.rsp.notecard.api.json
@@ -35,7 +35,7 @@
             "minApiVersion": "3.2.1"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Template Set Response",

--- a/note.update.req.notecard.api.json
+++ b/note.update.req.notecard.api.json
@@ -81,7 +81,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Update Note Body",

--- a/note.update.rsp.notecard.api.json
+++ b/note.update.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/ntn.gps.req.notecard.api.json
+++ b/ntn.gps.req.notecard.api.json
@@ -53,7 +53,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Enable Notecard GPS Override",

--- a/ntn.gps.rsp.notecard.api.json
+++ b/ntn.gps.rsp.notecard.api.json
@@ -22,7 +22,7 @@
             "type": "boolean"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Starnote Using Own GPS",

--- a/ntn.reset.req.notecard.api.json
+++ b/ntn.reset.req.notecard.api.json
@@ -45,7 +45,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Reset Starnote Configuration",

--- a/ntn.reset.rsp.notecard.api.json
+++ b/ntn.reset.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/ntn.status.req.notecard.api.json
+++ b/ntn.status.req.notecard.api.json
@@ -44,7 +44,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Get Starnote Connection Status",

--- a/ntn.status.rsp.notecard.api.json
+++ b/ntn.status.rsp.notecard.api.json
@@ -22,7 +22,7 @@
             "type": "string"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Starnote Idle Status",

--- a/tests/test_card_aux_rsp.py
+++ b/tests/test_card_aux_rsp.py
@@ -93,7 +93,7 @@ def test_state_additional_properties_not_allowed(schema):
     instance = {"state": [{"invalid_prop": True}]}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_time_valid(schema):
     """Tests valid time values (UNIX Epoch time)."""

--- a/tests/test_card_aux_serial_rsp.py
+++ b/tests/test_card_aux_serial_rsp.py
@@ -12,7 +12,7 @@ def test_valid_empty_response(schema):
 def test_valid_additional_properties(schema):
     """Tests that additional properties are allowed as per schema default."""
     instance = {"some_field": 123, "another": "value"}
-    # This should be valid because additionalProperties is not set to false
+    # This should be valid because unevaluatedProperties is not set to false
     jsonschema.validate(instance=instance, schema=schema)
 
 def test_invalid_type(schema):

--- a/tests/test_card_binary_get_req.py
+++ b/tests/test_card_binary_get_req.py
@@ -122,7 +122,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.binary.get", "extra": "invalid"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_card_binary_put_req.py
+++ b/tests/test_card_binary_put_req.py
@@ -119,7 +119,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.binary.put", "extra": "disallowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_card_binary_req.py
+++ b/tests/test_card_binary_req.py
@@ -74,7 +74,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.binary", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_carrier_req.py
+++ b/tests/test_card_carrier_req.py
@@ -74,7 +74,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.carrier", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_mode_sub_descriptions_exist(schema):
     """Tests that the mode property has sub-descriptions."""

--- a/tests/test_card_contact_req.py
+++ b/tests/test_card_contact_req.py
@@ -104,7 +104,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.contact", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_dfu_req.py
+++ b/tests/test_card_dfu_req.py
@@ -191,7 +191,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.dfu", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_card_illumination_req.py
+++ b/tests/test_card_illumination_req.py
@@ -33,7 +33,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.illumination", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_io_req.py
+++ b/tests/test_card_io_req.py
@@ -77,7 +77,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.io", "extra": "property"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_mode_sub_descriptions_exist(schema):
     """Tests that the mode property has sub-descriptions."""

--- a/tests/test_card_led_req.py
+++ b/tests/test_card_led_req.py
@@ -99,7 +99,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.led", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_schema_samples(schema):
     """Tests that all schema samples validate against the schema."""

--- a/tests/test_card_location_mode_req.py
+++ b/tests/test_card_location_mode_req.py
@@ -224,7 +224,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.location.mode", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_card_location_req.py
+++ b/tests/test_card_location_req.py
@@ -33,14 +33,14 @@ def test_invalid_additional_property_with_req(schema):
     instance = {"req": "card.location", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid request with cmd and an additional property."""
     instance = {"cmd": "card.location", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_location_track_req.py
+++ b/tests/test_card_location_track_req.py
@@ -170,7 +170,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.location.track", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_monitor_req.py
+++ b/tests/test_card_monitor_req.py
@@ -156,7 +156,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.monitor", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_card_motion_mode_req.py
+++ b/tests/test_card_motion_mode_req.py
@@ -136,7 +136,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.motion.mode", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_motion_mode_rsp.py
+++ b/tests/test_card_motion_mode_rsp.py
@@ -14,7 +14,7 @@ def test_invalid_additional_property(schema):
     instance = {"tracking_enabled": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('tracking_enabled' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('tracking_enabled' was unexpected)" in str(excinfo.value)
 
 def test_start_property(schema):
     """Tests valid response with start boolean."""

--- a/tests/test_card_motion_req.py
+++ b/tests/test_card_motion_req.py
@@ -66,7 +66,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.motion", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_motion_sync_req.py
+++ b/tests/test_card_motion_sync_req.py
@@ -131,7 +131,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.motion.sync", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_motion_sync_rsp.py
+++ b/tests/test_card_motion_sync_rsp.py
@@ -14,7 +14,7 @@ def test_invalid_additional_property(schema):
     instance = {"sync_status": "active"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('sync_status' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('sync_status' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_motion_track_req.py
+++ b/tests/test_card_motion_track_req.py
@@ -166,7 +166,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.motion.track", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_motion_track_rsp.py
+++ b/tests/test_card_motion_track_rsp.py
@@ -14,7 +14,7 @@ def test_invalid_additional_property(schema):
     instance = {"tracking": True, "file": "_motion.qo"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_power_req.py
+++ b/tests/test_card_power_req.py
@@ -101,7 +101,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.power", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_power_rsp.py
+++ b/tests/test_card_power_rsp.py
@@ -114,7 +114,7 @@ def test_invalid_additional_property(schema):
     instance = {"temperature": 25.0, "voltage": 4.1, "status": "ok"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('status' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('status' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_random_req.py
+++ b/tests/test_card_random_req.py
@@ -101,14 +101,14 @@ def test_invalid_additional_property_with_req(schema):
     instance = {"req": "card.random", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid request with cmd and an additional property."""
     instance = {"cmd": "card.random", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_large_count_value(schema):
     """Tests large count values are accepted."""

--- a/tests/test_card_random_rsp.py
+++ b/tests/test_card_random_rsp.py
@@ -88,7 +88,7 @@ def test_invalid_additional_property(schema):
     instance = {"count": 50, "status": "success"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('status' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('status' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -99,7 +99,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_restart_req.py
+++ b/tests/test_card_restart_req.py
@@ -47,14 +47,14 @@ def test_invalid_additional_property_with_req(schema):
     instance = {"req": "card.restart", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid request with cmd and an additional property."""
     instance = {"cmd": "card.restart", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_restart_rsp.py
+++ b/tests/test_card_restart_rsp.py
@@ -14,7 +14,7 @@ def test_invalid_additional_property(schema):
     instance = {"restarting": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('restarting' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('restarting' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -24,7 +24,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_restore_req.py
+++ b/tests/test_card_restore_req.py
@@ -90,14 +90,14 @@ def test_invalid_additional_property_with_req(schema):
     instance = {"req": "card.restore", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid request with cmd and an additional property."""
     instance = {"cmd": "card.restore", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_restore_rsp.py
+++ b/tests/test_card_restore_rsp.py
@@ -14,7 +14,7 @@ def test_invalid_additional_property(schema):
     instance = {"status": "resetting"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('status' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('status' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -24,7 +24,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_sleep_req.py
+++ b/tests/test_card_sleep_req.py
@@ -158,7 +158,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.sleep", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_card_sleep_rsp.py
+++ b/tests/test_card_sleep_rsp.py
@@ -152,7 +152,7 @@ def test_invalid_additional_property(schema):
     instance = {"status": "enabled"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('status' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('status' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -165,7 +165,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_status_req.py
+++ b/tests/test_card_status_req.py
@@ -47,14 +47,14 @@ def test_invalid_additional_property_with_req(schema):
     instance = {"req": "card.status", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid request with cmd and an additional property."""
     instance = {"cmd": "card.status", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_status_rsp.py
+++ b/tests/test_card_status_rsp.py
@@ -153,7 +153,7 @@ def test_invalid_additional_property(schema):
     instance = {**REQUIRED_FIELDS, "extra": "info"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -164,7 +164,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_temp_req.py
+++ b/tests/test_card_temp_req.py
@@ -131,7 +131,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.temp", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_temp_rsp.py
+++ b/tests/test_card_temp_rsp.py
@@ -116,7 +116,7 @@ def test_invalid_additional_property(schema):
     instance = {"value": 25.0, "sensor": "onboard"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('sensor' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('sensor' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -127,7 +127,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_time_req.py
+++ b/tests/test_card_time_req.py
@@ -47,14 +47,14 @@ def test_invalid_additional_property_with_req(schema):
     instance = {"req": "card.time", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid request with cmd and an additional property."""
     instance = {"cmd": "card.time", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_time_rsp.py
+++ b/tests/test_card_time_rsp.py
@@ -125,7 +125,7 @@ def test_invalid_additional_property(schema):
     instance = {"zone": "UTC,0", "time": 1700000000, "source": "gps"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('source' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('source' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -137,7 +137,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_trace_req.py
+++ b/tests/test_card_trace_req.py
@@ -71,7 +71,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.trace", "mode": "on", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_valid_trace_enable_request(schema):
     """Tests valid complete request to enable trace mode."""

--- a/tests/test_card_trace_rsp.py
+++ b/tests/test_card_trace_rsp.py
@@ -19,7 +19,7 @@ def test_invalid_additional_property(schema):
     instance = {"status": "enabled"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('status' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('status' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -30,28 +30,28 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_string_property(schema):
     """Tests invalid response with string property."""
     instance = {"message": "trace enabled"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('message' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('message' was unexpected)" in str(excinfo.value)
 
 def test_invalid_boolean_property(schema):
     """Tests invalid response with boolean property."""
     instance = {"success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('success' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('success' was unexpected)" in str(excinfo.value)
 
 def test_invalid_number_property(schema):
     """Tests invalid response with number property."""
     instance = {"code": 200}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('code' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('code' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_transport_req.py
+++ b/tests/test_card_transport_req.py
@@ -125,7 +125,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.transport", "method": "wifi-cell", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_valid_complete_request(schema):
     """Tests valid complete request with all fields."""

--- a/tests/test_card_transport_rsp.py
+++ b/tests/test_card_transport_rsp.py
@@ -79,7 +79,7 @@ def test_invalid_additional_property(schema):
     instance = {"method": "wifi-cell", "status": "active"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('status' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('status' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -91,21 +91,21 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_boolean_property(schema):
     """Tests invalid response with boolean property."""
     instance = {"method": "ntn", "enabled": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('enabled' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('enabled' was unexpected)" in str(excinfo.value)
 
 def test_invalid_number_property(schema):
     """Tests invalid response with number property."""
     instance = {"method": "wifi-cell", "timeout": 3600}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('timeout' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('timeout' was unexpected)" in str(excinfo.value)
 
 def test_method_sub_descriptions_exist(schema):
     """Tests that the method property has sub-descriptions."""

--- a/tests/test_card_triangulate_req.py
+++ b/tests/test_card_triangulate_req.py
@@ -33,14 +33,14 @@ def test_invalid_additional_property_with_req(schema):
     instance = {"req": "card.triangulate", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid request with cmd and an additional property."""
     instance = {"cmd": "card.triangulate", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_on_field_valid(schema):
     """Tests valid 'on' field values."""

--- a/tests/test_card_triangulate_rsp.py
+++ b/tests/test_card_triangulate_rsp.py
@@ -132,7 +132,7 @@ def test_invalid_additional_property(schema):
     instance = {"mode": "wifi,cell", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests response with multiple additional properties (should fail)."""
@@ -143,7 +143,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_various_mode_combinations(schema):
     """Tests various valid mode combinations."""

--- a/tests/test_card_usage_get_req.py
+++ b/tests/test_card_usage_get_req.py
@@ -91,7 +91,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.usage.get", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_usage_get_rsp.py
+++ b/tests/test_card_usage_get_rsp.py
@@ -73,7 +73,7 @@ def test_invalid_additional_property(schema):
     instance = {"seconds": 60, "source": "live"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('source' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('source' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_usage_test_req.py
+++ b/tests/test_card_usage_test_req.py
@@ -108,14 +108,14 @@ def test_invalid_additional_property_with_req(schema):
     instance = {"req": "card.usage.test", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid request with cmd and an additional property."""
     instance = {"cmd": "card.usage.test", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_usage_test_rsp.py
+++ b/tests/test_card_usage_test_rsp.py
@@ -198,7 +198,7 @@ def test_invalid_additional_property(schema):
     instance = {"max": 12730, "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_version_req.py
+++ b/tests/test_card_version_req.py
@@ -37,7 +37,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.version", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_card_version_rsp.py
+++ b/tests/test_card_version_rsp.py
@@ -167,7 +167,7 @@ def test_invalid_additional_property(schema):
     instance = {"version": "v1", "extra": "data"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 
@@ -178,7 +178,7 @@ def test_body_invalid_additional_property(schema):
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
     assert (
-        "Additional properties are not allowed ('invalid_field' was unexpected)"
+        "Unevaluated properties are not allowed ('invalid_field' was unexpected)"
         in str(excinfo.value)
     )
 

--- a/tests/test_card_voltage_req.py
+++ b/tests/test_card_voltage_req.py
@@ -224,7 +224,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.voltage", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_voltage_rsp.py
+++ b/tests/test_card_voltage_rsp.py
@@ -154,7 +154,7 @@ def test_invalid_additional_property(schema):
     instance = {"value": 4.1, "status": "ok"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('status' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('status' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_wifi_req.py
+++ b/tests/test_card_wifi_req.py
@@ -150,7 +150,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.wifi", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_wifi_rsp.py
+++ b/tests/test_card_wifi_rsp.py
@@ -101,7 +101,7 @@ def test_invalid_additional_property(schema):
     instance = {"secure": True, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_wireless_penalty_req.py
+++ b/tests/test_card_wireless_penalty_req.py
@@ -33,14 +33,14 @@ def test_invalid_additional_property_with_req(schema):
     instance = {"req": "card.wireless.penalty", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid request with cmd and an additional property."""
     instance = {"cmd": "card.wireless.penalty", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_valid_reset(schema):
     """Tests valid reset field."""

--- a/tests/test_card_wireless_penalty_rsp.py
+++ b/tests/test_card_wireless_penalty_rsp.py
@@ -86,7 +86,7 @@ def test_invalid_additional_property(schema):
     instance = {"minutes": 69, "additional": "property"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('additional' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('additional' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_card_wireless_req.py
+++ b/tests/test_card_wireless_req.py
@@ -142,7 +142,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "card.wireless", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_card_wireless_rsp.py
+++ b/tests/test_card_wireless_rsp.py
@@ -139,14 +139,14 @@ def test_invalid_additional_property(schema):
     instance = {"status": "ok", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_net_invalid_additional_property(schema):
     """Tests invalid net object with an additional property."""
     instance = {"net": {"rssi": -70, "extra": "field"}}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_dfu_get_req.py
+++ b/tests/test_dfu_get_req.py
@@ -69,7 +69,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "dfu.get", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_valid_binary_true(schema):
     """Tests valid binary parameter set to true."""

--- a/tests/test_dfu_get_rsp.py
+++ b/tests/test_dfu_get_rsp.py
@@ -45,7 +45,7 @@ def test_invalid_additional_property(schema):
     instance = {"payload": "dGVzdA==", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_valid_rsp_with_binary_fields(schema):
     """Tests a valid response with binary mode fields (cobs, length, status)."""

--- a/tests/test_dfu_status_req.py
+++ b/tests/test_dfu_status_req.py
@@ -149,7 +149,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "dfu.status", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_dfu_status_rsp.py
+++ b/tests/test_dfu_status_rsp.py
@@ -136,7 +136,7 @@ def test_invalid_additional_property(schema):
     instance = {"status": "test", "mode": "ready", "on": True, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_env_default_req.py
+++ b/tests/test_env_default_req.py
@@ -108,7 +108,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "env.default", "name": "test-var", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_env_default_rsp.py
+++ b/tests/test_env_default_rsp.py
@@ -14,21 +14,21 @@ def test_invalid_additional_property(schema):
     instance = {"extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_name_property(schema):
     """Tests that name property is not allowed in response."""
     instance = {"name": "test-var"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_text_property(schema):
     """Tests that text property is not allowed in response."""
     instance = {"text": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_env_get_req.py
+++ b/tests/test_env_get_req.py
@@ -110,7 +110,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "env.get", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_env_modified_req.py
+++ b/tests/test_env_modified_req.py
@@ -73,7 +73,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "env.modified", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_env_modified_rsp.py
+++ b/tests/test_env_modified_rsp.py
@@ -59,7 +59,7 @@ def test_invalid_additional_property(schema):
     instance = {"time": 1605814493, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_env_set_req.py
+++ b/tests/test_env_set_req.py
@@ -89,7 +89,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "env.set", "name": "test-var", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_env_set_rsp.py
+++ b/tests/test_env_set_rsp.py
@@ -64,21 +64,21 @@ def test_invalid_additional_property(schema):
     instance = {"time": 1605814493, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_name_property(schema):
     """Tests that name property is not allowed in response."""
     instance = {"time": 1605814493, "name": "test-var"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_text_property(schema):
     """Tests that text property is not allowed in response."""
     instance = {"time": 1605814493, "text": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_env_template_req.py
+++ b/tests/test_env_template_req.py
@@ -118,7 +118,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "env.template", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_env_template_rsp.py
+++ b/tests/test_env_template_rsp.py
@@ -71,7 +71,7 @@ def test_invalid_additional_property(schema):
     instance = {"bytes": 22, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_file_changes_pending_req.py
+++ b/tests/test_file_changes_pending_req.py
@@ -89,21 +89,21 @@ def test_invalid_additional_property(schema):
     instance = {"req": "file.changes.pending", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with an additional property."""
     instance = {"cmd": "file.changes.pending", "invalid": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "file.changes.pending", "extra1": 123, "extra2": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_file_changes_pending_rsp.py
+++ b/tests/test_file_changes_pending_rsp.py
@@ -246,7 +246,7 @@ def test_invalid_additional_property(schema):
     instance = {"total": 3, "changes": 3, "pending": True, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_file_changes_req.py
+++ b/tests/test_file_changes_req.py
@@ -139,7 +139,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "file.changes", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_file_changes_rsp.py
+++ b/tests/test_file_changes_rsp.py
@@ -152,7 +152,7 @@ def test_info_file_changes_invalid_type(schema):
 
 def test_info_file_additional_properties_allowed(schema):
     """Tests that additional properties are allowed in info file objects."""
-    # Since additionalProperties is true, any additional properties should be allowed
+    # Since unevaluatedProperties is true, any additional properties should be allowed
     instance = {"total": 5, "info": {"sensors.qo": {"changes": 5, "custom_field": "any_value", "timestamp": 123}}}
     jsonschema.validate(instance=instance, schema=schema)
 
@@ -234,7 +234,7 @@ def test_invalid_additional_property(schema):
     instance = {"total": 3, "changes": 1, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_file_clear_req.py
+++ b/tests/test_file_clear_req.py
@@ -137,14 +137,14 @@ def test_invalid_additional_property(schema):
     instance = {"req": "file.clear", "file": "data.qo", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with an additional property."""
     instance = {"cmd": "file.clear", "file": "data.qo", "invalid": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_file_clear_rsp.py
+++ b/tests/test_file_clear_rsp.py
@@ -19,42 +19,42 @@ def test_invalid_additional_property_single(schema):
     instance = {"extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_string(schema):
     """Tests invalid response with string additional property."""
     instance = {"message": "cleared"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_boolean(schema):
     """Tests invalid response with boolean additional property."""
     instance = {"success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_object(schema):
     """Tests invalid response with object additional property."""
     instance = {"result": {"status": "ok"}}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_array(schema):
     """Tests invalid response with array additional property."""
     instance = {"files": ["data.qo"]}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid response with multiple additional properties."""
     instance = {"extra1": 123, "extra2": "value", "extra3": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_response_fields(schema):
     """Tests that common response fields are not allowed."""
@@ -71,7 +71,7 @@ def test_invalid_common_response_fields(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""

--- a/tests/test_file_delete_req.py
+++ b/tests/test_file_delete_req.py
@@ -175,14 +175,14 @@ def test_invalid_additional_property(schema):
     instance = {"req": "file.delete", "files": ["data.qo"], "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with an additional property."""
     instance = {"cmd": "file.delete", "files": ["data.qo"], "invalid": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_file_delete_rsp.py
+++ b/tests/test_file_delete_rsp.py
@@ -19,49 +19,49 @@ def test_invalid_additional_property_single(schema):
     instance = {"extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_string(schema):
     """Tests invalid response with string additional property."""
     instance = {"message": "deleted"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_boolean(schema):
     """Tests invalid response with boolean additional property."""
     instance = {"success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_object(schema):
     """Tests invalid response with object additional property."""
     instance = {"result": {"status": "ok"}}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_array(schema):
     """Tests invalid response with array additional property."""
     instance = {"files": ["data.qo"]}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_result_property(schema):
     """Tests that the old result property is no longer allowed."""
     instance = {"result": {}}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid response with multiple additional properties."""
     instance = {"extra1": 123, "extra2": "value", "extra3": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_response_fields(schema):
     """Tests that common response fields are not allowed."""
@@ -78,7 +78,7 @@ def test_invalid_common_response_fields(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""

--- a/tests/test_file_stats_req.py
+++ b/tests/test_file_stats_req.py
@@ -145,21 +145,21 @@ def test_invalid_additional_property(schema):
     instance = {"req": "file.stats", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with an additional property."""
     instance = {"cmd": "file.stats", "invalid": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "file.stats", "extra1": 123, "extra2": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_file_stats_rsp.py
+++ b/tests/test_file_stats_rsp.py
@@ -113,7 +113,7 @@ def test_invalid_additional_property(schema):
     instance = {"total": 83, "changes": 78, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -129,7 +129,7 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""

--- a/tests/test_hub_get_req.py
+++ b/tests/test_hub_get_req.py
@@ -89,21 +89,21 @@ def test_invalid_additional_property(schema):
     instance = {"req": "hub.get", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with an additional property."""
     instance = {"cmd": "hub.get", "invalid": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "hub.get", "extra1": 123, "extra2": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_no_parameters_required(schema):
     """Tests that hub.get requires no parameters besides req/cmd."""

--- a/tests/test_hub_get_rsp.py
+++ b/tests/test_hub_get_rsp.py
@@ -206,7 +206,7 @@ def test_invalid_additional_property(schema):
     instance = {"mode": "periodic", "device": "dev:123", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -221,7 +221,7 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""

--- a/tests/test_hub_log_req.py
+++ b/tests/test_hub_log_req.py
@@ -166,21 +166,21 @@ def test_invalid_additional_property(schema):
     instance = {"req": "hub.log", "text": "test", "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with an additional property."""
     instance = {"cmd": "hub.log", "text": "test", "invalid": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "hub.log", "text": "test", "extra1": 123, "extra2": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_valid_field_combinations(schema):
     """Tests valid requests with various field combinations."""

--- a/tests/test_hub_log_rsp.py
+++ b/tests/test_hub_log_rsp.py
@@ -19,7 +19,7 @@ def test_invalid_additional_property(schema):
     instance = {"extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -37,14 +37,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"status": "ok", "message": "logged"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -88,9 +88,9 @@ def test_no_properties_defined(schema):
     assert schema.get("properties") == {}
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    # Verify schema has additionalProperties: false
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    # Verify schema has unevaluatedProperties: false
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -104,7 +104,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_hub_set_req.py
+++ b/tests/test_hub_set_req.py
@@ -413,7 +413,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "hub.set", "extra": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_valid_complex_configuration(schema):

--- a/tests/test_hub_set_rsp.py
+++ b/tests/test_hub_set_rsp.py
@@ -14,7 +14,7 @@ def test_invalid_additional_property(schema):
     instance = {"extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -33,14 +33,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"status": "ok", "message": "configured"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -84,9 +84,9 @@ def test_no_properties_defined(schema):
     assert schema.get("properties") == {}
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    # Verify schema has additionalProperties: false
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    # Verify schema has unevaluatedProperties: false
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -100,7 +100,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_hub_signal_req.py
+++ b/tests/test_hub_signal_req.py
@@ -135,21 +135,21 @@ def test_invalid_additional_property(schema):
     instance = {"req": "hub.signal", "extra": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with additional property."""
     instance = {"cmd": "hub.signal", "timeout": 30}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "hub.signal", "extra1": 123, "extra2": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -166,7 +166,7 @@ def test_invalid_common_additional_properties(schema):
         field_dict["req"] = "hub.signal"
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_seconds_optional_parameter(schema):
     """Tests that seconds parameter is optional."""

--- a/tests/test_hub_signal_rsp.py
+++ b/tests/test_hub_signal_rsp.py
@@ -183,7 +183,7 @@ def test_invalid_additional_property(schema):
     instance = {"body": {"key": "value"}, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -202,14 +202,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"body": {}, "status": "ok", "message": "received"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -259,7 +259,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_hub_status_req.py
+++ b/tests/test_hub_status_req.py
@@ -103,21 +103,21 @@ def test_invalid_additional_property(schema):
     instance = {"req": "hub.status", "extra": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with additional property."""
     instance = {"cmd": "hub.status", "status": "check"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "hub.status", "extra1": 123, "extra2": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -134,7 +134,7 @@ def test_invalid_common_additional_properties(schema):
         field_dict["req"] = "hub.status"
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_no_parameters_required(schema):
     """Tests that hub.status requires no parameters besides req/cmd."""

--- a/tests/test_hub_status_rsp.py
+++ b/tests/test_hub_status_rsp.py
@@ -146,7 +146,7 @@ def test_invalid_additional_property(schema):
     instance = {"status": "connected", "connected": True, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -165,14 +165,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"status": "connected", "connected": True, "result": "ok", "message": "success"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -222,7 +222,7 @@ def test_strict_validation(schema):
         instance = {"status": "ok", "connected": True, prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_hub_sync_req.py
+++ b/tests/test_hub_sync_req.py
@@ -207,21 +207,21 @@ def test_invalid_additional_property(schema):
     instance = {"req": "hub.sync", "extra": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with additional property."""
     instance = {"cmd": "hub.sync", "force": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "hub.sync", "extra1": 123, "extra2": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -238,7 +238,7 @@ def test_invalid_common_additional_properties(schema):
         field_dict["req"] = "hub.sync"
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_all_parameters_optional(schema):
     """Tests that all parameters except req/cmd are optional."""

--- a/tests/test_hub_sync_rsp.py
+++ b/tests/test_hub_sync_rsp.py
@@ -19,7 +19,7 @@ def test_invalid_additional_property(schema):
     instance = {"extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -39,14 +39,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"status": "ok", "message": "synced"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -90,9 +90,9 @@ def test_no_properties_defined(schema):
     assert schema.get("properties") == {}
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    # Verify schema has additionalProperties: false
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    # Verify schema has unevaluatedProperties: false
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -107,7 +107,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_sync_related_properties_invalid(schema):
     """Tests that sync-related properties are not allowed in response."""
@@ -123,7 +123,7 @@ def test_sync_related_properties_invalid(schema):
     for prop_dict in sync_properties:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=prop_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_hub_sync_status_req.py
+++ b/tests/test_hub_sync_status_req.py
@@ -123,21 +123,21 @@ def test_invalid_additional_property(schema):
     instance = {"req": "hub.sync.status", "extra": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with additional property."""
     instance = {"cmd": "hub.sync.status", "status": "check"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "hub.sync.status", "extra1": 123, "extra2": "value"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -154,7 +154,7 @@ def test_invalid_common_additional_properties(schema):
         field_dict["req"] = "hub.sync.status"
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_sync_parameter_optional(schema):
     """Tests that sync parameter is optional."""

--- a/tests/test_hub_sync_status_rsp.py
+++ b/tests/test_hub_sync_status_rsp.py
@@ -352,7 +352,7 @@ def test_invalid_additional_property(schema):
     instance = {**REQUIRED_FIELDS, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -373,14 +373,14 @@ def test_invalid_common_additional_properties(schema):
         instance = {**REQUIRED_FIELDS, **field_dict}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {**REQUIRED_FIELDS, "extra1": "value1", "extra2": "value2"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -419,9 +419,9 @@ def test_response_is_object_type(schema):
         jsonschema.validate(instance=True, schema=schema)
 
 def test_additional_properties_False(schema):
-    """Tests that additionalProperties is set to False."""
-    # Verify schema has additionalProperties: False
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to False."""
+    # Verify schema has unevaluatedProperties: False
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -436,7 +436,7 @@ def test_strict_validation(schema):
         instance = {**REQUIRED_FIELDS, prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_common_status_codes(schema):
     """Tests that common status codes are accepted."""

--- a/tests/test_note_add_req.py
+++ b/tests/test_note_add_req.py
@@ -529,7 +529,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "note.add", "body": {"data": "value"}, "extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_invalid_additional_property_with_cmd(schema):
@@ -537,7 +537,7 @@ def test_invalid_additional_property_with_cmd(schema):
     instance = {"cmd": "note.add", "body": {"data": "value"}, "unknown": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_invalid_multiple_additional_properties(schema):
@@ -550,7 +550,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_invalid_common_additional_properties(schema):
@@ -571,7 +571,7 @@ def test_invalid_common_additional_properties(schema):
         field_dict["body"] = {"data": "value"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_empty_object_invalid(schema):

--- a/tests/test_note_add_rsp.py
+++ b/tests/test_note_add_rsp.py
@@ -136,7 +136,7 @@ def test_invalid_additional_property(schema):
     instance = {"total": 1, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -164,14 +164,14 @@ def test_invalid_common_additional_properties(schema):
         field_dict["total"] = 1  # Add required field
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"total": 1, "status": "ok", "message": "added", "extra": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -210,9 +210,9 @@ def test_response_is_object_type(schema):
         jsonschema.validate(instance=True, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    # Verify schema has additionalProperties: false
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    # Verify schema has unevaluatedProperties: false
+    assert schema.get("unevaluatedProperties") is False
 
 def test_empty_response_invalid(schema):
     """Tests that empty response is invalid due to required total field."""
@@ -242,7 +242,7 @@ def test_strict_validation(schema):
         instance = {"total": 1, prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_field_combinations(schema):
     """Tests various valid field combinations."""

--- a/tests/test_note_changes_req.py
+++ b/tests/test_note_changes_req.py
@@ -349,7 +349,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "note.changes", "file": "data.db", "extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_invalid_additional_property_with_cmd(schema):
@@ -357,7 +357,7 @@ def test_invalid_additional_property_with_cmd(schema):
     instance = {"cmd": "note.changes", "file": "data.db", "unknown": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_invalid_multiple_additional_properties(schema):
@@ -370,7 +370,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_invalid_common_additional_properties(schema):
@@ -391,7 +391,7 @@ def test_invalid_common_additional_properties(schema):
         field_dict["file"] = "test.db"
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_empty_object_invalid(schema):

--- a/tests/test_note_changes_rsp.py
+++ b/tests/test_note_changes_rsp.py
@@ -251,7 +251,7 @@ def test_note_entry_additional_properties_invalid(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_note_entry_valid_empty_body(schema):
     """Tests valid note entry with empty body object."""
@@ -302,7 +302,7 @@ def test_invalid_additional_property(schema):
     instance = {"extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -326,14 +326,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"status": "ok", "message": "retrieved", "extra": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -372,9 +372,9 @@ def test_response_is_object_type(schema):
         jsonschema.validate(instance=True, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    # Verify schema has additionalProperties: false
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    # Verify schema has unevaluatedProperties: false
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -389,7 +389,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_field_combinations(schema):
     """Tests various valid field combinations."""

--- a/tests/test_note_delete_req.py
+++ b/tests/test_note_delete_req.py
@@ -181,21 +181,21 @@ def test_invalid_additional_property(schema):
     instance = {"req": "note.delete", "file": "data.db", "note": "test-id", "extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_with_cmd(schema):
     """Tests invalid command with additional property."""
     instance = {"cmd": "note.delete", "file": "data.db", "note": "test-id", "unknown": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "note.delete", "file": "data.db", "note": "test-id", "extra1": 123, "extra2": "test"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -217,7 +217,7 @@ def test_invalid_common_additional_properties(schema):
         field_dict["note"] = "test-id"
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_empty_object_invalid(schema):
     """Tests that empty object is invalid."""

--- a/tests/test_note_delete_rsp.py
+++ b/tests/test_note_delete_rsp.py
@@ -25,14 +25,14 @@ def test_invalid_additional_property_single(schema):
     instance = {"extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_success(schema):
     """Tests invalid response with success property (removed from v0.2.1)."""
     instance = {"success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -55,14 +55,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"status": "ok", "message": "deleted", "success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -101,9 +101,9 @@ def test_response_is_object_type(schema):
         jsonschema.validate(instance=True, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    # Verify schema has additionalProperties: false
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    # Verify schema has unevaluatedProperties: false
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -119,7 +119,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_empty_object_variations(schema):
     """Tests various empty object representations."""

--- a/tests/test_note_get_req.py
+++ b/tests/test_note_get_req.py
@@ -166,14 +166,14 @@ def test_invalid_additional_property(schema):
     instance = {"req": "note.get", "file": "data.qi", "extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "note.get", "file": "data.qi", "extra1": 123, "extra2": "test"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_queue_file_scenarios(schema):
     """Tests scenarios specific to queue files."""

--- a/tests/test_note_get_rsp.py
+++ b/tests/test_note_get_rsp.py
@@ -150,7 +150,7 @@ def test_invalid_additional_property(schema):
     instance = {"body": {"data": "test"}, "extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -169,14 +169,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"body": {"data": "test"}, "status": "ok", "message": "retrieved"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -193,8 +193,8 @@ def test_response_type_validation(schema):
             jsonschema.validate(instance=invalid_instance, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -207,7 +207,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_base64_payload_patterns(schema):
     """Tests various base64 payload patterns."""

--- a/tests/test_note_template_req.py
+++ b/tests/test_note_template_req.py
@@ -124,7 +124,7 @@ def test_invalid_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_valid_verify_parameter(schema):

--- a/tests/test_note_template_rsp.py
+++ b/tests/test_note_template_rsp.py
@@ -101,14 +101,14 @@ def test_invalid_additional_property(schema):
     instance = {"extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid response with multiple additional properties."""
     instance = {"extra1": 123, "extra2": "test"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -119,8 +119,8 @@ def test_response_type_validation(schema):
             jsonschema.validate(instance=invalid_instance, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_note_update_req.py
+++ b/tests/test_note_update_req.py
@@ -220,14 +220,14 @@ def test_invalid_additional_property(schema):
     instance = {"req": "note.update", "file": "data.db", "note": "test", "body": {"data": "test"}, "extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
     instance = {"req": "note.update", "file": "data.db", "note": "test", "body": {"data": "test"}, "extra1": 123, "extra2": "test"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_database_update_scenarios(schema):
     """Tests typical database update scenarios."""

--- a/tests/test_note_update_rsp.py
+++ b/tests/test_note_update_rsp.py
@@ -25,14 +25,14 @@ def test_invalid_additional_property_single(schema):
     instance = {"extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_success(schema):
     """Tests invalid response with legacy success property."""
     instance = {"success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -53,14 +53,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"status": "ok", "message": "updated", "success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -95,8 +95,8 @@ def test_response_is_object_type(schema):
         jsonschema.validate(instance=True, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -110,7 +110,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_empty_object_variations(schema):
     """Tests various empty object representations."""

--- a/tests/test_ntn_gps_req.py
+++ b/tests/test_ntn_gps_req.py
@@ -161,7 +161,7 @@ def test_invalid_additional_property(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
@@ -173,7 +173,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_starnote_gps_scenarios(schema):
     """Tests realistic Starnote GPS configuration scenarios."""
@@ -247,8 +247,8 @@ def test_request_type_validation(schema):
             jsonschema.validate(instance=invalid_instance, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_ntn_gps_rsp.py
+++ b/tests/test_ntn_gps_rsp.py
@@ -94,7 +94,7 @@ def test_invalid_additional_property(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid response with multiple additional properties."""
@@ -105,7 +105,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -174,8 +174,8 @@ def test_minimal_responses(schema):
         jsonschema.validate(instance=response, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_response_field_validation(schema):
     """Tests that response field types are correctly validated."""

--- a/tests/test_ntn_reset_req.py
+++ b/tests/test_ntn_reset_req.py
@@ -55,7 +55,7 @@ def test_invalid_additional_property(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
@@ -66,7 +66,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_parameters(schema):
     """Tests that no parameters are allowed beyond req/cmd."""
@@ -81,7 +81,7 @@ def test_invalid_parameters(schema):
     for invalid_request in invalid_parameters:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=invalid_request, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_reset_scenarios(schema):
     """Tests realistic Starnote reset scenarios."""
@@ -118,8 +118,8 @@ def test_req_cmd_validation(schema):
         jsonschema.validate(instance={}, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_ntn_reset_rsp.py
+++ b/tests/test_ntn_reset_rsp.py
@@ -14,14 +14,14 @@ def test_invalid_additional_property_single(schema):
     instance = {"extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_success(schema):
     """Tests invalid response with legacy success property."""
     instance = {"success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -41,14 +41,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"status": "ok", "message": "reset complete", "success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -59,8 +59,8 @@ def test_response_type_validation(schema):
             jsonschema.validate(instance=invalid_instance, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -74,7 +74,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 
 def test_empty_properties_validation(schema):

--- a/tests/test_ntn_status_req.py
+++ b/tests/test_ntn_status_req.py
@@ -55,7 +55,7 @@ def test_invalid_additional_property(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
@@ -66,7 +66,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_parameters(schema):
     """Tests that no parameters are allowed beyond req/cmd."""
@@ -81,7 +81,7 @@ def test_invalid_parameters(schema):
     for invalid_request in invalid_parameters:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=invalid_request, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_starnote_status_scenarios(schema):
     """Tests realistic Starnote status request scenarios."""
@@ -118,8 +118,8 @@ def test_req_cmd_validation(schema):
         jsonschema.validate(instance={}, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_ntn_status_rsp.py
+++ b/tests/test_ntn_status_rsp.py
@@ -76,7 +76,7 @@ def test_invalid_additional_property(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid response with multiple additional properties."""
@@ -87,7 +87,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -148,8 +148,8 @@ def test_status_flag_patterns(schema):
         jsonschema.validate(instance=pattern, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_optional_fields_validation(schema):
     """Tests that all response fields are optional."""

--- a/tests/test_schema_hierarchy.py
+++ b/tests/test_schema_hierarchy.py
@@ -22,7 +22,7 @@ EXPECTED_HIERARCHY = [
     "skus",
     "properties",
     "oneOf",
-    "additionalProperties",
+    "unevaluatedProperties",
     "annotations",
     "samples"
 ]

--- a/tests/test_var_delete_req.py
+++ b/tests/test_var_delete_req.py
@@ -114,7 +114,7 @@ def test_invalid_additional_property(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
@@ -126,7 +126,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_variable_name_scenarios(schema):
     """Tests various realistic variable name scenarios."""
@@ -169,8 +169,8 @@ def test_req_cmd_validation(schema):
         jsonschema.validate(instance={}, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_empty_name_string(schema):
     """Tests empty name string validation."""

--- a/tests/test_var_delete_rsp.py
+++ b/tests/test_var_delete_rsp.py
@@ -14,7 +14,7 @@ def test_invalid_additional_property(schema):
     instance = {"extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid response with multiple additional properties."""
@@ -24,7 +24,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -45,7 +45,7 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -56,8 +56,8 @@ def test_response_type_validation(schema):
             jsonschema.validate(instance=invalid_instance, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_empty_properties(schema):
     """Tests that schema has no defined properties."""
@@ -75,7 +75,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_var_get_req.py
+++ b/tests/test_var_get_req.py
@@ -114,7 +114,7 @@ def test_invalid_additional_property(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
@@ -126,7 +126,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_variable_retrieval_scenarios(schema):
     """Tests various realistic variable retrieval scenarios."""
@@ -169,8 +169,8 @@ def test_req_cmd_validation(schema):
         jsonschema.validate(instance={}, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_empty_name_string(schema):
     """Tests empty name string validation."""

--- a/tests/test_var_get_rsp.py
+++ b/tests/test_var_get_rsp.py
@@ -99,7 +99,7 @@ def test_invalid_additional_property(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid response with multiple additional properties."""
@@ -110,7 +110,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -129,7 +129,7 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -160,8 +160,8 @@ def test_variable_retrieval_scenarios(schema):
         jsonschema.validate(instance=scenario, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_all_fields_optional(schema):
     """Tests that all response fields are optional."""
@@ -199,7 +199,7 @@ def test_strict_validation(schema):
         instance = {"text": "test", prop: "value"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_number_edge_cases(schema):
     """Tests edge cases for numeric value field."""

--- a/tests/test_var_set_req.py
+++ b/tests/test_var_set_req.py
@@ -225,7 +225,7 @@ def test_invalid_additional_property(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests invalid request with multiple additional properties."""
@@ -238,7 +238,7 @@ def test_invalid_multiple_additional_properties(schema):
     }
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_variable_setting_scenarios(schema):
     """Tests various realistic variable setting scenarios."""
@@ -279,8 +279,8 @@ def test_req_cmd_validation(schema):
         jsonschema.validate(instance={}, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_empty_string_values(schema):
     """Tests empty string values for name and text."""

--- a/tests/test_var_set_rsp.py
+++ b/tests/test_var_set_rsp.py
@@ -14,21 +14,21 @@ def test_invalid_additional_property_single(schema):
     instance = {"extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_name(schema):
     """Tests invalid response with legacy name property."""
     instance = {"name": "status"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_additional_property_text(schema):
     """Tests invalid response with legacy text property."""
     instance = {"text": "open"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_common_additional_properties(schema):
     """Tests that common additional properties are not allowed."""
@@ -51,14 +51,14 @@ def test_invalid_common_additional_properties(schema):
     for field_dict in invalid_fields:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=field_dict, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_invalid_multiple_additional_properties(schema):
     """Tests that multiple additional properties are not allowed."""
     instance = {"status": "ok", "message": "variable set", "success": True}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_response_type_validation(schema):
     """Tests that response must be an object."""
@@ -69,8 +69,8 @@ def test_response_type_validation(schema):
             jsonschema.validate(instance=invalid_instance, schema=schema)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_strict_validation(schema):
     """Tests that schema enforces strict validation."""
@@ -84,7 +84,7 @@ def test_strict_validation(schema):
         instance = {prop: "test"}
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=instance, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_empty_properties_validation(schema):
     """Tests that response schema has empty properties and strict validation."""
@@ -140,7 +140,7 @@ def test_legacy_response_properties_invalid(schema):
     for legacy_response in legacy_properties:
         with pytest.raises(jsonschema.ValidationError) as excinfo:
             jsonschema.validate(instance=legacy_response, schema=schema)
-        assert "Additional properties are not allowed" in str(excinfo.value)
+        assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_api_reference_compliance(schema):
     """Tests that response schema complies with API reference (no response members)."""

--- a/tests/test_web_delete_req.py
+++ b/tests/test_web_delete_req.py
@@ -98,7 +98,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "web.delete", "route": "SensorService", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_valid_complex_request(schema):
     """Tests a complex valid request with multiple parameters."""

--- a/tests/test_web_delete_rsp.py
+++ b/tests/test_web_delete_rsp.py
@@ -128,7 +128,7 @@ def test_invalid_additional_property(schema):
     instance = {"result": 200, "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_web_get_req.py
+++ b/tests/test_web_get_req.py
@@ -126,7 +126,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "web.get", "route": "api", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_web_get_rsp.py
+++ b/tests/test_web_get_rsp.py
@@ -59,11 +59,11 @@ def test_invalid_additional_property(schema):
     instance = {"result": 200, "extra": "not allowed"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_additional_properties_false(schema):
-    """Tests that additionalProperties is set to false."""
-    assert schema.get("additionalProperties") is False
+    """Tests that unevaluatedProperties is set to false."""
+    assert schema.get("unevaluatedProperties") is False
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_web_post_req.py
+++ b/tests/test_web_post_req.py
@@ -182,7 +182,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "web.post", "route": "SensorService", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_valid_complex_request(schema):
     """Tests a complex valid request with multiple parameters."""

--- a/tests/test_web_post_rsp.py
+++ b/tests/test_web_post_rsp.py
@@ -120,7 +120,7 @@ def test_invalid_additional_property(schema):
     instance = {"result": 200, "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_web_put_req.py
+++ b/tests/test_web_put_req.py
@@ -182,7 +182,7 @@ def test_invalid_additional_property(schema):
     instance = {"req": "web.put", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(excinfo.value)
 
 def test_valid_complex_request(schema):
     """Tests a complex valid request with multiple parameters."""

--- a/tests/test_web_put_rsp.py
+++ b/tests/test_web_put_rsp.py
@@ -130,7 +130,7 @@ def test_invalid_additional_property(schema):
     instance = {"result": 200, "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/tests/test_web_req.py
+++ b/tests/test_web_req.py
@@ -189,13 +189,13 @@ def test_invalid_additional_property(schema):
     instance = {"req": "web", "method": "GET", "route": "weatherInfo", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
     instance = {"cmd": "web", "method": "GET", "route": "weatherInfo", "extra": "field"}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed ('extra' was unexpected)" in str(
+    assert "Unevaluated properties are not allowed ('extra' was unexpected)" in str(
         excinfo.value
     )
 

--- a/tests/test_web_rsp.py
+++ b/tests/test_web_rsp.py
@@ -85,7 +85,7 @@ def test_invalid_additional_property(schema):
     instance = {"result": 200, "extra": 123}
     with pytest.raises(jsonschema.ValidationError) as excinfo:
         jsonschema.validate(instance=instance, schema=schema)
-    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "Unevaluated properties are not allowed" in str(excinfo.value)
 
 def test_validate_samples_from_schema(schema, schema_samples):
     """Tests that samples in the schema definition are valid."""

--- a/var.delete.req.notecard.api.json
+++ b/var.delete.req.notecard.api.json
@@ -68,7 +68,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Delete Variable with Default File",

--- a/var.delete.rsp.notecard.api.json
+++ b/var.delete.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/var.get.req.notecard.api.json
+++ b/var.get.req.notecard.api.json
@@ -68,7 +68,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Retrieve Variable with Default File",

--- a/var.get.rsp.notecard.api.json
+++ b/var.get.rsp.notecard.api.json
@@ -27,7 +27,7 @@
             "type": "number"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Text Value Response",

--- a/var.set.req.notecard.api.json
+++ b/var.set.req.notecard.api.json
@@ -142,7 +142,7 @@
             ]
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Set Text Variable",

--- a/var.set.rsp.notecard.api.json
+++ b/var.set.rsp.notecard.api.json
@@ -13,5 +13,5 @@
         "WIFI"
     ],
     "properties": {},
-    "additionalProperties": false
+    "unevaluatedProperties": false
 }

--- a/web.delete.req.notecard.api.json
+++ b/web.delete.req.notecard.api.json
@@ -83,7 +83,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Web DELETE Transaction",

--- a/web.delete.rsp.notecard.api.json
+++ b/web.delete.rsp.notecard.api.json
@@ -30,7 +30,7 @@
             "type": "string"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "description": "Example Response",

--- a/web.get.req.notecard.api.json
+++ b/web.get.req.notecard.api.json
@@ -93,7 +93,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Web GET Transaction",

--- a/web.get.rsp.notecard.api.json
+++ b/web.get.rsp.notecard.api.json
@@ -33,7 +33,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "description": "Response body from HTTP GET request to the external service.",

--- a/web.post.req.notecard.api.json
+++ b/web.post.req.notecard.api.json
@@ -196,7 +196,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "description": "Performs a simple HTTP or HTTPS POST request and returns the response.",

--- a/web.post.rsp.notecard.api.json
+++ b/web.post.rsp.notecard.api.json
@@ -39,7 +39,7 @@
             "type": "string"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "description": "Example Response",

--- a/web.put.req.notecard.api.json
+++ b/web.put.req.notecard.api.json
@@ -147,7 +147,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "title": "Web PUT Transaction",

--- a/web.put.rsp.notecard.api.json
+++ b/web.put.rsp.notecard.api.json
@@ -30,7 +30,7 @@
             "type": "string"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "description": "Example Response",

--- a/web.req.notecard.api.json
+++ b/web.req.notecard.api.json
@@ -147,7 +147,7 @@
             }
         }
     ],
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "annotations": [
         {
             "title": "note",

--- a/web.rsp.notecard.api.json
+++ b/web.rsp.notecard.api.json
@@ -34,7 +34,7 @@
             "type": "integer"
         }
     },
-    "additionalProperties": false,
+    "unevaluatedProperties": false,
     "samples": [
         {
             "description": "Response from a web request",


### PR DESCRIPTION
## Summary

- Replaces `additionalProperties: false` with `unevaluatedProperties: false` in all 134 schema files (including nested object schemas)
- Updates all test assertions and direct schema key checks to match the new keyword
- No behavioral change for existing public API consumers — schemas remain equally strict

## Motivation

`unevaluatedProperties: false` is the JSON Schema 2020-12 composition-aware equivalent of `additionalProperties: false`. Unlike `additionalProperties`, it considers properties defined in any `allOf`/`anyOf`/`oneOf`/`$ref` branch as "evaluated", allowing schema extension via composition.

This is a prerequisite for a private API schema repository that will extend these public schemas with internal-only fields using `allOf`.